### PR TITLE
chore(helm): Add parallel grading switch

### DIFF
--- a/helm-chart/mark-jobs/values.yaml
+++ b/helm-chart/mark-jobs/values.yaml
@@ -33,5 +33,12 @@ env:
   ENABLE_LTI_SCHEDULER: "false"      # gate the LTI cron in mark-jobs
   ENABLE_TRANSLATION: "true"         # required by SharedModule TranslationService ctor
   TRANSLATION_CONCURRENCY: "8"       # BullMQ worker concurrency for mark.assignment.v2.translations queue
+  # Master switch for the dependency-level wave grading scheduler. mark-jobs
+  # is where ATTEMPT_GRADE actually executes (JOBS_EXECUTE_LOCALLY=true), so
+  # this is the tier where the flag is load-bearing. Chart default "false"
+  # keeps the legacy sequential path active; per-environment overlays flip
+  # to "true" when the rollout window is open. Runtime check is strict
+  # equality with "true".
+  ENABLE_PARALLEL_GRADING: "false"
 
 secretEnv: {}


### PR DESCRIPTION
The wave scheduler in GradingRateLimiterService defaults to parallelEnabled=true when the env is unset. mark-api had an explicit "false" default in its chart, but mark-jobs — which is where ATTEMPT_GRADE actually executes because JOBS_EXECUTE_LOCALLY=true — had no chart-level setting, so unflagged clusters silently inherited the code default and ran parallel grading without an operational kill switch. Production needs an explicit knob to flip in either direction during rollout and incident response; making the chart default "false" gives every environment a real off-state to opt out of, and the mark-jobs overlay can flip it to "true" per-environment when ready.

<!-- This is helper text. It won't appear in the rendered output, but it will be visible when editing the Markdown file. -->

## **PR Description**

### **Overview:**

<!-- Select all that applies -->

#### **Type of Issue:**

- [ ] **Feature (`feat`)**: New functionality or feature added.
- [ ] **Bug Fix (`bug`)**: Issue or bug resolved.
- [x] **Chore (`chore`)**: Maintenance, refactoring, or non-functional changes.
- [ ] **Documentation Update (`doc`)**: Documentation improvements or additions.

#### **Change Type:**

- [ ] **Major:** Significant changes that introduce new features, large refactoring, or breaking changes. Requires thorough review and testing.
- [ ] **Minor:** Small to medium changes, such as adding new functionality that is backward-compatible or minor refactoring. Moderate review needed.
- [x] **Patch:** Bug fixes, small tweaks, or documentation updates. Light review is sufficient.

## Test Coverage
- [ ] Unit tests updated
- [ ] Manual verification done