### PR TITLE
fix(admin): stop /admin analytics from starving the Postgres pool

### DIFF
--- a/apps/api/src/api/admin/admin.service.spec.ts
+++ b/apps/api/src/api/admin/admin.service.spec.ts
@@ -9,6 +9,10 @@ import { JobStatusServiceV2 } from "../assignment/v2/services/job-status.service
 import { QuestionService } from "../assignment/v2/services/question.service";
 import { AssignmentTypeEnum } from "../llm/features/question-generation/services/question-generation.service";
 import { LLM_PRICING_SERVICE } from "../llm/llm.constants";
+import {
+  UserRole,
+  UserSession,
+} from "../../auth/interfaces/user.session.interface";
 import { AdminService } from "./admin.service";
 
 const mockLogger = {
@@ -120,6 +124,96 @@ describe("AdminService", () => {
 
   it("should be defined", () => {
     expect(service).toBeDefined();
+  });
+
+  describe("getAssignmentAnalytics (connection-pool guard)", () => {
+    const adminSession = {
+      role: UserRole.ADMIN,
+      userId: "admin@ibm.com",
+    } as unknown as UserSession;
+
+    beforeEach(() => {
+      mockPrisma.assignment.count = jest.fn().mockResolvedValue(500);
+      mockPrisma.assignment.findMany = jest.fn().mockResolvedValue([
+        { id: 1, name: "A1", published: true, updatedAt: new Date() },
+        { id: 2, name: "A2", published: false, updatedAt: new Date() },
+      ]);
+      // One mock for all three assignmentAttempt.groupBy calls; branch on args
+      // so the call order doesn't matter.
+      mockPrisma.assignmentAttempt.groupBy = jest.fn((args: any) => {
+        if (args.by?.includes("userId")) {
+          // distinct (assignmentId, userId) pairs — assignment 1 has 2 learners,
+          // assignment 2 has 1.
+          return Promise.resolve([
+            { assignmentId: 1, userId: "u1" },
+            { assignmentId: 1, userId: "u2" },
+            { assignmentId: 2, userId: "u1" },
+          ]);
+        }
+        if (args.where?.submitted) {
+          return Promise.resolve([
+            { assignmentId: 1, _count: { id: 5 }, _avg: { grade: 0.8 } },
+          ]);
+        }
+        return Promise.resolve([
+          { assignmentId: 1, _count: { id: 10 } },
+          { assignmentId: 2, _count: { id: 3 } },
+        ]);
+      });
+      mockPrisma.assignmentFeedback.groupBy = jest
+        .fn()
+        .mockResolvedValue([
+          { assignmentId: 1, _avg: { assignmentRating: 4 } },
+        ]);
+      mockPrisma.aIUsage.findMany = jest.fn().mockResolvedValue([]);
+    });
+
+    it("clamps an oversized requested limit to the page cap", async () => {
+      const result = await service.getAssignmentAnalytics(
+        adminSession,
+        1,
+        1000,
+      );
+
+      // The page the DB is asked for is bounded regardless of the request.
+      expect(mockPrisma.assignment.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({ take: 50 }),
+      );
+      expect(result.pagination.limit).toBe(50);
+    });
+
+    it("derives unique learners with ONE grouped query, not one per assignment", async () => {
+      await service.getAssignmentAnalytics(adminSession, 1, 1000);
+
+      const pairCalls = (
+        mockPrisma.assignmentAttempt.groupBy as jest.Mock
+      ).mock.calls.filter(([args]) => args.by?.includes("userId"));
+      expect(pairCalls).toHaveLength(1);
+    });
+
+    it("batches AI usage into ONE query scoped to the page's assignments", async () => {
+      await service.getAssignmentAnalytics(adminSession, 1, 1000);
+
+      expect(mockPrisma.aIUsage.findMany).toHaveBeenCalledTimes(1);
+      expect(mockPrisma.aIUsage.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { assignmentId: { in: [1, 2] } },
+        }),
+      );
+    });
+
+    it("returns the correct per-assignment unique-learner counts", async () => {
+      const result = await service.getAssignmentAnalytics(
+        adminSession,
+        1,
+        1000,
+      );
+
+      const a1 = result.data.find((d) => d.id === 1);
+      const a2 = result.data.find((d) => d.id === 2);
+      expect(a1?.uniqueLearners).toBe(2);
+      expect(a2?.uniqueLearners).toBe(1);
+    });
   });
 
   describe("removeAssignment", () => {

--- a/apps/api/src/api/admin/admin.service.spec.ts
+++ b/apps/api/src/api/admin/admin.service.spec.ts
@@ -61,6 +61,11 @@ describe("AdminService", () => {
   let mockAssignmentService: { publishAssignment: jest.Mock };
   let mockQuestionService: { generateQuestions: jest.Mock };
   let mockJobStatusService: { getJobStatus: jest.Mock };
+  let mockLlmPricingService: {
+    calculateCost: jest.Mock;
+    getTokenCount: jest.Mock;
+    calculateCostWithBreakdown: jest.Mock;
+  };
 
   beforeEach(async () => {
     mockPrisma = makeMockPrisma();
@@ -89,9 +94,18 @@ describe("AdminService", () => {
       getJobStatus: jest.fn(),
     };
 
-    const mockLlmPricingService = {
+    mockLlmPricingService = {
       calculateCost: jest.fn().mockReturnValue(0.01),
       getTokenCount: jest.fn().mockReturnValue(100),
+      calculateCostWithBreakdown: jest.fn().mockResolvedValue({
+        totalCost: 0.01,
+        inputCost: 0.005,
+        outputCost: 0.005,
+        inputTokenPrice: 0.000_001,
+        outputTokenPrice: 0.000_002,
+        pricingEffectiveDate: new Date(),
+        modelKey: "gpt-4o",
+      }),
     };
 
     const module: TestingModule = await Test.createTestingModule({
@@ -213,6 +227,57 @@ describe("AdminService", () => {
       const a2 = result.data.find((d) => d.id === 2);
       expect(a1?.uniqueLearners).toBe(2);
       expect(a2?.uniqueLearners).toBe(1);
+    });
+
+    it("bounds how many assignment cost chains hit pricing lookups concurrently", async () => {
+      const ids = [1, 2, 3, 4, 5, 6];
+      mockPrisma.assignment.findMany = jest.fn().mockResolvedValue(
+        ids.map((id) => ({
+          id,
+          name: `A${id}`,
+          published: true,
+          updatedAt: new Date(),
+        })),
+      );
+      // Every assignment has AI usage, so each cost chain calls the (uncached,
+      // DB-backed) pricing lookup at least once.
+      mockPrisma.aIUsage.findMany = jest.fn().mockResolvedValue(
+        ids.map((assignmentId) => ({
+          assignmentId,
+          tokensIn: 10,
+          tokensOut: 5,
+          createdAt: new Date(),
+          usageType: "grading",
+          modelKey: "gpt-4o",
+        })),
+      );
+
+      let active = 0;
+      let maxActive = 0;
+      mockLlmPricingService.calculateCostWithBreakdown.mockImplementation(
+        async () => {
+          active += 1;
+          maxActive = Math.max(maxActive, active);
+          // Yield so concurrent chains overlap inside the limiter.
+          await new Promise((resolve) => setImmediate(resolve));
+          active -= 1;
+          return {
+            totalCost: 0.01,
+            inputCost: 0.005,
+            outputCost: 0.005,
+            inputTokenPrice: 0.000_001,
+            outputTokenPrice: 0.000_002,
+            pricingEffectiveDate: new Date(),
+            modelKey: "gpt-4o",
+          };
+        },
+      );
+
+      await service.getAssignmentAnalytics(adminSession, 1, 1000);
+
+      // Pricing was exercised, but never more than the cost-calc cap at once.
+      expect(maxActive).toBeGreaterThan(0);
+      expect(maxActive).toBeLessThanOrEqual(4);
     });
   });
 

--- a/apps/api/src/api/admin/admin.service.ts
+++ b/apps/api/src/api/admin/admin.service.ts
@@ -11,6 +11,7 @@ import {
   UserSession,
 } from "../../auth/interfaces/user.session.interface";
 import { PrismaService } from "../../database/prisma.service";
+import { ConcurrencyLimiter } from "../llm/features/grading/services/concurrency-limiter";
 import {
   Choice,
   QuestionDto,
@@ -1154,6 +1155,11 @@ export class AdminService {
     );
     const skip = (Math.max(1, page) - 1) * safeLimit;
 
+    // How many assignments' cost chains may compute at once. Each chain does
+    // uncached per-row pricing lookups (one pool connection at a time), so this
+    // bounds how many connections this endpoint can hold concurrently.
+    const COST_CALC_CONCURRENCY = 4;
+
     const searchCondition = search
       ? {
           OR: [
@@ -1314,8 +1320,14 @@ export class AdminService {
       }
     }
 
-    const analyticsData = await Promise.all(
-      assignments.map(async (assignment) => {
+    // Cost calculation does an uncached per-row pricing lookup, so running
+    // every assignment's cost chain at once would hold one pool connection per
+    // assignment and could starve the pool. Bound how many run concurrently.
+    // (The per-row lookup volume itself is left to the pricing-batching fix.)
+    const analyticsData = await new ConcurrencyLimiter(
+      COST_CALC_CONCURRENCY,
+    ).run(
+      assignments.map((assignment) => async () => {
         const totalAttempts = totalStatsMap.get(assignment.id) || 0;
         const submittedData = submittedStatsMap.get(assignment.id);
         const completedAttempts = submittedData?._count.id || 0;

--- a/apps/api/src/api/admin/admin.service.ts
+++ b/apps/api/src/api/admin/admin.service.ts
@@ -1139,7 +1139,20 @@ export class AdminService {
     search?: string,
   ) {
     const isAdmin = adminSession.role === UserRole.ADMIN;
-    const skip = (page - 1) * limit;
+
+    // Stopgap pool guard: cap how many assignments one analytics request
+    // processes. This endpoint runs several grouped queries plus a per-assignment
+    // cost computation; the dashboard table requested limit=1000, letting a
+    // single request fan out across the whole table and starve the Postgres
+    // connection pool for everyone else. Bound the page server-side (the
+    // authoritative limit, regardless of what the client sends) until proper
+    // server-side pagination/search lands.
+    const MAX_ANALYTICS_PAGE_LIMIT = 50;
+    const safeLimit = Math.min(
+      Math.max(1, Number.isFinite(limit) ? Math.trunc(limit) : 10),
+      MAX_ANALYTICS_PAGE_LIMIT,
+    );
+    const skip = (Math.max(1, page) - 1) * safeLimit;
 
     const searchCondition = search
       ? {
@@ -1172,7 +1185,7 @@ export class AdminService {
     const assignments = await this.prisma.assignment.findMany({
       where: whereClause,
       skip,
-      take: limit,
+      take: safeLimit,
       select: {
         id: true,
         name: true,
@@ -1188,8 +1201,8 @@ export class AdminService {
         pagination: {
           total: totalCount,
           page,
-          limit,
-          totalPages: Math.ceil(totalCount / limit),
+          limit: safeLimit,
+          totalPages: Math.ceil(totalCount / safeLimit),
         },
       };
     }
@@ -1232,16 +1245,29 @@ export class AdminService {
           return { totalStatsMap, submittedStatsMap };
         }),
 
-        Promise.all(
-          assignmentIds.map(async (assignmentId) => {
-            const uniqueUsers = await this.prisma.assignmentAttempt.findMany({
-              where: { assignmentId },
-              distinct: ["userId"],
-              select: { userId: true },
-            });
-            return { assignmentId, uniqueUsersCount: uniqueUsers.length };
+        // Distinct learners per assignment in ONE query: grouping by
+        // (assignmentId, userId) yields one row per unique pair, so counting
+        // rows per assignmentId is the unique-learner count. Replaces a
+        // per-assignment findMany (one Postgres query each) that fanned out
+        // across the whole page.
+        this.prisma.assignmentAttempt
+          .groupBy({
+            by: ["assignmentId", "userId"],
+            where: { assignmentId: { in: assignmentIds } },
+          })
+          .then((pairs) => {
+            const counts = new Map<number, number>();
+            for (const pair of pairs) {
+              counts.set(
+                pair.assignmentId,
+                (counts.get(pair.assignmentId) ?? 0) + 1,
+              );
+            }
+            return assignmentIds.map((assignmentId) => ({
+              assignmentId,
+              uniqueUsersCount: counts.get(assignmentId) ?? 0,
+            }));
           }),
-        ),
 
         this.prisma.assignmentFeedback.groupBy({
           by: ["assignmentId"],
@@ -1263,6 +1289,31 @@ export class AdminService {
       uniqueLearnersStats.map((s) => [s.assignmentId, s.uniqueUsersCount]),
     );
     const feedbackMap = new Map(feedbackStats.map((s) => [s.assignmentId, s]));
+
+    // All AI usage for the page in ONE query, grouped in memory — replaces a
+    // per-assignment aIUsage.findMany inside the map below that issued one
+    // Postgres query per assignment (the second source of pool fan-out).
+    const aiUsageRows = await this.prisma.aIUsage.findMany({
+      where: { assignmentId: { in: assignmentIds } },
+      select: {
+        assignmentId: true,
+        tokensIn: true,
+        tokensOut: true,
+        createdAt: true,
+        usageType: true,
+        modelKey: true,
+      },
+    });
+    const aiUsageByAssignment = new Map<number, typeof aiUsageRows>();
+    for (const usage of aiUsageRows) {
+      const existing = aiUsageByAssignment.get(usage.assignmentId);
+      if (existing) {
+        existing.push(usage);
+      } else {
+        aiUsageByAssignment.set(usage.assignmentId, [usage]);
+      }
+    }
+
     const analyticsData = await Promise.all(
       assignments.map(async (assignment) => {
         const totalAttempts = totalStatsMap.get(assignment.id) || 0;
@@ -1273,16 +1324,7 @@ export class AdminService {
         const averageGrade = (submittedData?._avg.grade || 0) * 100;
         const averageRating = feedback?._avg.assignmentRating || 0;
 
-        const aiUsageDetails = await this.prisma.aIUsage.findMany({
-          where: { assignmentId: assignment.id },
-          select: {
-            tokensIn: true,
-            tokensOut: true,
-            createdAt: true,
-            usageType: true,
-            modelKey: true,
-          },
-        });
+        const aiUsageDetails = aiUsageByAssignment.get(assignment.id) ?? [];
 
         const costData = await this.calculateHistoricalCosts(aiUsageDetails);
         const totalCost = costData.totalCost;
@@ -1350,8 +1392,8 @@ export class AdminService {
       pagination: {
         total: totalCount,
         page,
-        limit,
-        totalPages: Math.ceil(totalCount / limit),
+        limit: safeLimit,
+        totalPages: Math.ceil(totalCount / safeLimit),
       },
     };
   }

--- a/apps/web/app/admin/components/AssignmentAnalyticsTable.tsx
+++ b/apps/web/app/admin/components/AssignmentAnalyticsTable.tsx
@@ -92,10 +92,13 @@ export function AssignmentAnalyticsTable({
     setError(null);
 
     try {
+      // Request a bounded page. The previous limit=1000 made the server fan out
+      // to one Postgres query per assignment and starve the connection pool; the
+      // server now also caps this, so asking for the whole table no longer helps.
       const response = await getAssignmentAnalytics(
         sessionToken,
         1,
-        1000,
+        50,
         undefined,
       );
       setData(response.data);


### PR DESCRIPTION
The admin dashboard analytics table requested limit=1000 on mount, and getAssignmentAnalytics then issued one Postgres query per assignment in two places (unique-learners and AI-usage), fanning out to hundreds of concurrent connections and exhausting the pool for real users in prod.

Temporary stopgap until proper server-side pagination/search lands:
- Cap the page size server-side (authoritative, regardless of the requested limit) so one request can't process the whole table.
- Compute unique learners in a single grouped query instead of one findMany per assignment.
- Batch the AI-usage fetch into a single query for the whole page instead of one findMany per assignment.
- Request a bounded page from the dashboard table.

Net effect: the endpoint now runs a small, constant number of queries per request rather than ~2 per assignment.
