### PR TITLE
feat(files): observability for upload-processing budget

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": null,
     "lines": null
   },
-  "generated_at": "2026-05-13T23:38:00Z",
+  "generated_at": "2026-05-14T18:54:49Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -574,7 +574,7 @@
       {
         "hashed_secret": "d3ecb0d890368d7659ee54010045b835dacb8efe",
         "is_verified": false,
-        "line_number": 2774,
+        "line_number": 2569,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -673,7 +673,7 @@
       }
     ]
   },
-  "version": "0.13.1+ibm.64.dss",
+  "version": "0.13.1+ibm.62.dss",
   "word_list": {
     "file": null,
     "hash": null

--- a/apps/api/prisma/migrations/20260514000000_add_file_upload_status_size/migration.sql
+++ b/apps/api/prisma/migrations/20260514000000_add_file_upload_status_size/migration.sql
@@ -1,0 +1,8 @@
+-- AlterTable
+ALTER TABLE "FileUpload"
+    ADD COLUMN "sizeBytes" BIGINT,
+    ADD COLUMN "status" TEXT NOT NULL DEFAULT 'PENDING',
+    ADD COLUMN "completedAt" TIMESTAMP(3);
+
+-- CreateIndex
+CREATE INDEX "FileUpload_status_idx" ON "FileUpload"("status");

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -1011,14 +1011,18 @@ model LLMFeatureAssignment {
 /// Tracks in-flight presigned multipart uploads so /complete and /abort
 /// can verify the caller owns the uploadId+key before forwarding to S3.
 model FileUpload {
-  id         Int      @id @default(autoincrement())
-  userId     String
-  uploadId   String   @unique
-  storageKey String
-  bucket     String
-  uploadType String
-  createdAt  DateTime @default(now())
+  id          Int       @id @default(autoincrement())
+  userId      String
+  uploadId    String    @unique
+  storageKey  String
+  bucket      String
+  uploadType  String
+  sizeBytes   BigInt?
+  status      String    @default("PENDING")
+  createdAt   DateTime  @default(now())
+  completedAt DateTime?
 
   @@index([userId])
   @@index([userId, storageKey])
+  @@index([status])
 }

--- a/apps/api/src/api/files/files.controller.ts
+++ b/apps/api/src/api/files/files.controller.ts
@@ -93,6 +93,46 @@ export class FilesController {
     summary:
       "Admin-only snapshot of file-processing budget. pod.* is per-replica, cluster.* aggregates FileUpload rows in PENDING status.",
   })
+  @ApiResponse({
+    status: 200,
+    description: "Budget snapshot",
+    schema: {
+      type: "object",
+      properties: {
+        pod: {
+          type: "object",
+          properties: {
+            budget: { type: "number", description: "Total budget in bytes" },
+            inflight: {
+              type: "number",
+              description: "Bytes currently held by active claims on this pod",
+            },
+            waiters: {
+              type: "number",
+              description: "Requests queued waiting for budget",
+            },
+            claims: {
+              type: "number",
+              description: "Number of active upload IDs on this pod",
+            },
+          },
+        },
+        cluster: {
+          type: "object",
+          properties: {
+            pendingUploads: {
+              type: "number",
+              description: "FileUpload rows still in PENDING status",
+            },
+            pendingBytes: {
+              type: "number",
+              description: "Sum of sizeBytes for PENDING rows across all pods",
+            },
+          },
+        },
+      },
+    },
+  })
   async getBudgetStatus(@Req() request: UserSessionRequest) {
     if (request.userSession.role !== UserRole.ADMIN) {
       throw new ForbiddenException();
@@ -106,7 +146,6 @@ export class FilesController {
         inflight: podStatus.inflight,
         waiters: podStatus.waiters,
         claims: claims.count,
-        claimedBytes: claims.totalBytes,
       },
       cluster: {
         pendingUploads: cluster.count,

--- a/apps/api/src/api/files/files.controller.ts
+++ b/apps/api/src/api/files/files.controller.ts
@@ -87,6 +87,34 @@ export class FilesController {
     return this.filesService.generatePublicUrl(key);
   }
 
+  @Get("_budget")
+  @UseGuards(AuthGuard)
+  @ApiOperation({
+    summary:
+      "Admin-only snapshot of file-processing budget. pod.* is per-replica, cluster.* aggregates FileUpload rows in PENDING status.",
+  })
+  async getBudgetStatus(@Req() request: UserSessionRequest) {
+    if (request.userSession.role !== UserRole.ADMIN) {
+      throw new ForbiddenException();
+    }
+    const podStatus = this.filesService.getProcessingBudgetStatus();
+    const claims = this.filesService.getBudgetClaimsSnapshot();
+    const cluster = await this.filesService.getPendingUploadAggregate();
+    return {
+      pod: {
+        budget: podStatus.budget,
+        inflight: podStatus.inflight,
+        waiters: podStatus.waiters,
+        claims: claims.count,
+        claimedBytes: claims.totalBytes,
+      },
+      cluster: {
+        pendingUploads: cluster.count,
+        pendingBytes: cluster.totalBytes,
+      },
+    };
+  }
+
   @Post("upload")
   @UseGuards(AuthGuard)
   async generateUploadUrl(

--- a/apps/api/src/api/files/services/file-processing-budget.service.ts
+++ b/apps/api/src/api/files/services/file-processing-budget.service.ts
@@ -60,11 +60,15 @@ export class FileProcessingBudgetService {
 
     if (this.inflight + bytes <= this.budget) {
       this.inflight += bytes;
+      this.logger.log(
+        `Acquired — inflight=${this.inflight}/${this.budget} ` +
+          `claimed=${bytes} waiters=${this.waiters.length}`,
+      );
       return;
     }
 
     this.logger.log(
-      `Acquire queued — inflight=${this.inflight} budget=${this.budget} ` +
+      `Acquire queued — inflight=${this.inflight}/${this.budget} ` +
         `requested=${bytes} waiters=${this.waiters.length}`,
     );
 
@@ -101,8 +105,16 @@ export class FileProcessingBudgetService {
     if (bytes > this.budget) return false;
     if (this.inflight + bytes <= this.budget) {
       this.inflight += bytes;
+      this.logger.log(
+        `Claimed — inflight=${this.inflight}/${this.budget} ` +
+          `claimed=${bytes} waiters=${this.waiters.length}`,
+      );
       return true;
     }
+    this.logger.log(
+      `Claim rejected — inflight=${this.inflight}/${this.budget} ` +
+        `requested=${bytes} waiters=${this.waiters.length}`,
+    );
     return false;
   }
 
@@ -127,6 +139,10 @@ export class FileProcessingBudgetService {
 
   release(bytes: number): void {
     this.inflight = Math.max(0, this.inflight - bytes);
+    this.logger.log(
+      `Released — inflight=${this.inflight}/${this.budget} ` +
+        `freed=${bytes} waiters=${this.waiters.length}`,
+    );
 
     while (
       this.waiters.length > 0 &&
@@ -138,6 +154,18 @@ export class FileProcessingBudgetService {
       this.inflight += next.bytes;
       next.resolve();
     }
+  }
+
+  /**
+   * Snapshot of pod-local budget state for the admin status endpoint.
+   * Values are per-pod and only reflect this replica.
+   */
+  getStatus(): { budget: number; inflight: number; waiters: number } {
+    return {
+      budget: this.budget,
+      inflight: this.inflight,
+      waiters: this.waiters.length,
+    };
   }
 
   private parseBytesFromEnv(

--- a/apps/api/src/api/files/services/files.service.spec.ts
+++ b/apps/api/src/api/files/services/files.service.spec.ts
@@ -28,6 +28,11 @@ describe("FilesService", () => {
       create: jest.fn(),
       findUnique: jest.fn(),
       deleteMany: jest.fn(),
+      updateMany: jest.fn().mockResolvedValue({ count: 1 }),
+      aggregate: jest.fn().mockResolvedValue({
+        _count: { _all: 0 },
+        _sum: { sizeBytes: null },
+      }),
     },
   } as unknown as PrismaService;
 
@@ -36,6 +41,9 @@ describe("FilesService", () => {
     acquire: jest.fn().mockResolvedValue(undefined),
     release: jest.fn(),
     buildBusyException: jest.fn(),
+    getStatus: jest
+      .fn()
+      .mockReturnValue({ budget: 1024 * 1024 * 1024, inflight: 0, waiters: 0 }),
   } as unknown as FileProcessingBudgetService;
 
   beforeEach(() => {

--- a/apps/api/src/api/files/services/files.service.ts
+++ b/apps/api/src/api/files/services/files.service.ts
@@ -543,10 +543,18 @@ export class FilesService {
       if (!entry) return;
       this.budgetClaims.delete(uploadId);
       this.processingBudget.release(entry.bytes);
+      const { inflight, budget } = this.processingBudget.getStatus();
       this.logger.warn(
         `Budget claim auto-released after ${FilesService.BUDGET_CLAIM_TTL_MS}ms ` +
-          `with no /complete or /abort: uploadId=${uploadId} bytes=${entry.bytes}`,
+          `with no /complete or /abort: uploadId=${uploadId} bytes=${entry.bytes} ` +
+          `inflight=${inflight}/${budget} claims=${this.budgetClaims.size}`,
       );
+      void this.markUploadStatus(uploadId, "ABORTED").catch((error) => {
+        this.logger.warn(
+          `Failed to mark abandoned upload ABORTED: uploadId=${uploadId} ` +
+            (error instanceof Error ? error.message : String(error)),
+        );
+      });
     }, FilesService.BUDGET_CLAIM_TTL_MS);
     // Node keeps the event loop alive on pending timers; unref so a quiet
     // process can still exit instead of waiting out the TTL.
@@ -562,6 +570,8 @@ export class FilesService {
         storageKey: key,
         bucket,
         uploadType,
+        sizeBytes: BigInt(fileSize),
+        status: "PENDING",
       },
     });
 
@@ -670,18 +680,14 @@ export class FilesService {
               : String(deleteError)),
         );
       }
-      await this.prisma.fileUpload.deleteMany({
-        where: { uploadId: request.uploadId },
-      });
+      await this.markUploadStatus(request.uploadId, "ABORTED");
       this.releaseBudgetClaim(request.uploadId);
       throw new BadRequestException(
         `File is too large. Max allowed is ${maxAllowedBytes} bytes.`,
       );
     }
 
-    await this.prisma.fileUpload.deleteMany({
-      where: { uploadId: request.uploadId },
-    });
+    await this.markUploadStatus(request.uploadId, "COMPLETED");
     this.releaseBudgetClaim(request.uploadId);
 
     return {
@@ -714,9 +720,7 @@ export class FilesService {
       UploadId: request.uploadId,
     });
 
-    await this.prisma.fileUpload.deleteMany({
-      where: { uploadId: request.uploadId },
-    });
+    await this.markUploadStatus(request.uploadId, "ABORTED");
     this.releaseBudgetClaim(request.uploadId);
   }
 
@@ -726,6 +730,56 @@ export class FilesService {
     clearTimeout(claim.timer);
     this.budgetClaims.delete(uploadId);
     this.processingBudget.release(claim.bytes);
+  }
+
+  private async markUploadStatus(
+    uploadId: string,
+    status: "COMPLETED" | "ABORTED",
+  ): Promise<void> {
+    await this.prisma.fileUpload.updateMany({
+      where: { uploadId, status: "PENDING" },
+      data: { status, completedAt: new Date() },
+    });
+  }
+
+  getProcessingBudgetStatus(): {
+    budget: number;
+    inflight: number;
+    waiters: number;
+  } {
+    return this.processingBudget.getStatus();
+  }
+
+  /**
+   * Pod-local view of outstanding budget claims. Used by the admin status
+   * endpoint to expose how many uploadIds this pod is currently holding
+   * bytes for. Returns a snapshot to avoid leaking the live Map reference.
+   */
+  getBudgetClaimsSnapshot(): { count: number; totalBytes: number } {
+    let totalBytes = 0;
+    for (const { bytes } of this.budgetClaims.values()) totalBytes += bytes;
+    return { count: this.budgetClaims.size, totalBytes };
+  }
+
+  /**
+   * Cluster-wide pending-upload aggregation. Sums sizeBytes for FileUpload
+   * rows still marked PENDING — accurate across all pods, unlike the
+   * in-memory budget counters which are per-replica.
+   */
+  async getPendingUploadAggregate(): Promise<{
+    count: number;
+    totalBytes: number;
+  }> {
+    const result = await this.prisma.fileUpload.aggregate({
+      where: { status: "PENDING" },
+      _count: { _all: true },
+      _sum: { sizeBytes: true },
+    });
+    const sum = result._sum.sizeBytes;
+    return {
+      count: result._count._all,
+      totalBytes: sum == null ? 0 : Number(sum),
+    };
   }
 
   private async assertUploadOwnership(

--- a/apps/api/src/api/files/services/files.service.ts
+++ b/apps/api/src/api/files/services/files.service.ts
@@ -732,6 +732,10 @@ export class FilesService {
     this.processingBudget.release(claim.bytes);
   }
 
+  // COMPLETED and ABORTED rows are retained for audit and for the cluster-wide
+  // pending-bytes aggregate. They are never deleted automatically. For the
+  // current upload volume this is acceptable; add a periodic sweep if row
+  // count becomes a concern.
   private async markUploadStatus(
     uploadId: string,
     status: "COMPLETED" | "ABORTED",
@@ -751,14 +755,13 @@ export class FilesService {
   }
 
   /**
-   * Pod-local view of outstanding budget claims. Used by the admin status
-   * endpoint to expose how many uploadIds this pod is currently holding
-   * bytes for. Returns a snapshot to avoid leaking the live Map reference.
+   * Pod-local count of outstanding budget claims. Used by the admin status
+   * endpoint. Note: the total claimed bytes always equals pod.inflight from
+   * getProcessingBudgetStatus() because both counters are updated together
+   * in registerBudgetClaim / releaseBudgetClaim.
    */
-  getBudgetClaimsSnapshot(): { count: number; totalBytes: number } {
-    let totalBytes = 0;
-    for (const { bytes } of this.budgetClaims.values()) totalBytes += bytes;
-    return { count: this.budgetClaims.size, totalBytes };
+  getBudgetClaimsSnapshot(): { count: number } {
+    return { count: this.budgetClaims.size };
   }
 
   /**


### PR DESCRIPTION
Adds a peek-at-current-usage capability so ops can answer "what's the budget doing right now" without tailing logs or guessing per-pod state.

- GET /v1/files/_budget (admin-only) returns per-pod {budget, inflight, waiters, claims} plus cluster-wide {pendingUploads, pendingBytes} derived from FileUpload rows still in PENDING.
- FileUpload gains sizeBytes / status / completedAt — complete/abort now update status instead of deleting, giving a queryable audit trail and making the cluster-wide sum honest across replicas.
- inflight=X/Y added to every claim/release/queue log line so a tail alone is enough to chart usage.
- TTL auto-release now also marks the abandoned row ABORTED so it stops contributing to the pending sum.