### PR TITLE
show Part questions only

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -145,8 +145,8 @@ jobs:
         run: |
           echo "🔍 SECRETS DETECTION SCAN"
           echo "========================"
-          
-          pip install git+https://github.com/IBM/detect-secrets.git@0.13.1+ibm.62.dss
+
+          pip install git+https://github.com/IBM/detect-secrets.git@0.13.1+ibm.64.dss
           
           # Run scan and show results
           echo "🔎 Scanning for potential secrets..."

--- a/apps/api/src/api/assignment/dto/update.questions.request.dto.ts
+++ b/apps/api/src/api/assignment/dto/update.questions.request.dto.ts
@@ -96,6 +96,14 @@ export class ScoringDto {
   rubrics: RubricDto[];
 
   @ApiProperty({
+    description: "Show sub-questions to the learner",
+    type: Boolean,
+  })
+  @IsBoolean()
+  @IsOptional()
+  showSubQuestionsToLearner?: boolean;
+
+  @ApiProperty({
     description: "Show rubric to the learner",
     type: Boolean,
   })
@@ -687,6 +695,14 @@ export class AttemptScoringDto {
   })
   @IsString()
   type: string;
+
+  @ApiPropertyOptional({
+    description: "Whether sub-questions are shown to the learner",
+    type: Boolean,
+  })
+  @IsOptional()
+  @IsBoolean()
+  showSubQuestionsToLearner?: boolean;
 
   @ApiPropertyOptional({
     description: "Whether rubrics are shown to the learner",

--- a/apps/web/app/author/(components)/(questionComponents)/QuestionWrapper.tsx
+++ b/apps/web/app/author/(components)/(questionComponents)/QuestionWrapper.tsx
@@ -261,6 +261,7 @@ const PresentationOptions: FC<PresentationOptionsProps> = ({
 };
 
 interface QuestionWrapperProps extends ComponentPropsWithoutRef<"div"> {
+  showSubQuestionsToLearner?: boolean;
   showRubricsToLearner?: boolean;
   showPoints?: boolean;
   questionId: number;
@@ -291,6 +292,7 @@ interface QuestionWrapperProps extends ComponentPropsWithoutRef<"div"> {
 }
 
 const QuestionWrapper: FC<QuestionWrapperProps> = ({
+  showSubQuestionsToLearner,
   showRubricsToLearner,
   showPoints,
   questionId,
@@ -864,41 +866,79 @@ const QuestionWrapper: FC<QuestionWrapperProps> = ({
               Rubric
             </p>
           </div>
-          {/* the section for 2 buttons */}
+          {/* the section for 3 buttons */}
           <div className="flex lg:flex-row flex-col gap-2">
             <div className="flex items-center mr-4 gap-2 text-gray-600 text-nowrap">
               <span className="text-gray-600 typography-body">
-                Show Rubrics to Learner
+                Show Sub-Questions to Learner
               </span>
               <Tooltip
-                content="Show rubrics to learners"
+                content="Show sub-questions to learners"
                 className="flex items-center"
               >
                 <button
                   type="button"
                   onClick={() =>
                     handleUpdateQuestionState({
-                      showRubricsToLearner: !showRubricsToLearner,
+                      showSubQuestionsToLearner: !showSubQuestionsToLearner,
                     })
                   }
                   className={cn(
                     "relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none",
-                    showRubricsToLearner ? "bg-violet-600" : "bg-gray-200",
+                    showSubQuestionsToLearner ? "bg-violet-600" : "bg-gray-200",
                   )}
                   role="switch"
-                  aria-checked={showRubricsToLearner}
+                  aria-checked={showSubQuestionsToLearner}
                 >
                   <span
                     aria-hidden="true"
                     className={cn(
                       "pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out",
-                      showRubricsToLearner ? "translate-x-5" : "translate-x-0",
+                      showSubQuestionsToLearner
+                        ? "translate-x-5"
+                        : "translate-x-0",
                     )}
                   />
                 </button>
               </Tooltip>
             </div>
-            {showRubricsToLearner && (
+            {showSubQuestionsToLearner && (
+              <div className="flex items-center mr-4 gap-2 text-gray-600 text-nowrap">
+                <span className="text-gray-600 typography-body">
+                  Show Rubrics to Learner
+                </span>
+                <Tooltip
+                  content="Show rubrics to learners"
+                  className="flex items-center"
+                >
+                  <button
+                    type="button"
+                    onClick={() =>
+                      handleUpdateQuestionState({
+                        showRubricsToLearner: !showRubricsToLearner,
+                      })
+                    }
+                    className={cn(
+                      "relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none",
+                      showRubricsToLearner ? "bg-violet-600" : "bg-gray-200",
+                    )}
+                    role="switch"
+                    aria-checked={showRubricsToLearner}
+                  >
+                    <span
+                      aria-hidden="true"
+                      className={cn(
+                        "pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out",
+                        showRubricsToLearner
+                          ? "translate-x-5"
+                          : "translate-x-0",
+                      )}
+                    />
+                  </button>
+                </Tooltip>
+              </div>
+            )}
+            {showSubQuestionsToLearner && showRubricsToLearner && (
               <div className="flex items-center mr-4 gap-2 text-gray-600 text-nowrap">
                 <span className="text-gray-600 typography-body">
                   Display Rubric Points to Learners

--- a/apps/web/app/author/(components)/AuthorQuestionsPage/Question.tsx
+++ b/apps/web/app/author/(components)/AuthorQuestionsPage/Question.tsx
@@ -143,11 +143,18 @@ const Question: FC<QuestionProps> = ({
     params: UpdateQuestionStateParams,
     variantMode = false,
   ) => {
+    //if showSubQuestionsToLearner is undefined, use false as default
+    const showSubQuestions =
+      params.showSubQuestionsToLearner !== undefined
+        ? params.showSubQuestionsToLearner
+        : (question.scoring?.showSubQuestionsToLearner ?? false);
+
     //if showRubricsToLearner is undefined, use false as default
-    const showRubrics =
-      params.showRubricsToLearner !== undefined
+    const showRubrics = showSubQuestions
+      ? params.showRubricsToLearner !== undefined
         ? params.showRubricsToLearner
-        : (question.scoring?.showRubricsToLearner ?? false);
+        : (question.scoring?.showRubricsToLearner ?? false)
+      : false;
 
     //if showRubrics is false, showPoints uses false as default
     const showPoints = showRubrics
@@ -177,6 +184,7 @@ const Question: FC<QuestionProps> = ({
         updatedData.maxCharacters = params.maxCharacters;
       }
 
+      updatedData.scoring.showSubQuestionsToLearner = showSubQuestions;
       updatedData.scoring.showRubricsToLearner = showRubrics;
       updatedData.scoring.showPoints = showPoints;
 
@@ -203,6 +211,7 @@ const Question: FC<QuestionProps> = ({
           params.randomizedChoices ?? question.randomizedChoices,
         scoring: {
           type: "CRITERIA_BASED",
+          showSubQuestionsToLearner: showSubQuestions,
           showPoints: showPoints,
           showRubricsToLearner: showRubrics,
           rubrics: params.rubrics
@@ -1001,6 +1010,9 @@ const Question: FC<QuestionProps> = ({
             questionFromParent={question}
             variantMode={false}
             responseType={question.responseType ?? ("OTHER" as const)}
+            showSubQuestionsToLearner={
+              question.scoring?.showSubQuestionsToLearner
+            }
             showRubricsToLearner={question.scoring?.showRubricsToLearner}
             showPoints={question.scoring?.showPoints}
           />

--- a/apps/web/app/learner/(components)/Question/LearnerRubricTable.tsx
+++ b/apps/web/app/learner/(components)/Question/LearnerRubricTable.tsx
@@ -12,10 +12,15 @@ interface SingleRubric {
 
 interface LearnerRubricTableProps {
   rubrics: SingleRubric[];
+  showRubrics: boolean;
   showPoints: boolean;
 }
 
-function LearnerRubricTable({ rubrics, showPoints }: LearnerRubricTableProps) {
+function LearnerRubricTable({
+  rubrics,
+  showRubrics,
+  showPoints,
+}: LearnerRubricTableProps) {
   if (!rubrics || rubrics.length === 0) return null;
 
   return (
@@ -25,39 +30,41 @@ function LearnerRubricTable({ rubrics, showPoints }: LearnerRubricTableProps) {
           <h4 className="text-gray-700 text-md font-semibold">
             Sub Question {i + 1}: {rubric.rubricQuestion}
           </h4>
-          <div className="overflow-x-auto">
-            <table className="w-full text-left border border-gray-300 overflow-hidden">
-              <thead className="bg-gray-100 border-b border-gray-300">
-                <tr>
-                  <th className="p-2 text-gray-700 font-semibold">
-                    Description
-                  </th>
-                  {showPoints && (
-                    <th className="p-2 text-gray-700 font-semibold text-center">
-                      Points
+          {showRubrics && (
+            <div className="overflow-x-auto">
+              <table className="w-full text-left border border-gray-300 overflow-hidden">
+                <thead className="bg-gray-100 border-b border-gray-300">
+                  <tr>
+                    <th className="p-2 text-gray-700 font-semibold">
+                      Description
                     </th>
-                  )}
-                </tr>
-              </thead>
-              <tbody>
-                {rubric.criteria.map((criterion, index) => (
-                  <tr
-                    key={index}
-                    className="border-b border-gray-300 last:border-0"
-                  >
-                    <td className="p-2 text-gray-600 max-w-sm text-wrap overflow-hidden">
-                      {criterion.description}
-                    </td>
                     {showPoints && (
-                      <td className="p-2 text-gray-600 text-center">
-                        {criterion.points}
-                      </td>
+                      <th className="p-2 text-gray-700 font-semibold text-center">
+                        Points
+                      </th>
                     )}
                   </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
+                </thead>
+                <tbody>
+                  {rubric.criteria.map((criterion, index) => (
+                    <tr
+                      key={index}
+                      className="border-b border-gray-300 last:border-0"
+                    >
+                      <td className="p-2 text-gray-600 max-w-sm text-wrap overflow-hidden">
+                        {criterion.description}
+                      </td>
+                      {showPoints && (
+                        <td className="p-2 text-gray-600 text-center">
+                          {criterion.points}
+                        </td>
+                      )}
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
         </div>
       ))}
     </div>

--- a/apps/web/app/learner/(components)/Question/QuestionContainer.tsx
+++ b/apps/web/app/learner/(components)/Question/QuestionContainer.tsx
@@ -60,12 +60,13 @@ function Component(props: Props) {
   const checkToShowRubric = () => {
     if (
       ["TEXT", "UPLOAD", "LINk_FILE", "URL"].includes(question.type) &&
-      question.scoring.showRubricsToLearner &&
+      question.scoring.showSubQuestionsToLearner &&
       question.scoring?.rubrics
     )
       return true;
     else return false;
   };
+  const showRubrics = question.scoring?.showRubricsToLearner ?? false;
   const showPoints = question.scoring?.showPoints ?? false;
   // Get the questionStatus directly from the store
   const questionStatus = getQuestionStatusById
@@ -328,6 +329,7 @@ function Component(props: Props) {
       {checkToShowRubric() && (
         <ShowHideRubric
           rubrics={question.scoring.rubrics}
+          showRubrics={showRubrics}
           showPoints={showPoints}
         />
       )}

--- a/apps/web/app/learner/(components)/Question/ShowHideRubric.tsx
+++ b/apps/web/app/learner/(components)/Question/ShowHideRubric.tsx
@@ -14,12 +14,14 @@ interface SingleRubric {
 interface ShowHideRubricProps {
   rubrics: SingleRubric[];
   className?: string;
+  showRubrics: boolean;
   showPoints: boolean;
 }
 
 function ShowHideRubric({
   rubrics,
   className,
+  showRubrics,
   showPoints,
 }: ShowHideRubricProps) {
   const [showRubric, setShowRubric] = useState(false);
@@ -56,7 +58,11 @@ function ShowHideRubric({
             transition={{ duration: 0.3, ease: "easeInOut" }}
             className="overflow-hidden"
           >
-            <LearnerRubricTable rubrics={rubrics} showPoints={showPoints} />
+            <LearnerRubricTable
+              rubrics={rubrics}
+              showRubrics={showRubrics}
+              showPoints={showPoints}
+            />
           </motion.div>
         )}
       </AnimatePresence>

--- a/apps/web/app/learner/[assignmentId]/successPage/Question.tsx
+++ b/apps/web/app/learner/[assignmentId]/successPage/Question.tsx
@@ -778,6 +778,7 @@ const Question: FC<Props> = ({
         <ShowHideRubric
           rubrics={scoring?.rubrics}
           className="mb-4"
+          showRubrics={scoring?.showRubricsToLearner}
           showPoints={scoring?.showPoints}
         />
       )}

--- a/apps/web/config/types.ts
+++ b/apps/web/config/types.ts
@@ -235,6 +235,7 @@ export type UpdateQuestionStateParams = {
   randomizedChoices?: boolean;
   maxWordCount?: number;
   questionTitle?: string;
+  showSubQuestionsToLearner?: boolean;
   showRubricsToLearner?: boolean;
   //if the points will be shown in the rubric
   showPoints?: boolean;
@@ -358,6 +359,7 @@ export type Scoring = {
   type: "CRITERIA_BASED" | "LOSS_PER_MISTAKE" | "AI_GRADED";
   rubrics?: Rubric[];
   criteria?: Criteria[];
+  showSubQuestionsToLearner?: boolean;
   showRubricsToLearner?: boolean;
   showPoints?: boolean;
 };


### PR DESCRIPTION
## **PR Description**
### **Overview:**
#### **Type of Issue:**
- [x] **Feature (`feat`)**: New functionality or feature added.
- [ ] **Bug Fix (`bug`)**: Issue or bug resolved.
- [x] **Chore (`chore`)**: Maintenance, refactoring, or non-functional changes.
- [ ] **Documentation Update (`doc`)**: Documentation improvements or additions.

#### **Change Type:**
- [ ] **Major:** Significant changes that introduce new features, large refactoring, or breaking changes. Requires thorough review and testing.
- [x] **Minor:** Small to medium changes, such as adding new functionality that is backward-compatible or minor refactoring. Moderate review needed.
- [ ] **Patch:** Bug fixes, small tweaks, or documentation updates. Light review is sufficient.

#### **Testing & Validation:**
- [ ] **Unit Tests:** Added/updated to cover new logic or edge cases.
- [ ] **Integration Tests:** Updated to verify interactions between components.
- [ ] **E2E Tests:** Performed end-to-end testing in staging or development environment.
- [x] **Manual Testing:** The changes were manually tested and validated.
- [ ] **No Regressions:** Verified that no existing functionality is broken.

### **Purpose:**
This PR adds a new "Show Sub-Questions to Learner" toggle feature for assignment rubrics. Previously, learners could only control whether they saw rubrics and their associated points. Now, authors can hierarchically control visibility: first, whether sub-questions are shown to learners, and then (if sub-questions are visible) whether the rubrics and points are shown. This provides more granular control over what learners see when completing assignments with criteria-based scoring.

The PR also includes a minor chore update to bump the IBM detect-secrets version from 0.13.1+ibm.62.dss to 0.13.1+ibm.64.dss in the CI workflow.

### **Context:**
### **Basic Usage:**
Authors will now see a new toggle option in the Rubric section when creating or editing questions. The UI flow is:
1. First toggle: "Show Sub-Questions to Learner" (new)
2. Second toggle: "Show Rubrics to Learner" (only visible if sub-questions are shown)
3. Third toggle: "Display Rubric Points to Learners" (only visible if both sub-questions and rubrics are shown)

For learners, the rubric display respects this new hierarchy, only showing sub-questions, rubrics, and points when the author has enabled each respective option.

No breaking changes to the API or existing functionality. The new field defaults to `false` to maintain backward compatibility with existing assignments.

### **Notes to Reviewer:**
- **Specific Areas to Focus:**
  - The conditional rendering logic in `apps/web/app/author/(components)/(questionComponents)/QuestionWrapper.tsx` lines 866-940 where the three toggles are arranged hierarchically
  - The default value handling in `apps/web/app/author/(components)/AuthorQuestionsPage/Question.tsx` lines 146-157 where `showSubQuestionsToLearner` controls whether `showRubricsToLearner` can be true
  - The updated learner-facing components `apps/web/app/learner/(components)/Question/LearnerRubricTable.tsx` and `apps/web/app/learner/(components)/Question/QuestionContainer.tsx` to ensure the visibility logic is correctly implemented

- **Known Issues/Limitations:** None currently identified. The feature has been implemented across both author and learner interfaces with proper DTO validation.