### PR TITLE
Fix/api pdf extraction resilience

### DIFF
--- a/apps/api/src/api/attempt/services/file-content-extraction.ts
+++ b/apps/api/src/api/attempt/services/file-content-extraction.ts
@@ -448,8 +448,25 @@ export class FileContentExtractionService {
     additionalMetadata?: Record<string, number | boolean | string>;
   }> {
     const fileExtension = filename.split(".").pop()?.toLowerCase() || "";
-    this.logger.debug(
-      `Extracting from ${filename} (type: ${mimeType}, ext: ${fileExtension}, size: ${buffer.length})`,
+
+    // Forensic identifiers — computed once from the raw buffer. No PII risk:
+    // filename is opaque, byteSize and sha256 are non-sensitive, magic bytes
+    // are the first 8 bytes used to discriminate file format from junk.
+    // Goal: when an extractor fails (or hangs / kills the pod), the entry
+    // log alone identifies which artifact and which dispatch path was taken.
+    const byteSize = buffer.byteLength;
+    const sha256Short = crypto
+      .createHash("sha256")
+      .update(buffer)
+      .digest("hex")
+      .slice(0, 16);
+    const magicBytesHex = buffer.subarray(0, 8).toString("hex");
+    const startTime = Date.now();
+
+    this.logger.log(
+      `extractTextFromBuffer entry: filename=${filename} ` +
+        `extension=${fileExtension} mimeType=${mimeType} ` +
+        `byteSize=${byteSize} sha256=${sha256Short} magicBytes=${magicBytesHex}`,
     );
 
     try {
@@ -458,18 +475,44 @@ export class FileContentExtractionService {
         filename,
         fileExtension,
       );
-      if (result) return result;
+      if (result) {
+        this.logger.log(
+          `extractTextFromBuffer completed: filename=${filename} ` +
+            `extension=${fileExtension} byteSize=${byteSize} sha256=${sha256Short} ` +
+            `dispatch=extension durationMs=${Date.now() - startTime}`,
+        );
+        return result;
+      }
 
       const mimeResult = await this.extractByMimeType(
         buffer,
         filename,
         mimeType,
       );
-      if (mimeResult) return mimeResult;
+      if (mimeResult) {
+        this.logger.log(
+          `extractTextFromBuffer completed: filename=${filename} ` +
+            `extension=${fileExtension} byteSize=${byteSize} sha256=${sha256Short} ` +
+            `dispatch=mimeType durationMs=${Date.now() - startTime}`,
+        );
+        return mimeResult;
+      }
 
-      return await this.extractWithFallback(buffer, filename);
+      const fallbackResult = await this.extractWithFallback(buffer, filename);
+      this.logger.log(
+        `extractTextFromBuffer completed: filename=${filename} ` +
+          `extension=${fileExtension} byteSize=${byteSize} sha256=${sha256Short} ` +
+          `dispatch=fallback durationMs=${Date.now() - startTime}`,
+      );
+      return fallbackResult;
     } catch (error) {
-      this.logger.warn(`Primary extraction failed for ${filename}:`, error);
+      this.logger.warn(
+        `Primary extraction failed: filename=${filename} ` +
+          `extension=${fileExtension} byteSize=${byteSize} sha256=${sha256Short} ` +
+          `magicBytes=${magicBytesHex} durationMs=${Date.now() - startTime} ` +
+          `error=${error instanceof Error ? error.message : String(error)}`,
+        error instanceof Error ? error.stack : undefined,
+      );
       return await this.extractWithFallback(buffer, filename);
     }
   }

--- a/apps/api/src/api/attempt/services/pdf-structure-extractor.service.ts
+++ b/apps/api/src/api/attempt/services/pdf-structure-extractor.service.ts
@@ -66,10 +66,7 @@ export class PdfStructureExtractorService {
     // the first 8 bytes of the file used to discriminate PDF/XLSX/junk).
     // Declared before the try so the catch branch can include them too.
     const byteSize = buffer.byteLength;
-    const sha256Full = crypto
-      .createHash("sha256")
-      .update(buffer)
-      .digest("hex");
+    const sha256Full = crypto.createHash("sha256").update(buffer).digest("hex");
     const sha256Short = sha256Full.slice(0, 16);
     const magicBytesHex = buffer.subarray(0, 8).toString("hex");
 
@@ -86,6 +83,15 @@ export class PdfStructureExtractorService {
         standardFontDataUrl: null,
       });
 
+      // Attach a tail .catch BEFORE awaiting so any late rejection from
+      // the loading task's background work (worker init, font preloads)
+      // cannot escape as a process-level unhandled rejection.
+      loadingTask.promise.catch((lateError: unknown) => {
+        this.logger.warn(
+          `Late getDocument rejection: submissionId=${submissionId} ` +
+            `${lateError instanceof Error ? lateError.message : String(lateError)}`,
+        );
+      });
       const pdfDocument: PDFDocumentProxy = await loadingTask.promise;
       const numberPages = pdfDocument.numPages ?? 0;
 
@@ -184,37 +190,65 @@ export class PdfStructureExtractorService {
     pageNumber: number,
     warnings: string[],
   ): Promise<StructuredPage> {
-    const page = await pdfDocument.getPage(pageNumber);
-    const viewport = page.getViewport({ scale: 1 });
+    const pageTask = pdfDocument.getPage(pageNumber);
+    pageTask.catch((lateError: unknown) => {
+      this.logger.warn(
+        `Late getPage rejection on page ${pageNumber}: ` +
+          `${lateError instanceof Error ? lateError.message : String(lateError)}`,
+      );
+    });
+    const page = await pageTask;
+    try {
+      const viewport = page.getViewport({ scale: 1 });
 
-    const textContent = await page.getTextContent();
-    const textItems = this.normalizeTextItems(textContent.items);
+      const textContentTask = page.getTextContent();
+      textContentTask.catch((lateError: unknown) => {
+        this.logger.warn(
+          `Late getTextContent rejection on page ${pageNumber}: ` +
+            `${lateError instanceof Error ? lateError.message : String(lateError)}`,
+        );
+      });
+      const textContent = await textContentTask;
+      const textItems = this.normalizeTextItems(textContent.items);
 
-    const blocks = this.groupTextItemsIntoBlocks(
-      textItems,
-      pageNumber,
-      viewport,
-    );
+      const blocks = this.groupTextItemsIntoBlocks(
+        textItems,
+        pageNumber,
+        viewport,
+      );
 
-    const typedBlocks = this.detectBlockTypes(blocks);
+      const typedBlocks = this.detectBlockTypes(blocks);
 
-    const imageBlocks = await this.extractImagesFromPage(
-      page,
-      pageNumber,
-      warnings,
-    );
+      const imageBlocks = await this.extractImagesFromPage(
+        page,
+        pageNumber,
+        warnings,
+      );
 
-    const allBlocks = [...typedBlocks, ...imageBlocks];
+      const allBlocks = [...typedBlocks, ...imageBlocks];
 
-    return {
-      pageNumber: pageNumber,
-      blocks: allBlocks,
-      metadata: {
-        width: viewport.width,
-        height: viewport.height,
-        rotation: viewport.rotation,
-      },
-    };
+      return {
+        pageNumber: pageNumber,
+        blocks: allBlocks,
+        metadata: {
+          width: viewport.width,
+          height: viewport.height,
+          rotation: viewport.rotation,
+        },
+      };
+    } finally {
+      // Best-effort release of worker-side resources for this page. cleanup()
+      // is synchronous in pdfjs-dist; wrap in try/catch so a cleanup failure
+      // cannot mask the real return value or throw out of finally.
+      try {
+        page.cleanup();
+      } catch (cleanupError) {
+        this.logger.debug(
+          `page.cleanup() failed for page ${pageNumber}: ` +
+            `${cleanupError instanceof Error ? cleanupError.message : String(cleanupError)}`,
+        );
+      }
+    }
   }
 
   private normalizeTextItems(
@@ -461,7 +495,18 @@ export class PdfStructureExtractorService {
             canvas: null,
           };
 
-          await page.render(renderContext).promise;
+          const renderTask = page.render(renderContext);
+          // Attach a tail catch BEFORE awaiting so any late rejection
+          // (e.g., font load or image decode resolving after the worker
+          // already moved on) is captured here and cannot escape as an
+          // unhandled promise rejection at the process level.
+          renderTask.promise.catch((lateError: unknown) => {
+            this.logger.warn(
+              `Late render rejection on page ${pageNumber}: ` +
+                `${lateError instanceof Error ? lateError.message : String(lateError)}`,
+            );
+          });
+          await renderTask.promise;
         }
       } catch (renderError) {
         this.logger.debug(
@@ -469,7 +514,16 @@ export class PdfStructureExtractorService {
         );
       }
 
-      const operatorList: PDFOperatorList = await page.getOperatorList();
+      const operatorListTask = page.getOperatorList();
+      // Same late-rejection guard for getOperatorList — it returns a Promise
+      // directly, so attach .catch to the Promise itself.
+      operatorListTask.catch((lateError: unknown) => {
+        this.logger.warn(
+          `Late getOperatorList rejection on page ${pageNumber}: ` +
+            `${lateError instanceof Error ? lateError.message : String(lateError)}`,
+        );
+      });
+      const operatorList: PDFOperatorList = await operatorListTask;
 
       let imageIndex = 0;
       const imageNames: string[] = [];

--- a/apps/api/src/api/attempt/services/pdf-structure-extractor.service.ts
+++ b/apps/api/src/api/attempt/services/pdf-structure-extractor.service.ts
@@ -61,6 +61,23 @@ export class PdfStructureExtractorService {
     const startTime = Date.now();
     const warnings: string[] = [];
 
+    // Forensic identifiers — computed once from the raw buffer (no PII risk;
+    // submissionId is opaque, hash + size are non-sensitive, magic bytes are
+    // the first 8 bytes of the file used to discriminate PDF/XLSX/junk).
+    // Declared before the try so the catch branch can include them too.
+    const byteSize = buffer.byteLength;
+    const sha256Full = crypto
+      .createHash("sha256")
+      .update(buffer)
+      .digest("hex");
+    const sha256Short = sha256Full.slice(0, 16);
+    const magicBytesHex = buffer.subarray(0, 8).toString("hex");
+
+    this.logger.log(
+      `extractStructuredContent entry: submissionId=${submissionId} ` +
+        `byteSize=${byteSize} sha256=${sha256Short} magicBytes=${magicBytesHex}`,
+    );
+
     try {
       const uint8Array = new Uint8Array(buffer);
       const loadingTask = pdfjs.getDocument({
@@ -107,11 +124,7 @@ export class PdfStructureExtractorService {
 
       const allBlocks = pages.flatMap((p) => p.blocks);
       const wordCount = this.calculateWordCount(allBlocks);
-      const checksum = crypto
-        .createHash("sha256")
-        .update(buffer)
-        .digest("hex")
-        .slice(0, 16);
+      const checksum = sha256Short;
 
       const sections = this.detectSections(pages);
 
@@ -142,12 +155,21 @@ export class PdfStructureExtractorService {
       };
 
       this.logger.log(
-        `Structured extraction completed: ${pages.length} pages, ${allBlocks.length} blocks, ${wordCount} words in ${duration}ms`,
+        `Structured extraction completed: submissionId=${submissionId} ` +
+          `pages=${pages.length} blocks=${allBlocks.length} ` +
+          `words=${wordCount} durationMs=${duration} ` +
+          `byteSize=${byteSize} sha256=${sha256Short} magicBytes=${magicBytesHex} ` +
+          `warnings=${warnings.length}`,
       );
 
       return { submission, metadata };
     } catch (error) {
-      this.logger.error("PDF structure extraction failed", error);
+      this.logger.error(
+        `PDF structure extraction failed: submissionId=${submissionId} ` +
+          `byteSize=${byteSize} sha256=${sha256Short} magicBytes=${magicBytesHex} ` +
+          `error=${error instanceof Error ? error.message : String(error)}`,
+        error instanceof Error ? error.stack : undefined,
+      );
       throw new Error(
         `Failed to extract PDF structure: ${error instanceof Error ? error.message : String(error)}`,
       );

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -237,8 +237,44 @@ async function bootstrap() {
       void shutdown("UNCAUGHT_EXCEPTION");
     });
 
-    process.on("unhandledRejection", (reason, promise) => {
-      logger.error("Unhandled Rejection at:", promise, "reason:", reason);
+    process.on("unhandledRejection", (reason) => {
+      // An unhandled rejection means a promise rejected with no handler
+      // attached. We cannot prove the application is in a sound state to
+      // keep serving requests (db/cache may be mid-operation, middleware
+      // may be partway through writing headers, BullMQ jobs may be in
+      // half-acknowledged state), so the safe default is to terminate
+      // and let K8s respawn. Prevent recurring crashes by catching
+      // expected async failures at the source — see e.g.
+      // PdfStructureExtractorService attaching `.catch` to PDF.js
+      // background tasks before awaiting.
+      let stack: string | undefined;
+      let name: string | undefined;
+      let serialized: string;
+      try {
+        if (reason instanceof Error) {
+          stack = reason.stack;
+          name = reason.name;
+          serialized = reason.message;
+        } else {
+          name = (reason as { constructor?: { name?: string } })?.constructor
+            ?.name;
+          stack = (reason as { stack?: string })?.stack;
+          try {
+            serialized = JSON.stringify(reason);
+          } catch {
+            serialized = String(reason);
+          }
+        }
+      } catch {
+        serialized = "<unserializable rejection reason>";
+      }
+
+      logger.error(
+        `Unhandled promise rejection: ` +
+          `name=${name ?? "<unknown>"} message=${String(reason)} ` +
+          `serialized=${serialized}`,
+        stack,
+      );
       void shutdown("UNHANDLED_REJECTION");
     });
 


### PR DESCRIPTION
<!-- This is helper text. It won't appear in the rendered output, but it will be visible when editing the Markdown file. -->

## **PR Description**
Certain PDFs were making mark pods kill themselves. Furthermore the dead pods would have the file processing request picked up by alive pods who would also kill themselves until no mark pods remained to process the file.

This PR adds basic guards against this behavior. We return proper error messages, and gracefully handle corrupt, or unsupported PDF types.


More Advanced Logs were also added for all file types. Though no protection was added for those routes yet.

### **Overview:**

  #### **Type of Issue:**

  - [ ] **Feature (`feat`)**
  - [X] **Bug Fix (`bug`)**
  - [ ] **Chore (`chore`)**
  - [ ] **Documentation Update (`doc`)**

  #### **Change Type:**

  - [ ] **Major**
  - [X] **Minor**
  - [ ] **Patch**

  ## Test Coverage
  - [ ] Unit tests updated
  - [X] Manual verification on staging:

  ## Impact / Risk
  - API pod shutdown behavior on `unhandledRejection` is unchanged (still kills on rejection — only the log format and reason-extraction wrapper changed).
  - PDF extractor: defensive `.catch` handlers + `page.cleanup()` in finally. No behavior change for valid PDFs.
  - File-content-extraction dispatch: new info-level logs only. No behavior change.
  - New log volume: 2 extra info lines per file extraction (entry + completion). Negligible.
  - No schema changes, no config changes, no new dependencies.

  ## Rollback
  Revert the four commits on this branch (or revert the merge commit).

  ## Reviewer Focus
  1. `apps/api/src/main.ts`
  right fields.
  2. `apps/api/src/api/attempt/services/pdf-structure-extractor.service.ts`: confirm `.catch`-before-await is correct on all 5 async paths and `page.cleanup()` is in finally.
  3. `apps/api/src/api/attempt/services/file-content-extraction.ts`