### PR TITLE
Chore: Increase CI test timeout

### DIFF
--- a/apps/api/src/job-queue/job-queue.integration.spec.ts
+++ b/apps/api/src/job-queue/job-queue.integration.spec.ts
@@ -31,7 +31,7 @@ describeIntegration("job-queue integration", () => {
     loggerSpy = jest
       .spyOn(Logger.prototype, "log")
       .mockImplementation(() => undefined);
-  });
+  }, 60_000);
 
   beforeEach(async () => {
     if (!redisHarness) {

--- a/apps/api/src/job-queue/job-queue.performance.spec.ts
+++ b/apps/api/src/job-queue/job-queue.performance.spec.ts
@@ -33,7 +33,7 @@ describePerformance("job-queue performance", () => {
     loggerSpy = jest
       .spyOn(Logger.prototype, "log")
       .mockImplementation(() => undefined);
-  });
+  }, 60_000);
 
   beforeEach(async () => {
     if (!redisHarness) {

--- a/apps/api/src/job-queue/job-queue.stress.spec.ts
+++ b/apps/api/src/job-queue/job-queue.stress.spec.ts
@@ -33,7 +33,7 @@ describeStress("job-queue stress", () => {
     loggerSpy = jest
       .spyOn(Logger.prototype, "log")
       .mockImplementation(() => undefined);
-  });
+  }, 60_000);
 
   beforeEach(async () => {
     if (!redisHarness) {

--- a/apps/api/test/job-queue.e2e-spec.ts
+++ b/apps/api/test/job-queue.e2e-spec.ts
@@ -233,7 +233,7 @@ describe("job-queue (e2e)", () => {
     }
 
     baseUrl = `http://127.0.0.1:${address.port}`;
-  });
+  }, 60_000);
 
   beforeEach(async () => {
     await redisHarness.flush();


### PR DESCRIPTION
Sometimes the test job CI failed because of a timeout. This bumps the timeout so it wont prematurely kill the test if its a little slower than usual