### PR TITLE
fix: add admin assignment publish endpoint

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,9 +1,9 @@
 {
   "exclude": {
-    "files": "^.secrets.baseline$",
+    "files": null,
     "lines": null
   },
-  "generated_at": "2026-05-19T19:14:28Z",
+  "generated_at": "2026-05-28T15:04:48Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -583,7 +583,7 @@
       {
         "hashed_secret": "d7ca4b093fc5dd3817b4846e4d57734b08eefa9d",
         "is_verified": false,
-        "line_number": 11,
+        "line_number": 17,
         "type": "Base64 High Entropy String",
         "verified_result": null
       }
@@ -673,7 +673,7 @@
       }
     ]
   },
-  "version": "0.13.1+ibm.64.dss",
+  "version": "0.13.1+ibm.62.dss",
   "word_list": {
     "file": null,
     "hash": null

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,6 +1,6 @@
 {
   "exclude": {
-    "files": null,
+    "files": "^.secrets.baseline$",
     "lines": null
   },
   "generated_at": "2026-05-28T15:04:48Z",
@@ -673,7 +673,7 @@
       }
     ]
   },
-  "version": "0.13.1+ibm.62.dss",
+  "version": "0.13.1+ibm.64.dss",
   "word_list": {
     "file": null,
     "hash": null

--- a/apps/api/src/api/admin/admin.controller.spec.ts
+++ b/apps/api/src/api/admin/admin.controller.spec.ts
@@ -140,6 +140,33 @@ describe("AdminController", () => {
     );
   });
 
+  it("uses the forwarded user-session header as the publish actor identity", async () => {
+    jest
+      .spyOn(adminService, "publishAssignment")
+      .mockResolvedValue({ message: "Publishing started", jobId: "job-5" });
+
+    await controller.publishAssignment(
+      12,
+      {
+        questions: [],
+        published: true,
+      } as any,
+      {
+        headers: {
+          "user-session": JSON.stringify({
+            userId: "context-manager@skills.network",
+          }),
+        },
+      } as any,
+    );
+
+    expect(adminService.publishAssignment).toHaveBeenCalledWith(
+      12,
+      expect.objectContaining({ published: true }),
+      "context-manager@skills.network",
+    );
+  });
+
   it("falls back to admin-api when no forwarded session identity is present", async () => {
     jest
       .spyOn(adminService, "generateQuestions")

--- a/apps/api/src/api/admin/admin.controller.ts
+++ b/apps/api/src/api/admin/admin.controller.ts
@@ -29,6 +29,7 @@ import { Logger } from "winston";
 import { AdminRepository } from "./admin.repository";
 import { AdminService } from "./admin.service";
 import { QuestionGenerationPayload } from "../assignment/dto/post.assignment.request.dto";
+import { UpdateAssignmentQuestionsDto } from "../assignment/dto/update.questions.request.dto";
 import {
   CompleteAssignmentFileDto,
   InitiateAssignmentFilesDto,
@@ -296,6 +297,36 @@ export class AdminController {
   @ApiResponse({ status: 404, description: "Job not found" })
   getQuestionGenerationJobStatus(@Param("jobId") jobId: string) {
     return this.adminService.getQuestionGenerationJobStatus(jobId);
+  }
+
+  @Put("assignments/:id/publish")
+  @ApiOperation({
+    summary: "Publish an assignment with updated questions using admin auth",
+  })
+  @ApiParam({ name: "id", required: true, description: "Assignment ID" })
+  @ApiBody({ type: UpdateAssignmentQuestionsDto })
+  @ApiResponse({
+    status: 200,
+    schema: {
+      type: "object",
+      properties: {
+        jobId: { type: "string", description: "Job ID for tracking progress" },
+        message: { type: "string", description: "Status message" },
+      },
+    },
+  })
+  @ApiResponse({ status: 404, description: "Assignment not found" })
+  publishAssignment(
+    @Param("id") id: number,
+    @Body(new ValidationPipe({ transform: true }))
+    payload: UpdateAssignmentQuestionsDto,
+    @Req() request: UserSessionRequest,
+  ): Promise<{ jobId: string; message: string }> {
+    return this.adminService.publishAssignment(
+      Number(id),
+      payload,
+      this.getActorUserId(request),
+    );
   }
 
   @Put("/assignments/:id")

--- a/apps/api/src/api/admin/admin.controller.ts
+++ b/apps/api/src/api/admin/admin.controller.ts
@@ -299,9 +299,11 @@ export class AdminController {
     return this.adminService.getQuestionGenerationJobStatus(jobId);
   }
 
-  @Put("assignments/:id/publish")
+  @Put("/assignments/:id/publish")
   @ApiOperation({
     summary: "Publish an assignment with updated questions using admin auth",
+    description:
+      "Always publishes (forces `published: true` regardless of the request body). Use the regular update endpoint if you need to keep the assignment unpublished.",
   })
   @ApiParam({ name: "id", required: true, description: "Assignment ID" })
   @ApiBody({ type: UpdateAssignmentQuestionsDto })

--- a/apps/api/src/api/admin/admin.service.spec.ts
+++ b/apps/api/src/api/admin/admin.service.spec.ts
@@ -54,6 +54,7 @@ describe("AdminService", () => {
     getAssignmentFiles: jest.Mock;
     initiateAssignmentFileUploads: jest.Mock;
   };
+  let mockAssignmentService: { publishAssignment: jest.Mock };
   let mockQuestionService: { generateQuestions: jest.Mock };
   let mockJobStatusService: { getJobStatus: jest.Mock };
 
@@ -68,6 +69,11 @@ describe("AdminService", () => {
       initiateAssignmentFileUploads: jest
         .fn()
         .mockResolvedValue({ uploads: [{ fileId: 7 }] }),
+    };
+    mockAssignmentService = {
+      publishAssignment: jest
+        .fn()
+        .mockResolvedValue({ message: "Publishing started", jobId: "job-2" }),
     };
     mockQuestionService = {
       generateQuestions: jest.fn().mockResolvedValue({
@@ -90,7 +96,7 @@ describe("AdminService", () => {
         { provide: PrismaService, useValue: mockPrisma },
         {
           provide: AssignmentServiceV2,
-          useValue: { publishAssignment: jest.fn() },
+          useValue: mockAssignmentService,
         },
         {
           provide: AssignmentFileService,
@@ -260,6 +266,45 @@ describe("AdminService", () => {
         }),
         "service-account",
       );
+    });
+  });
+
+  describe("publishAssignment", () => {
+    it("validates the assignment exists and delegates to the v2 publish service", async () => {
+      const payload = {
+        questions: [],
+        published: false,
+        versionDescription: "Admin publish",
+      } as any;
+
+      await expect(
+        service.publishAssignment(9, payload, "service-account"),
+      ).resolves.toEqual({
+        message: "Publishing started",
+        jobId: "job-2",
+      });
+
+      expect(mockPrisma.assignment.findUnique).toHaveBeenCalledWith({
+        where: { id: 9 },
+        select: { id: true },
+      });
+      expect(mockAssignmentService.publishAssignment).toHaveBeenCalledWith(
+        9,
+        expect.objectContaining({
+          published: true,
+          versionDescription: "Admin publish",
+        }),
+        "service-account",
+      );
+    });
+
+    it("404s without publishing when the assignment is missing", async () => {
+      mockPrisma.assignment.findUnique.mockResolvedValueOnce(null);
+
+      await expect(
+        service.publishAssignment(404, { questions: [] } as any),
+      ).rejects.toThrow(NotFoundException);
+      expect(mockAssignmentService.publishAssignment).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/api/src/api/admin/admin.service.ts
+++ b/apps/api/src/api/admin/admin.service.ts
@@ -1082,6 +1082,22 @@ export class AdminService {
       : { status: job.status, progress: job.progress };
   }
 
+  async publishAssignment(
+    assignmentId: number,
+    payload: UpdateAssignmentQuestionsDto,
+    userId = "admin-api",
+  ): Promise<{ message: string; jobId: string }> {
+    await this.assertAssignmentExists(assignmentId);
+    return this.assignmentService.publishAssignment(
+      assignmentId,
+      {
+        ...payload,
+        published: true,
+      },
+      userId,
+    );
+  }
+
   async updateAssignment(
     id: number,
     updateAssignmentDto: AdminUpdateAssignmentRequestDto,


### PR DESCRIPTION
<!-- This is helper text. It won't appear in the rendered output, but it will be visible when editing the Markdown file. -->

## Summary
- Add `PUT /api/v1/admin/assignments/:id/publish`
- Delegate admin publish requests to the existing v2 `publishAssignment` flow
- Force `published: true` for the admin publish wrapper
- Add focused controller/service coverage

### **Overview:**

<!-- Select all that applies -->

#### **Type of Issue:**

- [ ] **Feature (`feat`)**: New functionality or feature added.
- [ ] **Bug Fix (`bug`)**: Issue or bug resolved.
- [x] **Chore (`chore`)**: Maintenance, refactoring, or non-functional changes.
- [ ] **Documentation Update (`doc`)**: Documentation improvements or additions.

#### **Change Type:**

- [ ] **Major:** Significant changes that introduce new features, large refactoring, or breaking changes. Requires thorough review and testing.
- [ ] **Minor:** Small to medium changes, such as adding new functionality that is backward-compatible or minor refactoring. Moderate review needed.
- [ ] **Patch:** Bug fixes, small tweaks, or documentation updates. Light review is sufficient.

## Test Coverage
- [ ] Unit tests updated
- [ ] Manual verification done

Evidence:
<!-- commands, screenshots, GIFs if UI -->

## Impact / Risk
<!-- subsystems touched, breaking potential -->

## Rollback
<!-- git revert <sha> if needed or config toggle -->

## Reviewer Focus
<!-- specific files or logic to inspect -->