### PR TITLE
fix(grading): compact sparse full-grid XLSX so they grade instead of stalling

### DIFF
--- a/apps/api/src/api/attempt/services/__tests__/file-content-extraction.spec.ts
+++ b/apps/api/src/api/attempt/services/__tests__/file-content-extraction.spec.ts
@@ -537,6 +537,46 @@ describe("FileContentExtractionService.extractExcelText - used-range clamping", 
     );
     expect(payload.totalUsedCells).toBeGreaterThan(0);
   });
+
+  it("extracts a full-grid table sheet from its real data, not the declared grid", async () => {
+    const XLSX = await import("xlsx");
+    const sheet: XLSX.WorkSheet = {
+      A1: { t: "s", v: "name", w: "name" },
+      B1: { t: "s", v: "qty", w: "qty" },
+      ZZ1: { t: "s", v: "autoheader", w: "autoheader" },
+      A2: { t: "s", v: "widget", w: "widget" },
+      B2: { t: "n", v: 5, w: "5" },
+      B1048576: { t: "n", v: 5, w: "5", f: "SUM(B2:B1048575)" },
+      "!ref": "A1:XFD1048576",
+    };
+    const workbook: XLSX.WorkBook = {
+      SheetNames: ["Sheet1"],
+      Sheets: { Sheet1: sheet },
+    };
+    // service is the SUT instance from the existing describe-block setup
+    jest
+      .spyOn(
+        service as unknown as { readExcelWorkbook: () => XLSX.WorkBook },
+        "readExcelWorkbook",
+      )
+      .mockReturnValue(workbook);
+
+    jest
+      .spyOn(service as any, "extractExcelChartsAndImages")
+      .mockResolvedValue({ section: "", chartCount: 0, imageCount: 0 });
+
+    const started = Date.now();
+    const result = await (
+      service as unknown as {
+        extractExcelText: (b: Buffer, x?: boolean) => Promise<{ text: string }>;
+      }
+    ).extractExcelText(Buffer.from("x"), true);
+
+    expect(Date.now() - started).toBeLessThan(2000); // no 1M-row walk
+    expect(result.text).toContain("Range: A1:B3"); // 3 rows × 2 cols
+    expect(result.text).toContain("widget");
+    expect(result.text).not.toContain("autoheader"); // pruned empty column
+  });
 });
 
 describe("FileContentExtractionService.shouldUseStructuredExtraction", () => {

--- a/apps/api/src/api/attempt/services/__tests__/file-content-extraction.spec.ts
+++ b/apps/api/src/api/attempt/services/__tests__/file-content-extraction.spec.ts
@@ -579,6 +579,44 @@ describe("FileContentExtractionService.extractExcelText - used-range clamping", 
   });
 });
 
+// ─── extractExcelText – OversizedSubmissionError propagation ─────────────────
+
+describe("FileContentExtractionService.extractExcelText - OversizedSubmissionError propagation", () => {
+  let service: FileContentExtractionService;
+
+  beforeEach(() => {
+    service = createService();
+  });
+
+  it("re-throws OversizedSubmissionError without wrapping it in a generic Error", async () => {
+    // Build a workbook with a single sheet that is OVER the row budget.
+    // compactWorksheet calls assertSpreadsheetWithinBudget which throws
+    // OversizedSubmissionError when rows.length > MAX_EVIDENCE_BLOCKS_PER_SUBMISSION (50_000).
+    const XLSX = await import("xlsx");
+    const sheet: XLSX.WorkSheet = {};
+    for (let r = 0; r < 60_001; r++) {
+      const key = `A${r + 1}`;
+      sheet[key] = { t: "n", v: r, w: String(r) };
+    }
+    sheet["!ref"] = `A1:A60001`;
+    const wb: XLSX.WorkBook = {
+      SheetNames: ["BigSheet"],
+      Sheets: { BigSheet: sheet },
+    };
+
+    jest
+      .spyOn(service as any, "readExcelWorkbook")
+      .mockReturnValue(wb);
+    jest
+      .spyOn(service as any, "extractExcelChartsAndImages")
+      .mockResolvedValue({ section: "", chartCount: 0, imageCount: 0 });
+
+    await expect(
+      (service as any).extractExcelText(Buffer.from([]), true),
+    ).rejects.toThrow(OversizedSubmissionError);
+  });
+});
+
 describe("FileContentExtractionService.shouldUseStructuredExtraction", () => {
   let service: FileContentExtractionService;
   const original = process.env.ENABLE_PDF_STRUCTURED_EXTRACTION;

--- a/apps/api/src/api/attempt/services/file-content-extraction.ts
+++ b/apps/api/src/api/attempt/services/file-content-extraction.ts
@@ -3348,6 +3348,9 @@ export class FileContentExtractionService {
         },
       };
     } catch (error) {
+      if (error instanceof OversizedSubmissionError) {
+        throw error;
+      }
       const errorMessage =
         typeof error === "object" && error !== null && "message" in error
           ? (error as { message: string }).message

--- a/apps/api/src/api/attempt/services/file-content-extraction.ts
+++ b/apps/api/src/api/attempt/services/file-content-extraction.ts
@@ -11,6 +11,7 @@ import * as unzipper from "unzipper";
 import * as XLSX from "xlsx";
 import { parseStringPromise } from "xml2js";
 import { OversizedSubmissionError } from "../../llm/features/grading/errors/oversized-submission.error";
+import { compactWorksheet } from "../../llm/features/grading/services/spreadsheet-used-range.utils";
 import { LearnerFileUpload } from "../common/interfaces/attempt.interface";
 import { provenanceArtifactKey } from "../common/utils/provenance-artifact.util";
 
@@ -3190,48 +3191,6 @@ export class FileContentExtractionService {
   }
 
   /**
-   * Walk only real cell keys on the worksheet and compute the bounding box of
-   * cells that actually carry a value. SheetJS preserves the worksheet's
-   * declared dimension verbatim in `!ref`, which on Excel files saved with a
-   * full-sheet formal dimension (`A1:XFD1048576`) covers 17 billion virtual
-   * cells. Trusting that value blindly causes downstream consumers such as
-   * `sheet_to_csv` to materialize a row for every virtual row in the sheet.
-   * Returns null when the worksheet contains no real cells.
-   */
-  private computeUsedRange(worksheet: XLSX.WorkSheet): XLSX.Range | null {
-    let minRow = Number.POSITIVE_INFINITY;
-    let minCol = Number.POSITIVE_INFINITY;
-    let maxRow = Number.NEGATIVE_INFINITY;
-    let maxCol = Number.NEGATIVE_INFINITY;
-    let found = false;
-
-    for (const key in worksheet) {
-      if (key.charCodeAt(0) === 33) continue; // '!' meta key
-      const addr = XLSX.utils.decode_cell(key);
-      if (
-        !Number.isFinite(addr.r) ||
-        !Number.isFinite(addr.c) ||
-        addr.r < 0 ||
-        addr.c < 0
-      ) {
-        continue;
-      }
-      found = true;
-      if (addr.r < minRow) minRow = addr.r;
-      if (addr.c < minCol) minCol = addr.c;
-      if (addr.r > maxRow) maxRow = addr.r;
-      if (addr.c > maxCol) maxCol = addr.c;
-    }
-
-    if (!found) return null;
-
-    return {
-      s: { r: minRow, c: minCol },
-      e: { r: maxRow, c: maxCol },
-    };
-  }
-
-  /**
    * Thin wrapper around `XLSX.read` so tests can swap the parsed workbook
    * without going through a full disk-format round-trip (writing a workbook
    * with a formal `A1:XFD1048576` !ref is itself a memory bomb under
@@ -3282,23 +3241,19 @@ export class FileContentExtractionService {
 
         allText += `\n=== SHEET: ${sheetName} ===\n`;
 
-        // Replace the worksheet's declared !ref with a tight range covering
-        // only real cells. This bounds sheet_to_csv to the actual data and
-        // prevents the formal-dimension explosion.
-        const tightRange = this.computeUsedRange(worksheet);
-        if (tightRange) {
-          const tightRef = XLSX.utils.encode_range(tightRange);
-          worksheet["!ref"] = tightRef;
-          allText += `Range: ${tightRef} (${
-            tightRange.e.r - tightRange.s.r + 1
-          } rows × ${tightRange.e.c - tightRange.s.c + 1} cols)\n\n`;
-        } else {
-          // Drop !ref entirely so sheet_to_csv emits nothing rather than
-          // honoring a stale declared dimension over an empty sheet.
-          delete worksheet["!ref"];
+        // Compact the worksheet to its real used range (bounds every later
+        // !ref walk to actual data; rejects pathological sheets via the
+        // shared cell budget). Identity for contiguous, unpruned data.
+        compactWorksheet(worksheet, { filename: sheetName });
+        const ref = worksheet["!ref"];
+        if (ref) {
+          const range = XLSX.utils.decode_range(ref);
+          allText += `Range: ${ref} (${range.e.r - range.s.r + 1} rows × ${
+            range.e.c - range.s.c + 1
+          } cols)\n\n`;
         }
 
-        const csvText = tightRange
+        const csvText = ref
           ? XLSX.utils.sheet_to_csv(worksheet, {
               blankrows: true,
               skipHidden: false,

--- a/apps/api/src/api/llm/features/grading/constants.spec.ts
+++ b/apps/api/src/api/llm/features/grading/constants.spec.ts
@@ -1,0 +1,27 @@
+import { resolveMaxSpreadsheetCellsPerSubmission } from "./constants";
+
+describe("resolveMaxSpreadsheetCellsPerSubmission", () => {
+  const original = process.env.GRADING_MAX_SPREADSHEET_CELLS;
+  afterEach(() => {
+    if (original === undefined)
+      delete process.env.GRADING_MAX_SPREADSHEET_CELLS;
+    else process.env.GRADING_MAX_SPREADSHEET_CELLS = original;
+  });
+
+  it("defaults to 1,000,000 when the env var is unset", () => {
+    delete process.env.GRADING_MAX_SPREADSHEET_CELLS;
+    expect(resolveMaxSpreadsheetCellsPerSubmission()).toBe(1_000_000);
+  });
+
+  it("honors a positive integer override", () => {
+    process.env.GRADING_MAX_SPREADSHEET_CELLS = "250000";
+    expect(resolveMaxSpreadsheetCellsPerSubmission()).toBe(250_000);
+  });
+
+  it("falls back to the default for non-positive or non-integer values", () => {
+    process.env.GRADING_MAX_SPREADSHEET_CELLS = "0";
+    expect(resolveMaxSpreadsheetCellsPerSubmission()).toBe(1_000_000);
+    process.env.GRADING_MAX_SPREADSHEET_CELLS = "abc";
+    expect(resolveMaxSpreadsheetCellsPerSubmission()).toBe(1_000_000);
+  });
+});

--- a/apps/api/src/api/llm/features/grading/constants.ts
+++ b/apps/api/src/api/llm/features/grading/constants.ts
@@ -23,3 +23,25 @@ export function resolveMaxEvidenceBlocksPerSubmission(): number {
 
 export const MAX_EVIDENCE_BLOCKS_PER_SUBMISSION =
   resolveMaxEvidenceBlocksPerSubmission();
+
+// Hard cap on the number of cells (rows × columns) a single spreadsheet
+// submission may expand into after it is compacted to its real data. A genuine
+// dataset stays well under this; the cap exists to reject pathological sheets
+// (e.g. a table sized to the whole grid) before any walk materializes them.
+//
+// Tunable per environment via GRADING_MAX_SPREADSHEET_CELLS; falls back to the
+// default whenever that var is unset, empty, or not a positive integer.
+const DEFAULT_MAX_SPREADSHEET_CELLS_PER_SUBMISSION = 1_000_000;
+
+export function resolveMaxSpreadsheetCellsPerSubmission(): number {
+  const parsed = Number.parseInt(
+    process.env.GRADING_MAX_SPREADSHEET_CELLS ?? "",
+    10,
+  );
+  return Number.isInteger(parsed) && parsed > 0
+    ? parsed
+    : DEFAULT_MAX_SPREADSHEET_CELLS_PER_SUBMISSION;
+}
+
+export const MAX_SPREADSHEET_CELLS_PER_SUBMISSION =
+  resolveMaxSpreadsheetCellsPerSubmission();

--- a/apps/api/src/api/llm/features/grading/services/file-grading.service.spec.ts
+++ b/apps/api/src/api/llm/features/grading/services/file-grading.service.spec.ts
@@ -1,4 +1,6 @@
+import * as XLSX from "xlsx";
 import { HighlightLevel } from "../../../model/highlighting.model";
+import { compactWorksheet } from "./spreadsheet-used-range.utils";
 
 describe("FileGradingService.highlighting normalization", () => {
   it("serializes Map-based highlighting into JSON-friendly records", () => {
@@ -74,5 +76,27 @@ describe("FileGradingService.highlighting normalization", () => {
     const json = JSON.stringify(highlighting);
     expect(json).toContain("Hello");
     expect(json).toContain("sample.pdf");
+  });
+});
+
+describe("buildSpreadsheetMetrics compaction regression", () => {
+  it("compaction keeps sheet_to_json bounded for a bottom-outlier sheet", () => {
+    const sheet: XLSX.WorkSheet = {
+      A1: { t: "s", v: "name", w: "name" },
+      B1: { t: "s", v: "qty", w: "qty" },
+      A2: { t: "s", v: "widget", w: "widget" },
+      B2: { t: "n", v: 5, w: "5" },
+      B1048576: { t: "n", v: 5, w: "5" },
+      "!ref": "A1:XFD1048576",
+    };
+    compactWorksheet(sheet);
+    const started = Date.now();
+    const rows = XLSX.utils.sheet_to_json(sheet, {
+      header: 1,
+      blankrows: true,
+      defval: "",
+    });
+    expect(Date.now() - started).toBeLessThan(2000);
+    expect(rows.length).toBe(3); // header + data + total, no 1M-row gap
   });
 });

--- a/apps/api/src/api/llm/features/grading/services/spreadsheet-used-range.utils.spec.ts
+++ b/apps/api/src/api/llm/features/grading/services/spreadsheet-used-range.utils.spec.ts
@@ -1,9 +1,32 @@
 import * as XLSX from "xlsx";
 import {
   clampWorkbookToUsedRanges,
+  compactWorksheet,
   computeUsedRange,
   readClampedWorkbook,
 } from "./spreadsheet-used-range.utils";
+import { OversizedSubmissionError } from "../errors/oversized-submission.error";
+
+// Build a worksheet object directly (never round-trip a full-grid !ref through
+// disk — that is itself a SheetJS memory bomb).
+function ws(
+  cells: Record<string, string | number>,
+  ref: string,
+): XLSX.WorkSheet {
+  const sheet: XLSX.WorkSheet = {};
+  for (const [addr, v] of Object.entries(cells)) {
+    sheet[addr] =
+      typeof v === "number" ? { t: "n", v, w: String(v) } : { t: "s", v, w: v };
+  }
+  sheet["!ref"] = ref; // declared dimension (possibly bloated)
+  return sheet;
+}
+function csvLines(sheet: XLSX.WorkSheet): string[] {
+  return XLSX.utils
+    .sheet_to_csv(sheet, { blankrows: true, FS: "\t" })
+    .split("\n")
+    .filter((l) => l !== "");
+}
 
 describe("computeUsedRange", () => {
   it("returns the tight bounding box of real cells", () => {
@@ -150,5 +173,65 @@ describe("readClampedWorkbook", () => {
       header: 1,
     }) as unknown[][];
     expect(rows).toHaveLength(2);
+  });
+});
+
+describe("compactWorksheet", () => {
+  it("leaves contiguous, unpruned data unchanged (phantom dimension → tight box)", () => {
+    const sheet = ws({ A1: "h1", B1: "h2", A2: "x", B2: "y" }, "A1:XFD1048576");
+    compactWorksheet(sheet);
+    expect(sheet["!ref"]).toBe("A1:B2");
+    expect(sheet["A1"]).toBeDefined();
+    expect(sheet["B2"]).toBeDefined();
+  });
+
+  it("compacts a bottom-outlier total without spanning the gap", () => {
+    // header + 1 data row + grand total parked in the last grid row.
+    const sheet = ws(
+      { A1: "name", B1: "qty", A2: "widget", B2: 5, B1048576: 5 },
+      "A1:XFD1048576",
+    );
+    compactWorksheet(sheet);
+    // 3 populated rows (1, 2, 1048576) collapse to rows 1..3; cols A,B.
+    expect(sheet["!ref"]).toBe("A1:B3");
+    expect(csvLines(sheet).length).toBe(3);
+  });
+
+  it("prunes empty auto-header columns from a full-grid table", () => {
+    // header cell in a far column (no data below it) must be dropped.
+    const sheet = ws(
+      { A1: "real", B1: "real2", ZZ1: "autoheader", A2: "v1", B2: "v2" },
+      "A1:XFD1048576",
+    );
+    compactWorksheet(sheet);
+    expect(sheet["!ref"]).toBe("A1:B2"); // ZZ pruned (no data below header)
+  });
+
+  it("falls back to all populated columns for a header-only sheet", () => {
+    const sheet = ws({ A1: "h1", B1: "h2", C1: "h3" }, "A1:XFD1048576");
+    compactWorksheet(sheet);
+    expect(sheet["!ref"]).toBe("A1:C1");
+  });
+
+  it("collapses non-contiguous columns to a dense range", () => {
+    const sheet = ws({ A1: "a", C1: "c", A2: "1", C2: "3" }, "A1:XFD1048576");
+    compactWorksheet(sheet);
+    expect(sheet["!ref"]).toBe("A1:B2"); // cols A,C → A,B
+    expect(csvLines(sheet)[0]).toBe("a\tc");
+  });
+
+  it("rejects when populated rows exceed the evidence-block budget", () => {
+    const sheet: XLSX.WorkSheet = { "!ref": "A1:A1048576" };
+    for (let r = 0; r < 60_000; r += 1)
+      sheet[`A${r + 1}`] = { t: "n", v: r, w: String(r) };
+    expect(() => compactWorksheet(sheet, { filename: "big.xlsx" })).toThrow(
+      OversizedSubmissionError,
+    );
+  });
+
+  it("drops !ref for an empty sheet", () => {
+    const sheet: XLSX.WorkSheet = { "!ref": "A1:XFD1048576" };
+    compactWorksheet(sheet);
+    expect(sheet["!ref"]).toBeUndefined();
   });
 });

--- a/apps/api/src/api/llm/features/grading/services/spreadsheet-used-range.utils.ts
+++ b/apps/api/src/api/llm/features/grading/services/spreadsheet-used-range.utils.ts
@@ -1,4 +1,9 @@
 import * as XLSX from "xlsx";
+import {
+  MAX_EVIDENCE_BLOCKS_PER_SUBMISSION,
+  MAX_SPREADSHEET_CELLS_PER_SUBMISSION,
+} from "../constants";
+import { OversizedSubmissionError } from "../errors/oversized-submission.error";
 
 /**
  * Walk only real cell keys on the worksheet and compute the bounding box of
@@ -44,22 +49,168 @@ export function computeUsedRange(worksheet: XLSX.WorkSheet): XLSX.Range | null {
   };
 }
 
+export interface SpreadsheetBudgetMeta {
+  filename?: string;
+  questionId?: number;
+  attemptId?: number;
+}
+
+function assertSpreadsheetWithinBudget(
+  rowCount: number,
+  cellCount: number,
+  meta?: SpreadsheetBudgetMeta,
+): void {
+  const overRows = rowCount > MAX_EVIDENCE_BLOCKS_PER_SUBMISSION;
+  const overCells = cellCount > MAX_SPREADSHEET_CELLS_PER_SUBMISSION;
+  if (!overRows && !overCells) return;
+  throw new OversizedSubmissionError({
+    blockCount: overRows ? rowCount : cellCount,
+    cap: overRows
+      ? MAX_EVIDENCE_BLOCKS_PER_SUBMISSION
+      : MAX_SPREADSHEET_CELLS_PER_SUBMISSION,
+    filename: meta?.filename,
+    questionId: meta?.questionId,
+    attemptId: meta?.attemptId,
+  });
+}
+
+/**
+ * Rewrite a worksheet so `!ref` spans only its real data. Walks value-bearing
+ * cells once (O(real cells)): collects populated rows and "meaningful" columns
+ * (columns carrying a value in any row other than the topmost populated row —
+ * the de-facto header). When data is already contiguous and no column is
+ * pruned, only `!ref` is tightened (identical to the prior bounding-box clamp).
+ * Otherwise cells are remapped to a dense range so a far-flung total or a
+ * full-grid table does not force downstream `!ref` walks to span the gap.
+ * Throws OversizedSubmissionError when the compacted sheet is still over budget.
+ */
+export function compactWorksheet(
+  ws: XLSX.WorkSheet,
+  meta?: SpreadsheetBudgetMeta,
+): void {
+  const realCells: { r: number; c: number; key: string }[] = [];
+  const rowSet = new Set<number>();
+  const allColSet = new Set<number>();
+  let topRow = Number.POSITIVE_INFINITY;
+
+  for (const key in ws) {
+    if (key.codePointAt(0) === 33) continue; // '!' meta
+    const cell = ws[key] as XLSX.CellObject;
+    if (cell.t === "z") continue; // style-only stub, no value
+    const a = XLSX.utils.decode_cell(key);
+    if (!Number.isFinite(a.r) || !Number.isFinite(a.c) || a.r < 0 || a.c < 0) {
+      continue;
+    }
+    realCells.push({ r: a.r, c: a.c, key });
+    rowSet.add(a.r);
+    allColSet.add(a.c);
+    if (a.r < topRow) topRow = a.r;
+  }
+
+  if (realCells.length === 0) {
+    delete ws["!ref"];
+    return;
+  }
+
+  const belowTopColSet = new Set<number>();
+  for (const { r, c } of realCells) {
+    if (r !== topRow) belowTopColSet.add(c);
+  }
+  const cols = (
+    belowTopColSet.size > 0 ? [...belowTopColSet] : [...allColSet]
+  ).sort((x, y) => x - y);
+  const rows = [...rowSet].sort((x, y) => x - y);
+
+  assertSpreadsheetWithinBudget(rows.length, rows.length * cols.length, meta);
+
+  const rowsContiguous = rows.at(-1)! - rows[0] + 1 === rows.length;
+  const colsContiguous = cols.at(-1)! - cols[0] + 1 === cols.length;
+  const colsAllKept = cols.length === allColSet.size;
+
+  if (rowsContiguous && colsContiguous && colsAllKept) {
+    // Identity case: no gaps, nothing pruned — just tighten !ref (the original
+    // bounding-box clamp). Cells are left exactly where they are.
+    ws["!ref"] = XLSX.utils.encode_range({
+      s: { r: rows[0], c: cols[0] },
+      e: { r: rows.at(-1)!, c: cols.at(-1)! },
+    });
+    return;
+  }
+
+  // Compaction: remap to a dense, 0-based range.
+  const rowRemap = new Map<number, number>();
+  for (const [index, r] of rows.entries()) rowRemap.set(r, index);
+  const colRemap = new Map<number, number>();
+  for (const [index, c] of cols.entries()) colRemap.set(c, index);
+  const colKept = new Set(cols);
+
+  const newCells: Record<string, XLSX.CellObject> = {};
+  for (const { r, c, key } of realCells) {
+    if (!colKept.has(c)) continue; // prune non-meaningful columns
+    const nr = rowRemap.get(r)!;
+    const nc = colRemap.get(c)!;
+    newCells[XLSX.utils.encode_cell({ r: nr, c: nc })] = ws[
+      key
+    ] as XLSX.CellObject;
+  }
+
+  const comments = ws["!comments"] as Record<string, unknown> | undefined;
+  let newComments: Record<string, unknown> | undefined;
+  if (comments) {
+    newComments = {};
+    for (const cAddr in comments) {
+      const a = XLSX.utils.decode_cell(cAddr);
+      if (rowRemap.has(a.r) && colKept.has(a.c)) {
+        const na = XLSX.utils.encode_cell({
+          r: rowRemap.get(a.r)!,
+          c: colRemap.get(a.c)!,
+        });
+        newComments[na] = comments[cAddr];
+      }
+    }
+  }
+
+  // Wipe old cell keys and stale, index-bound presentation meta, then install
+  // the dense data. Old keys are removed before new ones are added, so a
+  // remapped address can safely reuse an old address.
+  for (const key in ws) {
+    if (key.codePointAt(0) === 33) {
+      if (
+        key === "!merges" ||
+        key === "!cols" ||
+        key === "!rows" ||
+        key === "!comments"
+      ) {
+        delete ws[key];
+      }
+      continue;
+    }
+    delete ws[key];
+  }
+  Object.assign(ws, newCells);
+  if (newComments && Object.keys(newComments).length > 0) {
+    ws["!comments"] = newComments;
+  }
+  ws["!ref"] = XLSX.utils.encode_range({
+    s: { r: 0, c: 0 },
+    e: { r: rows.length - 1, c: cols.length - 1 },
+  });
+}
+
 /**
  * Replace each worksheet's declared `!ref` with a tight range covering only
  * real cells so `sheet_to_json` / `sheet_to_csv` walks are bounded by actual
  * data. Worksheets with no real cells lose `!ref` entirely so consumers emit
  * nothing rather than honoring a stale declared dimension.
  */
-export function clampWorkbookToUsedRanges(workbook: XLSX.WorkBook): void {
+export function clampWorkbookToUsedRanges(
+  workbook: XLSX.WorkBook,
+  meta?: SpreadsheetBudgetMeta,
+): void {
   for (const sheetName of workbook.SheetNames) {
     const worksheet = workbook.Sheets[sheetName];
     if (!worksheet) continue;
-    const tightRange = computeUsedRange(worksheet);
-    if (tightRange) {
-      worksheet["!ref"] = XLSX.utils.encode_range(tightRange);
-    } else {
-      delete worksheet["!ref"];
-    }
+    compactWorksheet(worksheet, meta);
   }
 }
 
@@ -75,12 +226,13 @@ export function clampWorkbookToUsedRanges(workbook: XLSX.WorkBook): void {
 export function readClampedWorkbook(
   buffer: Buffer,
   options: XLSX.ParsingOptions & { FS?: string } = {},
+  meta?: SpreadsheetBudgetMeta,
 ): XLSX.WorkBook {
   const workbook = XLSX.read(buffer, {
     ...options,
     type: "buffer",
     sheetStubs: false,
   });
-  clampWorkbookToUsedRanges(workbook);
+  clampWorkbookToUsedRanges(workbook, meta);
   return workbook;
 }

--- a/apps/api/src/job-queue/job-state.service.spec.ts
+++ b/apps/api/src/job-queue/job-state.service.spec.ts
@@ -266,9 +266,7 @@ describe("JobStateService", () => {
       percentage: 100,
       result: { ok: true },
     });
-    expect(fakeRedis.ttls.get(`mark:jobs:state:${job.id}`)).toBe(
-      7 * 24 * 60 * 60,
-    );
+    expect(fakeRedis.ttls.get(`mark:jobs:state:${job.id}`)).toBe(2 * 60 * 60);
     expect(
       fakeRedis.strings.has(`mark:jobs:active:${hashActiveKey(activeKey)}`),
     ).toBe(false);

--- a/apps/api/src/job-queue/job-state.service.ts
+++ b/apps/api/src/job-queue/job-state.service.ts
@@ -14,7 +14,13 @@ interface StoredJobState extends JobStateRecord {
 }
 
 const ACTIVE_JOB_TTL_SECONDS = 24 * 60 * 60;
-const TERMINAL_JOB_TTL_SECONDS = 7 * 24 * 60 * 60;
+// Completed/failed job state is a short-lived convenience cache so the client can
+// read the final status and result immediately after a job finishes; the durable
+// grade and result are persisted in the database. Each terminal hash retains the
+// full serialized result blob, so a multi-day TTL made job state the dominant
+// consumer of the shared Redis instance and forced continuous LRU eviction. Two
+// hours covers the post-completion read window while keeping resident memory low.
+const TERMINAL_JOB_TTL_SECONDS = 2 * 60 * 60;
 const NULL_SENTINEL = "__null__";
 
 @Injectable()


### PR DESCRIPTION
## Problem

Some XLSX submissions still failed in the grading worker after the earlier used-range clamp shipped, with two symptoms:

- `job stalled more than allowable limit` (BullMQ stalled-job failure)
- `Submission would produce 1048635 blocks, exceeding the per-submission cap of 50000`

These came from real learner files whose three sheets each carry a table sized to the **entire grid** (`A1:XFD1048576`), a header row with a cell in all 16,384 columns, and a grand-total formula parked in cell `C1048576` (the last grid row). The actual content is only ~56 rows × 3–4 columns — everything else is empty grid Excel materialized for the full-width table.

## Root cause

The existing clamp computes a **min/max bounding box** over value-bearing cells. Because real cells genuinely touch column XFD *and* row 1,048,576, the bounding box *is* the full 17-billion-cell grid, so it reduces nothing. `extractExcelText`'s `sheet_to_csv(blankrows: true)` then walks that grid (measured >120s for a single sheet, never completing) — a synchronous walk that blocks the worker's event loop past BullMQ's stall interval, and on counting paths produces ~1M evidence blocks. The deterministic grading path's `sheet_to_json` has the same exposure (both honor `!ref`).

## Fix

`compactWorksheet` (shared in `spreadsheet-used-range.utils.ts`) replaces the bounding-box clamp:

- Walks value-bearing cells once (O(real cells)); keeps populated rows + **meaningful columns** (columns with data in any row below the header row), falling back to all populated columns for a header-only sheet.
- **Identity case** (contiguous rows, contiguous columns, nothing pruned): only tightens `!ref` — so normal and phantom-dimension files are byte-identical to before.
- **Compaction case** (gaps or pruned columns): remaps cells to a dense range, removing the row gap and the empty auto-header columns. The example file collapses to ~`A1:D57` per sheet and extracts in well under a second.
- **Budget backstop** (O(1), before any walk): rejects when populated rows exceed `MAX_EVIDENCE_BLOCKS_PER_SUBMISSION` (50,000) or rows × columns exceed `MAX_SPREADSHEET_CELLS_PER_SUBMISSION` (new, env-tunable via `GRADING_MAX_SPREADSHEET_CELLS`, default 1,000,000), throwing the existing learner-facing terminal `OversizedSubmissionError`.

`extractExcelText` now routes through `compactWorksheet`, and the duplicate private `computeUsedRange` is deleted (one source of truth — the grading path's `readClampedWorkbook` / `buildSpreadsheetMetrics` are covered too). A terminal-error guard was added to `extractExcelText`'s catch so an oversized rejection is no longer rewrapped into a generic `Error` (it must keep its identity for both the upstream `instanceof` guard and the worker's terminal-error classification).

## Testing

- New + existing unit tests across the cell-budget constant, `compactWorksheet` (identity, bottom-outlier compaction, empty-column pruning, header-only fallback, non-contiguous collapse, over-budget reject, empty sheet), extraction routing, the deterministic-grading `sheet_to_json` regression guard, and `OversizedSubmissionError` propagation through `extractExcelText`.
- The four touched suites pass together (74/74); `apps/api` `tsc --noEmit` clean.
- No client-side change (the in-browser parse path is dead; the server re-extracts from object storage as source of truth).

## Validation before merge

- [ ] Staging: the real full-grid submission grades on its actual rows (not stall / not block-cap).
- [ ] Staging: a genuinely oversized sheet returns the learner-facing "too large — reduce rows/sheets" terminal error.
