### PR TITLE
fix: stop report routes from hanging on NATS and exhausting Prisma pool

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": null,
     "lines": null
   },
-  "generated_at": "2026-05-13T23:38:00Z",
+  "generated_at": "2026-05-14T18:15:23Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -310,7 +310,7 @@
       {
         "hashed_secret": "035576b41cbaa44c5a58b0e7e3e8df19c5226a3f",
         "is_verified": false,
-        "line_number": 39,
+        "line_number": 41,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/apps/api/src/api/report/services/flo.service.ts
+++ b/apps/api/src/api/report/services/flo.service.ts
@@ -7,6 +7,8 @@ import {
   SkillsNetworkNatsServer,
 } from "../types/report.types";
 
+const FLO_PUBLISH_TIMEOUT_MS = 3000;
+
 @Injectable()
 export class FloService {
   private readonly logger = new Logger(FloService.name);
@@ -69,6 +71,44 @@ export class FloService {
   }
 
   /**
+   * Race a publish against a hard timeout so the underlying NATS connect
+   * (which has no built-in deadline in `sn-messaging-ts-client`) can never
+   * block a request handler indefinitely. Errors and timeouts both resolve
+   * to `false` — the caller treats this as best-effort telemetry.
+   */
+  private async publishWithTimeout(
+    label: string,
+    publish: () => Promise<unknown>,
+  ): Promise<boolean> {
+    let timer: NodeJS.Timeout | undefined;
+    const timeout = new Promise<"timeout">((resolve) => {
+      timer = setTimeout(() => resolve("timeout"), FLO_PUBLISH_TIMEOUT_MS);
+    });
+
+    try {
+      const result = await Promise.race([
+        publish().then(() => "ok" as const),
+        timeout,
+      ]);
+      if (result === "timeout") {
+        this.logger.warn(
+          `Flo publish (${label}) timed out after ${FLO_PUBLISH_TIMEOUT_MS}ms — NATS unreachable, skipping`,
+        );
+        return false;
+      }
+      return true;
+    } catch (error) {
+      this.logger.error(
+        `Flo publish (${label}) failed: ${(error as Error).message}`,
+        (error as Error).stack,
+      );
+      return false;
+    } finally {
+      if (timer) clearTimeout(timer);
+    }
+  }
+
+  /**
    * Send an error message to Flo
    */
   async sendError(
@@ -87,29 +127,24 @@ export class FloService {
       return false;
     }
 
-    try {
-      const messageData = {
-        title,
-        description,
-        category: "Mark Issue",
-        severity: options.severity || "info",
-        tool_name: "Mark AI Assistant",
-        type: "service",
-        tags: options.tags || ["mark", "chat"],
-        ...options,
-      };
+    const messageData = {
+      title,
+      description,
+      category: "Mark Issue",
+      severity: options.severity || "info",
+      tool_name: "Mark AI Assistant",
+      type: "service",
+      tags: options.tags || ["mark", "chat"],
+      ...options,
+    };
 
-      await client.publishUser(userEmail, "support.create", messageData);
-
+    const sent = await this.publishWithTimeout("sendError", () =>
+      client.publishUser(userEmail, "support.create", messageData),
+    );
+    if (sent) {
       this.logger.log(`Error report sent to Flo: ${title}`);
-      return true;
-    } catch (error) {
-      this.logger.error(
-        `Error sending to Flo: ${(error as Error).message}`,
-        (error as Error).stack,
-      );
-      return false;
     }
+    return sent;
   }
 
   /**
@@ -134,36 +169,31 @@ export class FloService {
       return false;
     }
 
-    try {
-      const messageData = {
-        organization: this.natsConfig.organization,
-        program: this.natsConfig.program,
-        project: this.natsConfig.project,
-        action: "feedback",
-        date: new Date().toISOString(),
-        subject: `${this.natsConfig.organization}.${this.natsConfig.program}.${this.natsConfig.project}.service.feedback`,
-        type: "service",
-        title,
-        description,
-        category: "feedback",
-        portal_name: options.portalName || "Mark AI Assistant",
-        portal_url: options.portalUrl,
-        user_email: options.userEmail,
-        rating: options.rating || "3",
-        ...options,
-      };
+    const messageData = {
+      organization: this.natsConfig.organization,
+      program: this.natsConfig.program,
+      project: this.natsConfig.project,
+      action: "feedback",
+      date: new Date().toISOString(),
+      subject: `${this.natsConfig.organization}.${this.natsConfig.program}.${this.natsConfig.project}.service.feedback`,
+      type: "service",
+      title,
+      description,
+      category: "feedback",
+      portal_name: options.portalName || "Mark AI Assistant",
+      portal_url: options.portalUrl,
+      user_email: options.userEmail,
+      rating: options.rating || "3",
+      ...options,
+    };
 
-      await client.publishService("feedback", messageData);
-
+    const sent = await this.publishWithTimeout("sendFeedback", () =>
+      client.publishService("feedback", messageData),
+    );
+    if (sent) {
       this.logger.log(`Feedback sent to Flo: ${title}`);
-      return true;
-    } catch (error) {
-      this.logger.error(
-        `Error sending feedback to Flo: ${(error as Error).message}`,
-        (error as Error).stack,
-      );
-      return false;
     }
+    return sent;
   }
 
   /**
@@ -188,34 +218,29 @@ export class FloService {
       return false;
     }
 
-    try {
-      const messageData = {
-        organization: this.natsConfig.organization,
-        program: this.natsConfig.program,
-        project: this.natsConfig.project,
-        action: "support",
-        date: new Date().toISOString(),
-        subject: `${this.natsConfig.organization}.${this.natsConfig.program}.${this.natsConfig.project}.service.support`,
-        type: "service",
-        title,
-        description,
-        portal_name: options.portalName || "Mark AI Assistant",
-        category: options.category || "Support Request",
-        userEmail: options.userEmail,
-        chatroomId: options.chatroomId,
-        ...options,
-      };
+    const messageData = {
+      organization: this.natsConfig.organization,
+      program: this.natsConfig.program,
+      project: this.natsConfig.project,
+      action: "support",
+      date: new Date().toISOString(),
+      subject: `${this.natsConfig.organization}.${this.natsConfig.program}.${this.natsConfig.project}.service.support`,
+      type: "service",
+      title,
+      description,
+      portal_name: options.portalName || "Mark AI Assistant",
+      category: options.category || "Support Request",
+      userEmail: options.userEmail,
+      chatroomId: options.chatroomId,
+      ...options,
+    };
 
-      await client.publishService("support", messageData);
-
+    const sent = await this.publishWithTimeout("sendSupportRequest", () =>
+      client.publishService("support", messageData),
+    );
+    if (sent) {
       this.logger.log(`Support request sent to Flo: ${title}`);
-      return true;
-    } catch (error) {
-      this.logger.error(
-        `Error sending support request to Flo: ${(error as Error).message}`,
-        (error as Error).stack,
-      );
-      return false;
     }
+    return sent;
   }
 }

--- a/apps/api/src/api/report/services/report.service.ts
+++ b/apps/api/src/api/report/services/report.service.ts
@@ -1371,15 +1371,26 @@ A new related issue has been created: #${issue.number}
 
       const report = await this.prisma.report.create({ data: reportData });
 
-      await this.floService.sendError(issueTitle, description, {
-        severity: issueSeverity,
-        tags: ["mark", "chat", "report", role || "user", issueType],
-        assignmentId,
-        attemptId,
-        github_issue: issue.number,
-        report_id: report.id,
-        is_duplicate: isDuplicate,
-      });
+      // Fire-and-forget: Flo is best-effort telemetry. Never block the
+      // request on its NATS publish — the underlying ts-nats client opens a
+      // fresh connection per call and has no built-in deadline.
+      void this.floService
+        .sendError(issueTitle, description, {
+          severity: issueSeverity,
+          tags: ["mark", "chat", "report", role || "user", issueType],
+          assignmentId,
+          attemptId,
+          github_issue: issue.number,
+          report_id: report.id,
+          is_duplicate: isDuplicate,
+        })
+        .catch((error) => {
+          this.logger.warn(
+            `Flo sendError dispatch failed for report ${report.id}: ${
+              (error as Error).message
+            }`,
+          );
+        });
 
       let message = `Thank you for your report. Issue #${issue.number} has been created and our team will review it soon. You can check the status of this issue anytime by asking me about your reported issues.`;
 
@@ -1599,86 +1610,25 @@ A new related issue has been created: #${issue.number}
       },
     });
 
-    const updatedReports = await Promise.all(
-      reports.map(async (report) => {
-        if (report.issueNumber) {
-          try {
-            const previousDeveloperComment = report.comments;
-            const { status, statusMessage, developerComment, closureReason } =
-              await this.syncGitHubIssueStatus(report.issueNumber);
-            const newDeveloperComment =
-              developerComment && developerComment !== previousDeveloperComment;
-            if (status !== report.status) {
-              await this.createStatusChangeNotification(
-                report.id,
-                status,
-                statusMessage,
-                closureReason,
-              );
-            }
-            if (
-              status !== report.status ||
-              developerComment ||
-              closureReason !== report.closureReason
-            ) {
-              const updates: {
-                status: ReportStatus;
-                statusMessage: string;
-                updatedAt: Date;
-                comments?: string;
-                resolution?: string;
-                closureReason?: string;
-              } = {
-                status,
-                statusMessage,
-                updatedAt: new Date(),
-              };
+    // Pure read: do not call GitHub or write to the DB on a list endpoint.
+    // GitHub → DB sync is driven by the webhook handler and the detail view;
+    // doing it here per-report fanned out N×M concurrent Prisma queries and
+    // routinely exhausted the connection pool.
+    //
+    // Duplicates still need the parent's resolved/closed status overlaid on
+    // the response. Batch-fetch all parents in a single query.
+    const parentIds = [
+      ...new Set(
+        reports
+          .map((r) => r.duplicateOfReportId)
+          .filter((id): id is number => typeof id === "number"),
+      ),
+    ];
 
-              if (developerComment) {
-                updates.comments = developerComment;
-              }
-
-              if (closureReason) {
-                updates.closureReason = closureReason;
-              }
-
-              await this.prisma.report.update({
-                where: { id: report.id },
-                data: updates,
-              });
-
-              report.status = status;
-              report.statusMessage = statusMessage;
-              report.closureReason = closureReason;
-
-              if (developerComment) {
-                report.comments = developerComment;
-              }
-
-              if (newDeveloperComment) {
-                const reporterEmail = report.reporterId;
-                await this.sendReportEmail(
-                  reporterEmail || undefined,
-                  `Update on your report #${report.issueNumber ?? report.id}`,
-                  `New developer comment:\n\n${developerComment}`,
-                );
-              }
-            }
-          } catch (error) {
-            this.logger.error(
-              `Error syncing GitHub issue status for report ID ${report.id}`,
-              {
-                reportId: report.id,
-                error: error instanceof Error ? error.message : String(error),
-                stack: error instanceof Error ? error.stack : undefined,
-              },
-            );
-          }
-        }
-
-        if (report.duplicateOfReportId) {
-          const parentReport = await this.prisma.report.findUnique({
-            where: { id: report.duplicateOfReportId },
+    const parents =
+      parentIds.length > 0
+        ? await this.prisma.report.findMany({
+            where: { id: { in: parentIds } },
             select: {
               id: true,
               issueNumber: true,
@@ -1686,63 +1636,35 @@ A new related issue has been created: #${issue.number}
               statusMessage: true,
               closureReason: true,
             },
-          });
+          })
+        : [];
 
-          if (parentReport) {
-            report.duplicateOfReportId = parentReport.id;
+    const parentById = new Map(parents.map((p) => [p.id, p]));
 
-            if (parentReport.status !== report.status) {
-              let statusMessage = report.statusMessage;
+    return reports.map((report) => {
+      if (!report.duplicateOfReportId) return report;
 
-              if (
-                parentReport.status === ReportStatus.RESOLVED ||
-                parentReport.status === ReportStatus.CLOSED
-              ) {
-                statusMessage = `This issue was marked as a duplicate of issue #${
-                  parentReport.issueNumber
-                } which has been ${
-                  parentReport.status === ReportStatus.RESOLVED
-                    ? "resolved"
-                    : "closed"
-                }.`;
+      const parent = parentById.get(report.duplicateOfReportId);
+      if (!parent) return report;
 
-                if (parentReport.closureReason) {
-                  await this.prisma.report.update({
-                    where: { id: report.id },
-                    data: {
-                      status: parentReport.status,
-                      statusMessage,
-                      closureReason: parentReport.closureReason,
-                      updatedAt: new Date(),
-                    },
-                  });
+      const parentClosed =
+        parent.status === ReportStatus.RESOLVED ||
+        parent.status === ReportStatus.CLOSED;
 
-                  report.status = parentReport.status;
-                  report.statusMessage = statusMessage;
-                  report.closureReason = parentReport.closureReason;
-                } else {
-                  await this.prisma.report.update({
-                    where: { id: report.id },
-                    data: {
-                      status: parentReport.status,
-                      statusMessage,
-                      updatedAt: new Date(),
-                    },
-                  });
-
-                  report.status = parentReport.status;
-                  report.statusMessage = statusMessage;
-                }
-              }
-            }
-          }
+      if (parentClosed && parent.status !== report.status) {
+        report.status = parent.status;
+        report.statusMessage = `This issue was marked as a duplicate of issue #${
+          parent.issueNumber
+        } which has been ${
+          parent.status === ReportStatus.RESOLVED ? "resolved" : "closed"
+        }.`;
+        if (parent.closureReason) {
+          report.closureReason = parent.closureReason;
         }
+      }
 
-        return report;
-      }),
-    );
-
-    return updatedReports;
+      return report;
+    });
   }
 
   async getReportComments(reportId: number, userSession: UserSession) {
@@ -2312,20 +2234,22 @@ A new related issue has been created: #${issue.number}
       },
     });
 
+    if (duplicateReports.length === 0) return;
+
+    const parentReport = await this.prisma.report.findUnique({
+      where: { id: parentReportId },
+      select: { issueNumber: true },
+    });
+
+    const updatedStatusMessage = parentReport?.issueNumber
+      ? `This issue was marked as a duplicate of issue #${
+          parentReport.issueNumber
+        } which has been ${
+          status === ReportStatus.RESOLVED ? "resolved" : "closed"
+        }.`
+      : statusMessage;
+
     for (const report of duplicateReports) {
-      const parentReport = await this.prisma.report.findUnique({
-        where: { id: parentReportId },
-        select: { issueNumber: true },
-      });
-
-      const updatedStatusMessage = parentReport?.issueNumber
-        ? `This issue was marked as a duplicate of issue #${
-            parentReport.issueNumber
-          } which has been ${
-            status === ReportStatus.RESOLVED ? "resolved" : "closed"
-          }.`
-        : statusMessage;
-
       const updateData: {
         status: ReportStatus;
         statusMessage: string;
@@ -2797,11 +2721,18 @@ A new related issue has been created: #${issue.number}
     assignmentId?: number,
   ): Promise<{ message: string; reportId?: number }> {
     try {
-      await this.floService.sendFeedback(title, description, {
-        rating,
-        userEmail,
-        portalName: portalName || "Mark AI Assistant",
-      });
+      // Fire-and-forget: see floService.sendError comment in reportIssue.
+      void this.floService
+        .sendFeedback(title, description, {
+          rating,
+          userEmail,
+          portalName: portalName || "Mark AI Assistant",
+        })
+        .catch((error) => {
+          this.logger.warn(
+            `Flo sendFeedback dispatch failed: ${(error as Error).message}`,
+          );
+        });
 
       const issueTitle = `[MARK CHAT] User Feedback: ${title}`;
       const issueBody = `


### PR DESCRIPTION
POST /api/v1/reports timed out at the gateway's 300s limit because floService.sendError was awaited on the request critical path. The underlying ts-nats client opens a fresh connection per publish with no default deadline, so any NATS outage blocked the handler indefinitely.

GET /api/v1/reports/user threw "Timed out fetching a new connection from the connection pool" because it ran a Promise.all over every report the user owned, and each iteration fanned out a GitHub fetch plus several Prisma updates and a second nested Promise.all inside syncGitHubIssueStatus. A user with N reports issued N x 3-5 concurrent queries, blowing the default pool under any real load.