### PR TITLE
Fix question order drift for marked assignments

### DIFF
--- a/apps/api/src/api/assignment/attempt/attempt.service.ts
+++ b/apps/api/src/api/assignment/attempt/attempt.service.ts
@@ -29,6 +29,7 @@ import {
   UserSession,
   UserSessionRequest,
 } from "../../../auth/interfaces/user.session.interface";
+import { applyQuestionOrder } from "../utils/question-order.util";
 import { PrismaService } from "../../../database/prisma.service";
 import { QuestionAnswerContext } from "../../llm/model/base.question.evaluate.model";
 import { FileUploadQuestionEvaluateModel } from "../../llm/model/file.based.question.evaluate.model";
@@ -394,10 +395,10 @@ export class AttemptServiceV1 {
       assignment.questionOrder &&
       assignment.questionOrder.length > 0
     ) {
-      questions.sort(
-        (a, b) =>
-          assignment.questionOrder.indexOf(a.id) -
-          assignment.questionOrder.indexOf(b.id),
+      questions.splice(
+        0,
+        questions.length,
+        ...applyQuestionOrder(questions, assignment.questionOrder),
       );
     }
     await this.prisma.assignmentAttempt.update({

--- a/apps/api/src/api/assignment/question/question.service.spec.ts
+++ b/apps/api/src/api/assignment/question/question.service.spec.ts
@@ -1,0 +1,138 @@
+import { NotFoundException } from "@nestjs/common";
+import { QuestionType } from "@prisma/client";
+import { LlmFacadeService } from "src/api/llm/llm-facade.service";
+import { PrismaService } from "src/database/prisma.service";
+import { QuestionService } from "./question.service";
+
+describe("QuestionService question order sync", () => {
+  let service: QuestionService;
+  let tx: {
+    assignment: {
+      findUnique: jest.Mock;
+      update: jest.Mock;
+    };
+    question: {
+      create: jest.Mock;
+      findUnique: jest.Mock;
+      delete: jest.Mock;
+    };
+  };
+  let prismaService: PrismaService & {
+    $transaction: jest.Mock;
+  };
+  let llmFacadeService: Pick<LlmFacadeService, "applyGuardRails">;
+
+  beforeEach(() => {
+    tx = {
+      assignment: {
+        findUnique: jest.fn(),
+        update: jest.fn(),
+      },
+      question: {
+        create: jest.fn(),
+        findUnique: jest.fn(),
+        delete: jest.fn(),
+      },
+    };
+
+    prismaService = {
+      assignment: tx.assignment,
+      question: tx.question,
+      $transaction: jest.fn(async (callback: (client: typeof tx) => unknown) =>
+        callback(tx),
+      ),
+    } as unknown as PrismaService & {
+      $transaction: jest.Mock;
+    };
+
+    llmFacadeService = {
+      applyGuardRails: jest.fn().mockResolvedValue(true),
+    };
+
+    service = new QuestionService(
+      prismaService,
+      llmFacadeService as LlmFacadeService,
+      {
+        child: jest.fn().mockReturnValue({
+          info: jest.fn(),
+          warn: jest.fn(),
+          error: jest.fn(),
+        }),
+      } as any,
+    );
+  });
+
+  it("appends a newly created question id to the persisted question order", async () => {
+    tx.assignment.findUnique.mockResolvedValue({
+      questionOrder: [20, 10],
+      questions: [{ id: 10 }, { id: 20 }],
+    });
+    tx.question.create.mockResolvedValue({ id: 30 });
+
+    const result = await service.create(1, {
+      question: "New question",
+      totalPoints: 1,
+      type: QuestionType.TEXT,
+    });
+
+    expect(result).toEqual({ id: 30, success: true });
+    expect(tx.assignment.update).toHaveBeenCalledWith({
+      where: { id: 1 },
+      data: {
+        questionOrder: [20, 10, 30],
+      },
+    });
+  });
+
+  it("repairs stale question order when creating a question", async () => {
+    tx.assignment.findUnique.mockResolvedValue({
+      questionOrder: [20],
+      questions: [{ id: 10 }, { id: 20 }],
+    });
+    tx.question.create.mockResolvedValue({ id: 30 });
+
+    await service.create(1, {
+      question: "New question",
+      totalPoints: 1,
+      type: QuestionType.TEXT,
+    });
+
+    expect(tx.assignment.update).toHaveBeenCalledWith({
+      where: { id: 1 },
+      data: {
+        questionOrder: [20, 10, 30],
+      },
+    });
+  });
+
+  it("removes deleted question ids from the persisted question order", async () => {
+    tx.question.findUnique.mockResolvedValue({ id: 20, assignmentId: 1 });
+    tx.assignment.findUnique.mockResolvedValue({
+      questionOrder: [30, 20, 10],
+      questions: [{ id: 10 }, { id: 30 }],
+    });
+    tx.question.delete.mockResolvedValue({ id: 20 });
+
+    const result = await service.remove(20);
+
+    expect(result).toEqual({ id: 20, success: true });
+    expect(tx.assignment.update).toHaveBeenCalledWith({
+      where: { id: 1 },
+      data: {
+        questionOrder: [30, 10],
+      },
+    });
+  });
+
+  it("throws when creating a question for a missing assignment", async () => {
+    tx.assignment.findUnique.mockResolvedValue(null);
+
+    await expect(
+      service.create(999, {
+        question: "Missing assignment question",
+        totalPoints: 1,
+        type: QuestionType.TEXT,
+      }),
+    ).rejects.toThrow(NotFoundException);
+  });
+});

--- a/apps/api/src/api/assignment/question/question.service.ts
+++ b/apps/api/src/api/assignment/question/question.service.ts
@@ -8,6 +8,7 @@ import {
 } from "@nestjs/common";
 import { Prisma } from "@prisma/client";
 import { WINSTON_MODULE_PROVIDER } from "nest-winston";
+import { normalizeQuestionOrder } from "src/api/assignment/utils/question-order.util";
 import { LlmFacadeService } from "src/api/llm/llm-facade.service";
 import { Logger } from "winston";
 import { PrismaService } from "../../../database/prisma.service";
@@ -60,14 +61,43 @@ export class QuestionService {
       choices,
     };
 
-    const result = await this.prisma.question.create({
-      data: dataToSave,
-    });
+    return this.prisma.$transaction(async (tx) => {
+      const assignment = await tx.assignment.findUnique({
+        where: { id: assignmentId },
+        select: {
+          questionOrder: true,
+          questions: {
+            where: { isDeleted: false },
+            select: { id: true },
+          },
+        },
+      });
 
-    return {
-      id: result.id,
-      success: true,
-    };
+      if (!assignment) {
+        throw new NotFoundException(
+          `Assignment with Id ${assignmentId} not found.`,
+        );
+      }
+
+      const result = await tx.question.create({
+        data: dataToSave,
+      });
+
+      await tx.assignment.update({
+        where: { id: assignmentId },
+        data: {
+          questionOrder: normalizeQuestionOrder(
+            [...assignment.questions.map((question) => question.id), result.id],
+            assignment.questionOrder,
+          ),
+        },
+      });
+
+      return {
+        id: result.id,
+        success: true,
+      };
+    });
   }
 
   async findOne(
@@ -222,14 +252,56 @@ export class QuestionService {
   }
 
   async remove(id: number): Promise<BaseQuestionResponseDto> {
-    const result = await this.prisma.question.delete({
-      where: { id },
-    });
+    return this.prisma.$transaction(async (tx) => {
+      const existingQuestion = await tx.question.findUnique({
+        where: { id },
+        select: {
+          id: true,
+          assignmentId: true,
+        },
+      });
 
-    return {
-      id: result.id,
-      success: true,
-    };
+      if (!existingQuestion) {
+        throw new NotFoundException(`Question with Id ${id} not found.`);
+      }
+
+      const assignment = await tx.assignment.findUnique({
+        where: { id: existingQuestion.assignmentId },
+        select: {
+          questionOrder: true,
+          questions: {
+            where: {
+              isDeleted: false,
+              id: { not: id },
+            },
+            select: { id: true },
+          },
+        },
+      });
+
+      const result = await tx.question.delete({
+        where: { id },
+      });
+
+      if (assignment) {
+        await tx.assignment.update({
+          where: { id: existingQuestion.assignmentId },
+          data: {
+            questionOrder: normalizeQuestionOrder(
+              assignment.questions.map((question) => question.id),
+              assignment.questionOrder.filter(
+                (questionId) => questionId !== id,
+              ),
+            ),
+          },
+        });
+      }
+
+      return {
+        id: result.id,
+        success: true,
+      };
+    });
   }
   async createMarkingRubric(
     question: QuestionDto,

--- a/apps/api/src/api/assignment/utils/question-order.util.spec.ts
+++ b/apps/api/src/api/assignment/utils/question-order.util.spec.ts
@@ -1,0 +1,56 @@
+import {
+  applyQuestionOrder,
+  normalizeQuestionOrder,
+  sanitizeQuestionOrder,
+} from "./question-order.util";
+
+describe("question-order.util", () => {
+  describe("sanitizeQuestionOrder", () => {
+    it("filters out non-finite ids", () => {
+      expect(
+        sanitizeQuestionOrder([3, Number.NaN, Number.POSITIVE_INFINITY, 1]),
+      ).toEqual([3, 1]);
+    });
+
+    it("falls back to an empty array for missing order", () => {
+      expect(sanitizeQuestionOrder()).toEqual([]);
+      expect(sanitizeQuestionOrder(null)).toEqual([]);
+    });
+  });
+
+  describe("normalizeQuestionOrder", () => {
+    it("preserves explicit ordering and appends missing ids", () => {
+      expect(normalizeQuestionOrder([10, 20, 30], [20, 10])).toEqual([
+        20, 10, 30,
+      ]);
+    });
+
+    it("drops invalid and duplicate ids while keeping the remaining ids stable", () => {
+      expect(normalizeQuestionOrder([1, 2, 3], [99, 2, 2, 1])).toEqual([
+        2, 1, 3,
+      ]);
+    });
+  });
+
+  describe("applyQuestionOrder", () => {
+    it("reorders matching items and appends newly added items to the end", () => {
+      const questions = [
+        { id: 1, label: "Question 1" },
+        { id: 2, label: "Question 2" },
+        { id: 3, label: "Question 3" },
+      ];
+
+      expect(
+        applyQuestionOrder(questions, [2, 1]).map((question) => question.id),
+      ).toEqual([2, 1, 3]);
+    });
+
+    it("falls back to the current item order when no order is provided", () => {
+      const questions = [{ id: 7 }, { id: 8 }];
+
+      expect(
+        applyQuestionOrder(questions).map((question) => question.id),
+      ).toEqual([7, 8]);
+    });
+  });
+});

--- a/apps/api/src/api/assignment/utils/question-order.util.ts
+++ b/apps/api/src/api/assignment/utils/question-order.util.ts
@@ -1,0 +1,46 @@
+export function sanitizeQuestionOrder(
+  order?: readonly number[] | null,
+): number[] {
+  return Array.isArray(order)
+    ? order.filter((id): id is number => Number.isFinite(id))
+    : [];
+}
+
+export function normalizeQuestionOrder(
+  validIds: readonly number[],
+  order?: readonly number[] | null,
+): number[] {
+  const validSet = new Set(validIds);
+  const seen = new Set<number>();
+  const normalized: number[] = [];
+
+  for (const id of sanitizeQuestionOrder(order)) {
+    if (validSet.has(id) && !seen.has(id)) {
+      normalized.push(id);
+      seen.add(id);
+    }
+  }
+
+  for (const id of validIds) {
+    if (!seen.has(id)) {
+      normalized.push(id);
+      seen.add(id);
+    }
+  }
+
+  return normalized;
+}
+
+export function applyQuestionOrder<T extends { id: number }>(
+  items: readonly T[],
+  order?: readonly number[] | null,
+): T[] {
+  const itemMap = new Map(items.map((item) => [item.id, item]));
+
+  return normalizeQuestionOrder(
+    items.map((item) => item.id),
+    order,
+  )
+    .map((id) => itemMap.get(id))
+    .filter((item): item is T => item !== undefined);
+}

--- a/apps/api/src/api/assignment/v1/services/assignment.service.ts
+++ b/apps/api/src/api/assignment/v1/services/assignment.service.ts
@@ -16,6 +16,7 @@ import { Job, Prisma, QuestionVariant, ReportType } from "@prisma/client";
 import Bottleneck from "bottleneck";
 import { WINSTON_MODULE_PROVIDER } from "nest-winston";
 import { JobStatusServiceV1 } from "src/api/Job/job-status.service";
+import { applyQuestionOrder } from "src/api/assignment/utils/question-order.util";
 import { AssignmentTypeEnum } from "src/api/llm/features/question-generation/services/question-generation.service";
 import { LlmFacadeService } from "src/api/llm/llm-facade.service";
 import {
@@ -271,11 +272,10 @@ export class AssignmentServiceV1 {
         }
       }
     }
-    if (result.questions && result.questionOrder) {
-      result.questions.sort(
-        (a, b) =>
-          result.questionOrder.indexOf(a.id) -
-          result.questionOrder.indexOf(b.id),
+    if (result.questions) {
+      result.questions = applyQuestionOrder(
+        result.questions,
+        result.questionOrder,
       );
     }
 
@@ -1009,14 +1009,12 @@ export class AssignmentServiceV1 {
         const backendId = frontendToBackendIdMap.get(q.id);
         return backendId || q.id;
       });
-      allQuestions.sort(
-        (a, b) => questionOrder.indexOf(a.id) - questionOrder.indexOf(b.id),
-      );
+      const orderedQuestions = applyQuestionOrder(allQuestions, questionOrder);
 
       const responseData: UpdateAssignmentQuestionsResponseDto = {
         id: assignmentId,
         success: true,
-        questions: allQuestions.map((q) => {
+        questions: orderedQuestions.map((q) => {
           const variants = q.variants.map((v) => {
             const choices = (v.choices as unknown as Choice[]) ?? [];
             return { ...v, choices };
@@ -1739,13 +1737,13 @@ export class AssignmentServiceV1 {
       where: { id: assignmentId },
       select: { questionOrder: true },
     });
-    const questionOrder = assignmentData?.questionOrder || [];
-    const questionsForGradingContext = assignment.questions
-      .sort((a, b) => questionOrder.indexOf(a.id) - questionOrder.indexOf(b.id))
-      .map((q) => ({
-        id: q.id,
-        questionText: q.question,
-      }));
+    const questionsForGradingContext = applyQuestionOrder(
+      assignment.questions,
+      assignmentData?.questionOrder,
+    ).map((q) => ({
+      id: q.id,
+      questionText: q.question,
+    }));
 
     const questionGradingContextMap =
       await this.llmFacadeService.generateQuestionGradingContext(

--- a/apps/api/src/api/assignment/v2/repositories/assignment.repository.ts
+++ b/apps/api/src/api/assignment/v2/repositories/assignment.repository.ts
@@ -1,5 +1,6 @@
 import { Injectable, Logger, NotFoundException } from "@nestjs/common";
 import { Assignment, Question, QuestionVariant } from "@prisma/client";
+import { applyQuestionOrder } from "src/api/assignment/utils/question-order.util";
 import {
   UserRole,
   UserSession,
@@ -340,18 +341,10 @@ export class AssignmentRepository {
         return questionDto;
       });
 
-    if (
-      filteredQuestions.length > 0 &&
-      Array.isArray(assignment.questionOrder)
-    ) {
-      filteredQuestions.sort(
-        (a, b) =>
-          assignment.questionOrder.indexOf(a.id) -
-          assignment.questionOrder.indexOf(b.id),
-      );
-    }
-
-    assignment.questions = filteredQuestions;
+    assignment.questions = applyQuestionOrder(
+      filteredQuestions,
+      assignment.questionOrder,
+    );
     return assignment as Assignment & { questions: QuestionDto[] };
   }
 

--- a/apps/api/src/api/assignment/v2/services/__tests__/version-management.service.spec.ts
+++ b/apps/api/src/api/assignment/v2/services/__tests__/version-management.service.spec.ts
@@ -19,6 +19,7 @@ describe("VersionManagementService", () => {
     assignmentVersion: {
       create: jest.fn(),
       findMany: jest.fn(),
+      findFirst: jest.fn(),
       findUnique: jest.fn(),
       updateMany: jest.fn(),
       update: jest.fn(),
@@ -36,6 +37,7 @@ describe("VersionManagementService", () => {
   const mockLogger = {
     child: jest.fn().mockReturnThis(),
     info: jest.fn(),
+    debug: jest.fn(),
     warn: jest.fn(),
     error: jest.fn(),
   };
@@ -305,6 +307,172 @@ describe("VersionManagementService", () => {
           changeType: "modified",
         }),
       );
+    });
+  });
+
+  describe("question ordering in version snapshots", () => {
+    const mockUserSession = {
+      userId: "user123",
+      role: UserRole.AUTHOR,
+    };
+
+    const buildQuestion = (id: number, question: string) => ({
+      id,
+      totalPoints: 5,
+      authorComment: null,
+      type: "TEXT",
+      responseType: "ESSAY",
+      question,
+      maxWords: null,
+      scoring: null,
+      choices: null,
+      randomizedChoices: false,
+      answer: null,
+      gradingContextQuestionIds: [],
+      maxCharacters: null,
+      videoPresentationConfig: null,
+      liveRecordingConfig: null,
+    });
+
+    const buildAssignment = () => ({
+      id: 1,
+      currentVersionId: null,
+      name: "Assignment",
+      introduction: null,
+      instructions: null,
+      gradingCriteriaOverview: null,
+      timeEstimateMinutes: null,
+      type: "MANUAL",
+      graded: false,
+      numAttempts: 1,
+      attemptsBeforeCoolDown: 1,
+      retakeAttemptCoolDownMinutes: 5,
+      allotedTimeMinutes: null,
+      attemptsPerTimeRange: null,
+      attemptsTimeRangeHours: null,
+      passingGrade: 50,
+      displayOrder: "DEFINED",
+      questionDisplay: "ONE_PER_PAGE",
+      numberOfQuestionsPerAttempt: null,
+      questionOrder: [2, 1],
+      published: true,
+      showAssignmentScore: true,
+      showQuestionScore: true,
+      showSubmissionFeedback: true,
+      showQuestions: true,
+      correctAnswerVisibility: "NEVER",
+      questionControls: null,
+      languageCode: "en",
+      questions: [
+        buildQuestion(1, "Question 1"),
+        buildQuestion(2, "Question 2"),
+      ],
+      versions: [],
+    });
+
+    it("creates question versions using assignment.questionOrder", async () => {
+      const assignment = buildAssignment();
+      const tx = {
+        assignmentVersion: {
+          create: jest.fn().mockResolvedValue({
+            id: 10,
+            versionNumber: "1.0.0",
+            versionDescription: "Version 1",
+            isDraft: false,
+            isActive: false,
+            published: true,
+            createdBy: mockUserSession.userId,
+            createdAt: new Date(),
+          }),
+        },
+        questionVersion: {
+          create: jest.fn().mockResolvedValue({ id: 100 }),
+        },
+        versionHistory: {
+          create: jest.fn().mockResolvedValue({}),
+        },
+      };
+
+      mockPrismaService.assignment.findUnique.mockResolvedValue(assignment);
+      mockPrismaService.assignmentVersion.findFirst.mockResolvedValue(null);
+      mockPrismaService.$transaction.mockImplementation(async (callback) =>
+        callback(tx),
+      );
+
+      await service.createVersion(
+        1,
+        {
+          versionNumber: "1.0.0",
+          versionDescription: "Version 1",
+          isDraft: false,
+          shouldActivate: false,
+        },
+        mockUserSession as any,
+      );
+
+      expect(
+        tx.questionVersion.create.mock.calls.map(
+          (call) => call[0].data.questionId,
+        ),
+      ).toEqual([2, 1]);
+      expect(
+        tx.questionVersion.create.mock.calls.map(
+          (call) => call[0].data.displayOrder,
+        ),
+      ).toEqual([1, 2]);
+    });
+
+    it("updates existing versions using assignment.questionOrder", async () => {
+      const assignment = buildAssignment();
+      const tx = {
+        assignmentVersion: {
+          update: jest.fn().mockResolvedValue({
+            id: 10,
+            versionNumber: "1.0.1",
+            versionDescription: "Updated version",
+            isDraft: false,
+            isActive: false,
+            published: true,
+            createdBy: mockUserSession.userId,
+            createdAt: new Date(),
+            _count: { questionVersions: 2 },
+          }),
+        },
+        questionVersion: {
+          deleteMany: jest.fn().mockResolvedValue({ count: 2 }),
+          create: jest.fn().mockResolvedValue({ id: 200 }),
+        },
+        versionHistory: {
+          create: jest.fn().mockResolvedValue({}),
+        },
+      };
+
+      mockPrismaService.assignment.findUnique.mockResolvedValue(assignment);
+      mockPrismaService.$transaction.mockImplementation(async (callback) =>
+        callback(tx),
+      );
+
+      await service["updateExistingVersion"](
+        1,
+        10,
+        {
+          versionDescription: "Updated version",
+          isDraft: false,
+          shouldActivate: false,
+        },
+        mockUserSession as any,
+      );
+
+      expect(
+        tx.questionVersion.create.mock.calls.map(
+          (call) => call[0].data.questionId,
+        ),
+      ).toEqual([2, 1]);
+      expect(
+        tx.questionVersion.create.mock.calls.map(
+          (call) => call[0].data.displayOrder,
+        ),
+      ).toEqual([1, 2]);
     });
   });
 });

--- a/apps/api/src/api/assignment/v2/services/assignment.service.ts
+++ b/apps/api/src/api/assignment/v2/services/assignment.service.ts
@@ -17,6 +17,7 @@ import {
   UpdateAssignmentQuestionsDto,
   VariantDto,
 } from "../../dto/update.questions.request.dto";
+import { applyQuestionOrder } from "../../utils/question-order.util";
 import { AssignmentRepository } from "../repositories/assignment.repository";
 import { JobStatusServiceV2 } from "./job-status.service";
 import { QuestionService } from "./question.service";
@@ -263,6 +264,7 @@ export class AssignmentServiceV2 {
       }
 
       let questionContentChanged = false;
+      let frontendToBackendIdMap = new Map<number, number>();
 
       if (updateDto.questions && updateDto.questions.length > 0) {
         await this.jobStatusService.updateJobStatus(jobId, {
@@ -287,19 +289,20 @@ export class AssignmentServiceV2 {
           percentage: 20,
         });
 
-        await this.questionService.processQuestionsForPublishing(
-          assignmentId,
-          updateDto.questions,
-          jobId,
-          async (childProgress: number) => {
-            const mappedProgress = 30 + (childProgress * 50) / 100;
-            await this.jobStatusService.updateJobStatus(jobId, {
-              status: "In Progress",
-              progress: `Processing questions: ${childProgress}% complete`,
-              percentage: Math.floor(mappedProgress),
-            });
-          },
-        );
+        frontendToBackendIdMap =
+          await this.questionService.processQuestionsForPublishing(
+            assignmentId,
+            updateDto.questions,
+            jobId,
+            async (childProgress: number) => {
+              const mappedProgress = 30 + (childProgress * 50) / 100;
+              await this.jobStatusService.updateJobStatus(jobId, {
+                status: "In Progress",
+                progress: `Processing questions: ${childProgress}% complete`,
+                percentage: Math.floor(mappedProgress),
+              });
+            },
+          );
       }
 
       const existingTranslationCount =
@@ -431,36 +434,35 @@ export class AssignmentServiceV2 {
         percentage: 90,
       });
 
-      const questionOrder = this.resolveQuestionOrder(
+      const updatedQuestions =
+        await this.questionService.getQuestionsForAssignment(assignmentId);
+      const resolvedQuestionOrder = this.resolveQuestionOrder(
         updateDto,
         existingAssignment,
       );
-
-      if (questionContentChanged || !existingAssignment.published) {
-        await this.questionService.updateQuestionGradingContext(assignmentId);
-      }
+      const questionOrder = this.normalizeQuestionOrder(
+        resolvedQuestionOrder.map((id) => frontendToBackendIdMap.get(id) ?? id),
+        updatedQuestions.map((question) => question.id),
+      );
 
       await this.assignmentRepository.update(assignmentId, {
         questionOrder,
         published: updateDto.published,
       });
 
-      const updatedQuestions =
-        await this.questionService.getQuestionsForAssignment(assignmentId);
+      if (questionContentChanged || !existingAssignment.published) {
+        await this.questionService.updateQuestionGradingContext(assignmentId);
+      }
 
-      const questionOrderIndex = new Map(
-        questionOrder.map((id, index) => [id, index]),
+      const orderedUpdatedQuestions = applyQuestionOrder(
+        updatedQuestions,
+        questionOrder,
       );
-      updatedQuestions.sort((a, b) => {
-        const indexA = questionOrderIndex.get(a.id) ?? Number.MAX_SAFE_INTEGER;
-        const indexB = questionOrderIndex.get(b.id) ?? Number.MAX_SAFE_INTEGER;
-        return indexA - indexB;
-      });
 
       this.logger.info(
-        `Found ${updatedQuestions.length} questions after processing for assignment ${assignmentId}`,
+        `Found ${orderedUpdatedQuestions.length} questions after processing for assignment ${assignmentId}`,
         {
-          questionIds: updatedQuestions.map((q) => q.id),
+          questionIds: orderedUpdatedQuestions.map((q) => q.id),
         },
       );
 
@@ -472,7 +474,7 @@ export class AssignmentServiceV2 {
 
       try {
         this.logger.info(
-          `Managing version after question processing - found ${updatedQuestions.length} questions`,
+          `Managing version after question processing - found ${orderedUpdatedQuestions.length} questions`,
         );
 
         const userSession = {
@@ -514,7 +516,7 @@ export class AssignmentServiceV2 {
                 gradingCriteriaOverview: updateDto.gradingCriteriaOverview,
                 timeEstimateMinutes: updateDto.timeEstimateMinutes,
               },
-              questionsData: updatedQuestions,
+              questionsData: orderedUpdatedQuestions,
               versionDescription:
                 updateDto.versionDescription ??
                 `Published version - ${new Date().toLocaleDateString()}`,
@@ -577,7 +579,7 @@ export class AssignmentServiceV2 {
                 gradingCriteriaOverview: updateDto.gradingCriteriaOverview,
                 timeEstimateMinutes: updateDto.timeEstimateMinutes,
               },
-              questionsData: updatedQuestions,
+              questionsData: orderedUpdatedQuestions,
               versionDescription:
                 updateDto.versionDescription ??
                 `Draft - ${new Date().toLocaleDateString()}`,
@@ -608,7 +610,7 @@ export class AssignmentServiceV2 {
               versionError instanceof Error ? versionError.stack : undefined,
             assignmentId,
             userId,
-            questionsFound: updatedQuestions.length,
+            questionsFound: orderedUpdatedQuestions.length,
           },
         );
       }
@@ -879,6 +881,7 @@ export class AssignmentServiceV2 {
     for (const id of validIds) {
       if (!seen.has(id)) {
         normalized.push(id);
+        seen.add(id);
       }
     }
 

--- a/apps/api/src/api/assignment/v2/services/question.service.ts
+++ b/apps/api/src/api/assignment/v2/services/question.service.ts
@@ -21,6 +21,7 @@ import {
   VariantDto,
   VariantType,
 } from "../../dto/update.questions.request.dto";
+import { applyQuestionOrder } from "../../utils/question-order.util";
 import { QuestionRepository } from "../repositories/question.repository";
 import { VariantRepository } from "../repositories/variant.repository";
 import { JobStatusServiceV2 } from "./job-status.service";
@@ -104,7 +105,7 @@ export class QuestionService {
     jobId?: number,
     progressCallback?: (progress: number) => Promise<void>,
     forceTranslation = false,
-  ): Promise<void> {
+  ): Promise<Map<number, number>> {
     void forceTranslation;
     const INITIAL_SETUP_RANGE = { start: 0, end: 10 };
     const QUESTION_PROCESSING_RANGE = { start: 10, end: 90 };
@@ -268,6 +269,8 @@ export class QuestionService {
         FINAL_CLEANUP_RANGE.end,
         "Question processing completed successfully",
       );
+
+      return frontendToBackendIdMap;
     } catch (error) {
       const errorMessage =
         error instanceof Error ? error.message : "Unknown error";
@@ -395,10 +398,9 @@ export class QuestionService {
       );
     }
 
-    const questionOrder = assignment.questionOrder || [];
-
-    const sortedQuestions = [...assignment.questions].sort(
-      (a, b) => questionOrder.indexOf(a.id) - questionOrder.indexOf(b.id),
+    const sortedQuestions = applyQuestionOrder(
+      assignment.questions,
+      assignment.questionOrder,
     );
 
     const questionsForGradingContext = sortedQuestions.map((q) => ({

--- a/apps/api/src/api/assignment/v2/services/version-management.service.ts
+++ b/apps/api/src/api/assignment/v2/services/version-management.service.ts
@@ -19,6 +19,7 @@ import {
 import { WINSTON_MODULE_PROVIDER } from "nest-winston";
 import { UserSession } from "src/auth/interfaces/user.session.interface";
 import { Logger } from "winston";
+import { applyQuestionOrder } from "../../utils/question-order.util";
 import { PrismaService } from "../../../../database/prisma.service";
 import { QuestionDto } from "../../dto/update.questions.request.dto";
 
@@ -316,7 +317,12 @@ export class VersionManagementService {
         `Creating ${assignment.questions.length} question versions for assignment version ${assignmentVersion.id}`,
       );
 
-      for (const [index, question] of assignment.questions.entries()) {
+      const orderedQuestions = applyQuestionOrder(
+        assignment.questions,
+        assignment.questionOrder,
+      );
+
+      for (const [index, question] of orderedQuestions.entries()) {
         const questionVersion = await tx.questionVersion.create({
           data: {
             assignmentVersionId: assignmentVersion.id,
@@ -347,7 +353,7 @@ export class VersionManagementService {
       }
 
       this.logger.info(
-        `Successfully created all ${assignment.questions.length} question versions`,
+        `Successfully created all ${orderedQuestions.length} question versions`,
       );
 
       if (createVersionDto.shouldActivate) {
@@ -1079,7 +1085,12 @@ export class VersionManagementService {
         where: { assignmentVersionId: versionId },
       });
 
-      for (const [index, question] of assignment.questions.entries()) {
+      const orderedQuestions = applyQuestionOrder(
+        assignment.questions,
+        assignment.questionOrder,
+      );
+
+      for (const [index, question] of orderedQuestions.entries()) {
         await tx.questionVersion.create({
           data: {
             assignmentVersionId: versionId,

--- a/apps/api/src/api/assignment/v2/tests/unit/__mocks__/ common-mocks.ts
+++ b/apps/api/src/api/assignment/v2/tests/unit/__mocks__/ common-mocks.ts
@@ -1801,7 +1801,7 @@ export const createMockQuestionService = () => ({
       { ...createMockQuestionDto(), variants: [createMockVariantDto()] },
     ],
   }),
-  processQuestionsForPublishing: jest.fn().mockResolvedValue(undefined),
+  processQuestionsForPublishing: jest.fn().mockResolvedValue(new Map()),
   generateQuestions: jest
     .fn()
     .mockResolvedValue({ message: "Question generation started", jobId: 1 }),

--- a/apps/api/src/api/assignment/v2/tests/unit/repositories/assignment.repository.spec.ts
+++ b/apps/api/src/api/assignment/v2/tests/unit/repositories/assignment.repository.spec.ts
@@ -336,6 +336,68 @@ describe("AssignmentRepository", () => {
       global.JSON.parse = originalJsonParse;
     });
 
+    it("should append questions missing from questionOrder instead of moving them to the front", async () => {
+      const assignmentId = 1;
+      const mockQuestions = [
+        {
+          id: 3,
+          question: "Question 3",
+          type: QuestionType.SINGLE_CORRECT,
+          isDeleted: false,
+          choices: JSON.stringify([]),
+          variants: [],
+          assignmentId: 1,
+        },
+        {
+          id: 1,
+          question: "Question 1",
+          type: QuestionType.SINGLE_CORRECT,
+          isDeleted: false,
+          choices: JSON.stringify([]),
+          variants: [],
+          assignmentId: 1,
+        },
+        {
+          id: 2,
+          question: "Question 2",
+          type: QuestionType.SINGLE_CORRECT,
+          isDeleted: false,
+          choices: JSON.stringify([]),
+          variants: [],
+          assignmentId: 1,
+        },
+      ];
+
+      const mockAssignment = {
+        ...createMockAssignment({ id: assignmentId }),
+        questions: mockQuestions,
+        questionOrder: [2, 1],
+      };
+
+      jest
+        .spyOn(prismaService.assignment, "findUnique")
+        .mockResolvedValue(mockAssignment);
+
+      const originalJsonParse = JSON.parse;
+      global.JSON.parse = jest.fn().mockImplementation((text) => {
+        if (typeof text === "string") {
+          return originalJsonParse(text) as unknown;
+        }
+        return text as unknown;
+      });
+
+      const result = (await repository.findById(
+        assignmentId,
+        sampleAuthorSession,
+      )) as GetAssignmentResponseDto;
+
+      expect(result.questions?.map((question) => question.id)).toEqual([
+        2, 1, 3,
+      ]);
+
+      global.JSON.parse = originalJsonParse;
+    });
+
     describe("version handling", () => {
       it("should use currentVersion when it exists and is active", async () => {
         const assignmentId = 1;

--- a/apps/api/src/api/assignment/v2/tests/unit/services/assignment.service.spec.ts
+++ b/apps/api/src/api/assignment/v2/tests/unit/services/assignment.service.spec.ts
@@ -370,6 +370,60 @@ describe("AssignmentServiceV2 – full unit-suite", () => {
     );
   });
 
+  it("maps temporary frontend question ids to persisted backend ids before saving question order", async () => {
+    const assignmentId = 1;
+    const jobId = 1;
+    const tempQuestionId = 966_122_647;
+    const persistedQuestionId = 3;
+    const dto = createMockUpdateAssignmentQuestionsDto(
+      {
+        questionOrder: [1, tempQuestionId, 2],
+        questions: [
+          createMockQuestionDto({ id: 1 }),
+          createMockQuestionDto({ id: tempQuestionId }),
+          createMockQuestionDto({ id: 2 }),
+        ],
+      },
+      false,
+    );
+
+    const existingAssignment = createMockGetAssignmentResponseDto(
+      { published: true, questionOrder: [1, 2] },
+      [createMockQuestion({ id: 1 }), createMockQuestion({ id: 2 })],
+    );
+    assignmentRepository.findById.mockResolvedValue(existingAssignment);
+    questionService.processQuestionsForPublishing.mockResolvedValue(
+      new Map([[tempQuestionId, persistedQuestionId]]),
+    );
+    questionService.getQuestionsForAssignment.mockResolvedValue([
+      createMockQuestionDto({ id: 1 }),
+      createMockQuestionDto({ id: 2 }),
+      createMockQuestionDto({ id: persistedQuestionId }),
+    ]);
+
+    jest
+      .spyOn<
+        any,
+        any
+      >(service as any, "haveTranslatableAssignmentFieldsChanged")
+      .mockReturnValue(false);
+    jest
+      .spyOn<any, any>(service as any, "haveQuestionContentsChanged")
+      .mockReturnValue(false);
+
+    await service["startPublishingProcess"](
+      jobId,
+      assignmentId,
+      dto,
+      "author-123",
+    );
+
+    expect(assignmentRepository.update).toHaveBeenCalledWith(
+      assignmentId,
+      expect.objectContaining({ questionOrder: [1, persistedQuestionId, 2] }),
+    );
+  });
+
   describe("resolveQuestionOrder", () => {
     it("uses explicit questionOrder even when questions payload is absent", () => {
       const existingAssignment = createMockGetAssignmentResponseDto();

--- a/apps/api/src/api/assignment/v2/tests/unit/services/question.service.spec.ts
+++ b/apps/api/src/api/assignment/v2/tests/unit/services/question.service.spec.ts
@@ -425,6 +425,40 @@ describe("QuestionService", () => {
         expect(prismaService.question.update).toHaveBeenCalledTimes(2);
       });
 
+      it("should append questions missing from questionOrder when building grading context", async () => {
+        const assignmentId = 1;
+        const mockAssignment = {
+          id: assignmentId,
+          questionOrder: [2, 1],
+          questions: [
+            { id: 1, question: "Question 1", isDeleted: false },
+            { id: 2, question: "Question 2", isDeleted: false },
+            { id: 3, question: "Question 3", isDeleted: false },
+          ],
+        };
+
+        prismaService.assignment.findUnique.mockResolvedValue(mockAssignment);
+        llmFacadeService.generateQuestionGradingContext.mockResolvedValue({
+          "1": [2],
+          "2": [1],
+          "3": [1, 2],
+        });
+        prismaService.question.update.mockResolvedValue({});
+
+        await questionService.updateQuestionGradingContext(assignmentId);
+
+        expect(
+          llmFacadeService.generateQuestionGradingContext,
+        ).toHaveBeenCalledWith(
+          [
+            { id: 2, questionText: "Question 2" },
+            { id: 1, questionText: "Question 1" },
+            { id: 3, questionText: "Question 3" },
+          ],
+          assignmentId,
+        );
+      });
+
       it("should throw not found exception for invalid assignment", async () => {
         const assignmentId = 999;
         prismaService.assignment.findUnique.mockResolvedValue(null);

--- a/apps/api/src/api/attempt/services/attempt-submission.service.spec.ts
+++ b/apps/api/src/api/attempt/services/attempt-submission.service.spec.ts
@@ -399,6 +399,47 @@ describe("AttemptSubmissionService - Grading Validation", () => {
       expect(orderedQuestions[0].id).toBe(2001);
       expect(orderedQuestions[0].variants).toHaveLength(0);
     });
+
+    it("appends questions missing from questionOrder when creating learner attempts", async () => {
+      const questionVersions = [
+        makeQuestionVersion({ id: 3001, questionId: 10, question: "Q1" }),
+        makeQuestionVersion({ id: 3002, questionId: 20, question: "Q2" }),
+        makeQuestionVersion({ id: 3003, questionId: 30, question: "Q3" }),
+      ];
+
+      mockAssignmentRepository.findById.mockResolvedValue({
+        ...baseAssignment,
+        questionOrder: [20, 10],
+      });
+      mockPrisma.assignment.findUnique.mockResolvedValue({
+        currentVersionId: 9,
+        currentVersion: { questionVersions },
+        questions: [],
+      });
+      mockPrisma.question.findMany.mockResolvedValue([
+        { id: 10, variants: [] },
+        { id: 20, variants: [] },
+        { id: 30, variants: [] },
+      ]);
+
+      await service.createAssignmentAttempt(assignmentId, userSession);
+
+      const [, orderedQuestions] = mockQuestionVariantService
+        .createAttemptQuestionVariants.mock.calls[0] as [
+        number,
+        Array<{ id: number }>,
+      ];
+
+      expect(orderedQuestions.map((question) => question.id)).toEqual([
+        20, 10, 30,
+      ]);
+      expect(mockPrisma.assignmentAttempt.update).toHaveBeenCalledWith({
+        where: { id: 55 },
+        data: {
+          questionOrder: [20, 10, 30],
+        },
+      });
+    });
   });
 
   describe("updateAssignmentAttempt - author preview", () => {

--- a/apps/api/src/api/attempt/services/attempt-submission.service.ts
+++ b/apps/api/src/api/attempt/services/attempt-submission.service.ts
@@ -39,6 +39,7 @@ import {
   VariantType,
   VideoPresentationConfig,
 } from "src/api/assignment/dto/update.questions.request.dto";
+import { applyQuestionOrder } from "src/api/assignment/utils/question-order.util";
 import { ScoringType } from "src/api/assignment/question/dto/create.update.question.request.dto";
 import { AssignmentRepository } from "src/api/assignment/v2/repositories/assignment.repository";
 import { UserSessionMiddleware } from "src/auth/middleware/user.session.middleware";
@@ -1449,10 +1450,9 @@ export class AttemptSubmissionService {
       assignment.questionOrder &&
       assignment.questionOrder.length > 0
     ) {
-      orderedQuestions.sort(
-        (a, b) =>
-          assignment.questionOrder.indexOf(a.id) -
-          assignment.questionOrder.indexOf(b.id),
+      orderedQuestions = applyQuestionOrder(
+        orderedQuestions,
+        assignment.questionOrder,
       );
     }
 

--- a/apps/web/app/chatbot/store/useAuthorContext.ts
+++ b/apps/web/app/chatbot/store/useAuthorContext.ts
@@ -3,6 +3,7 @@
 "use client";
 
 import { useAuthorStore } from "@/stores/author";
+import { applyQuestionOrder } from "@/stores/utils/question-order";
 import { useEffect, useState, useCallback } from "react";
 import { shallow } from "zustand/shallow";
 
@@ -152,13 +153,7 @@ export const useAuthorContext = (): UseAuthorContextInterface => {
 
       const orderedQuestions =
         Array.isArray(questionOrder) && questionOrder.length > 0
-          ? safeQuestions.sort((a, b) => {
-              const aIndex = questionOrder.indexOf(a.id);
-              const bIndex = questionOrder.indexOf(b.id);
-              if (aIndex === -1) return 1;
-              if (bIndex === -1) return -1;
-              return aIndex - bIndex;
-            })
+          ? applyQuestionOrder(safeQuestions, questionOrder).questions
           : safeQuestions;
 
       orderedQuestions.forEach((q, idx) => {

--- a/apps/web/stores/__tests__/author.test.ts
+++ b/apps/web/stores/__tests__/author.test.ts
@@ -1,0 +1,77 @@
+import { QuestionAuthorStore } from "@/config/types";
+import { useAuthorStore } from "../author";
+
+const makeQuestion = (id: number, index: number): QuestionAuthorStore => ({
+  id,
+  index,
+  question: `Question ${id}`,
+  type: "TEXT",
+  totalPoints: 1,
+  scoring: {
+    type: "CRITERIA_BASED",
+    rubrics: [],
+  },
+  numRetries: 1,
+  choices: [],
+  variants: [],
+  alreadyInBackend: true,
+  answer: null,
+  assignmentId: 1,
+  gradingContextQuestionIds: [],
+  randomizedChoices: false,
+});
+
+describe("useAuthorStore question order syncing", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useAuthorStore.getState().deleteStore();
+  });
+
+  it("syncs questionOrder when questions are set directly", () => {
+    useAuthorStore
+      .getState()
+      .setQuestions([makeQuestion(2, 1), makeQuestion(1, 2)]);
+
+    expect(useAuthorStore.getState().questionOrder).toEqual([2, 1]);
+  });
+
+  it("appends new questions to questionOrder when authors add them", () => {
+    useAuthorStore
+      .getState()
+      .setQuestions([makeQuestion(1, 1), makeQuestion(2, 2)]);
+
+    useAuthorStore.getState().addQuestion(makeQuestion(3, 3));
+
+    expect(useAuthorStore.getState().questionOrder).toEqual([1, 2, 3]);
+  });
+
+  it("removes deleted question ids from questionOrder", () => {
+    useAuthorStore
+      .getState()
+      .setQuestions([
+        makeQuestion(1, 1),
+        makeQuestion(2, 2),
+        makeQuestion(3, 3),
+      ]);
+
+    useAuthorStore.getState().removeQuestion(2);
+
+    expect(useAuthorStore.getState().questionOrder).toEqual([1, 3]);
+    expect(
+      useAuthorStore.getState().questions.map((question) => question.id),
+    ).toEqual([1, 3]);
+  });
+
+  it("keeps questionOrder stable when replacing a question", () => {
+    useAuthorStore
+      .getState()
+      .setQuestions([makeQuestion(1, 1), makeQuestion(2, 2)]);
+
+    useAuthorStore.getState().replaceQuestion(2, {
+      ...makeQuestion(2, 2),
+      question: "Updated question",
+    });
+
+    expect(useAuthorStore.getState().questionOrder).toEqual([1, 2]);
+  });
+});

--- a/apps/web/stores/author.ts
+++ b/apps/web/stores/author.ts
@@ -840,7 +840,11 @@ export const useAuthorStore = createWithEqualityFn<
         },
         questions: [],
         setQuestions: (questions) => {
-          set({ questions, hasUnsavedChanges: true });
+          set({
+            questions,
+            questionOrder: questions.map((question) => question.id),
+            hasUnsavedChanges: true,
+          });
         },
         setEvaluateBodyLanguage: (questionId, bodyLanguageBool) => {
           set((state) => {
@@ -963,6 +967,7 @@ export const useAuthorStore = createWithEqualityFn<
 
             return {
               questions: updatedQuestions,
+              questionOrder: updatedQuestions.map((item) => item.id),
               updatedAt: Date.now(),
               hasUnsavedChanges: true,
             };
@@ -976,7 +981,11 @@ export const useAuthorStore = createWithEqualityFn<
               (q) => q.id !== questionId,
             );
             useQuestionStore.getState().clearQuestionState(questionId);
-            return { questions: updatedQuestions, hasUnsavedChanges: true };
+            return {
+              questions: updatedQuestions,
+              questionOrder: updatedQuestions.map((question) => question.id),
+              hasUnsavedChanges: true,
+            };
           }),
         replaceQuestion: (questionId, newQuestion) =>
           set((state) => {
@@ -984,7 +993,11 @@ export const useAuthorStore = createWithEqualityFn<
             if (index === -1) return {};
             const updatedQuestions = [...state.questions];
             updatedQuestions[index] = newQuestion;
-            return { questions: updatedQuestions, hasUnsavedChanges: true };
+            return {
+              questions: updatedQuestions,
+              questionOrder: updatedQuestions.map((question) => question.id),
+              hasUnsavedChanges: true,
+            };
           }),
         modifyQuestion: (questionId, modifiedData) => {
           set((state) => {

--- a/apps/web/stores/utils/__tests__/question-order.test.ts
+++ b/apps/web/stores/utils/__tests__/question-order.test.ts
@@ -57,4 +57,18 @@ describe("applyQuestionOrder", () => {
     expect(result.questionOrder).toEqual([5, 6]);
     expect(result.questions.map((q) => q.id)).toEqual([5, 6]);
   });
+
+  it("appends newly added questions that are missing from backend order", () => {
+    const questions = [
+      makeQuestion(1, 1),
+      makeQuestion(2, 2),
+      makeQuestion(99, 3),
+    ];
+
+    const result = applyQuestionOrder(questions, [2, 1]);
+
+    expect(result.questionOrder).toEqual([2, 1, 99]);
+    expect(result.questions.map((q) => q.id)).toEqual([2, 1, 99]);
+    expect(result.questions.map((q) => q.index)).toEqual([1, 2, 3]);
+  });
 });


### PR DESCRIPTION
## Summary
- add a shared question-order helper and use it across author fetch, publish, versioning, and learner attempt flows
- persist questionOrder correctly when questions are created, deleted, and published, including mapping frontend temp IDs to backend IDs
- add backend and frontend regression tests covering author state, repository/service ordering, publish/version snapshots, and learner attempts

## Testing
- API targeted jest: 7 suites, 141 tests
- Web targeted jest: 2 suites, 8 tests
- Targeted eslint on changed API and web source files