### PR TITLE
feat(admin): add force-pass endpoint and UI to manually pass a learner attempt

### DIFF
--- a/apps/api/src/api/admin/admin.module.ts
+++ b/apps/api/src/api/admin/admin.module.ts
@@ -5,6 +5,7 @@ import { JobQueueModule } from "src/job-queue/job-queue.module";
 import { AdminAuthModule } from "../../auth/admin-auth.module";
 import { AuthModule } from "../../auth/auth.module";
 import { AssignmentModuleV2 } from "../assignment/v2/modules/assignment.module";
+import { LtiSyncModule } from "../attempt/lti-sync.module";
 import { FilesModule } from "../files/files.module";
 import { LlmModule } from "../llm/llm.module";
 import { ScheduledTasksModule } from "../scheduled-tasks/scheduled-tasks.module";
@@ -12,6 +13,7 @@ import { AdminController } from "./admin.controller";
 import { AdminRepository } from "./admin.repository";
 import { AdminService } from "./admin.service";
 import { AdminDashboardController } from "./controllers/admin-dashboard.controller";
+import { AttemptAdminController } from "./controllers/attempt-admin.controller";
 import { AssignmentLevelStandardsController } from "./controllers/assignment-level-standards.controller";
 import { AssignmentAnalyticsController } from "./controllers/assignment-analytics.controller";
 import { FlaggedSubmissionsController } from "./controllers/flagged-submissions.controller";
@@ -21,6 +23,7 @@ import { QueueStatusController } from "./controllers/queue-status.controller";
 import { RegradingRequestsController } from "./controllers/regrading-requests.controller";
 import { TranslationMaintenanceController } from "./controllers/translation-maintenance.controller";
 import { TRANSLATION_MAINTENANCE_JOB_RUNNER } from "./controllers/translation-maintenance.job-runner";
+import { AttemptAdminService } from "./services/attempt-admin.service";
 import { QueueStatusService } from "./services/queue-status.service";
 
 @Module({
@@ -33,6 +36,7 @@ import { QueueStatusService } from "./services/queue-status.service";
     ScheduledTasksModule,
     JobQueueModule,
     FilesModule,
+    LtiSyncModule,
     // Per-admin rate limits for the queue-status write actions (retry/remove).
     // Registered here (not as APP_GUARD) so it stays scoped to this module;
     // QueueStatusController opts in via @UseGuards(ThrottlerGuard) + @Throttle.
@@ -49,11 +53,13 @@ import { QueueStatusService } from "./services/queue-status.service";
     AssignmentLevelStandardsController,
     TranslationMaintenanceController,
     QueueStatusController,
+    AttemptAdminController,
   ],
   providers: [
     AdminService,
     AdminRepository,
     QueueStatusService,
+    AttemptAdminService,
     TranslationMaintenanceController,
     {
       provide: TRANSLATION_MAINTENANCE_JOB_RUNNER,

--- a/apps/api/src/api/admin/admin.service.ts
+++ b/apps/api/src/api/admin/admin.service.ts
@@ -56,6 +56,14 @@ interface DashboardFilters {
 @Injectable()
 export class AdminService {
   private readonly logger = new Logger(AdminService.name);
+  // TODO: this insights cache is a per-pod in-memory Map, so writes that change
+  // an attempt (e.g. the admin force-pass in AttemptAdminService) can't
+  // invalidate it across replicas — the admin analytics view stays stale for up
+  // to INSIGHTS_CACHE_TTL after such a write. Accepted for now: force-pass is a
+  // rare admin action, the underlying DB is updated synchronously, and the
+  // acting admin gets an optimistic UI update. If insights need to be live after
+  // writes, move this to a shared Redis-backed cache service (see
+  // AttemptAccessCacheService / GradingCacheService) with an invalidate(assignmentId).
   private readonly insightsCache = new Map<
     string,
     { data: any; cachedAt: number }

--- a/apps/api/src/api/admin/controllers/attempt-admin.controller.ts
+++ b/apps/api/src/api/admin/controllers/attempt-admin.controller.ts
@@ -1,0 +1,74 @@
+import {
+  Body,
+  Controller,
+  Logger,
+  Param,
+  ParseIntPipe,
+  Post,
+  Req,
+  UseGuards,
+  UsePipes,
+  ValidationPipe,
+} from "@nestjs/common";
+import {
+  ApiBearerAuth,
+  ApiBody,
+  ApiOperation,
+  ApiParam,
+  ApiResponse,
+  ApiTags,
+} from "@nestjs/swagger";
+import { Throttle, ThrottlerGuard } from "@nestjs/throttler";
+import { AdminGuard } from "src/auth/guards/admin.guard";
+import { UserSessionRequest } from "src/auth/interfaces/user.session.interface";
+import { ForcePassAttemptDto } from "../dto/force-pass-attempt.dto";
+import { AttemptAdminService } from "../services/attempt-admin.service";
+
+@ApiTags("Admin Attempts")
+// AdminGuard covers the whole controller and is the single source of truth for
+// access (it rejects any non-admin session). Lives under "admin-dashboard/..."
+// — not "admin/..." — so it routes through the same api-gateway path as the
+// other admin-dashboard endpoints (cookie session + x-admin-token) and reaches
+// mark-api's AdminGuard, rather than the gateway's JWT-bearer "/admin/*" guard.
+@UseGuards(AdminGuard)
+@ApiBearerAuth()
+@UsePipes(
+  new ValidationPipe({
+    whitelist: true,
+    forbidNonWhitelisted: true,
+    transform: true,
+  }),
+)
+@Controller({ path: "admin-dashboard/attempts", version: "1" })
+export class AttemptAdminController {
+  private readonly logger = new Logger(AttemptAdminController.name);
+
+  constructor(private readonly attemptAdminService: AttemptAdminService) {}
+
+  @Post(":attemptId/force-pass")
+  // Mutating override action: rate-limit per admin in line with the other
+  // admin write actions (queue retry/remove).
+  @UseGuards(ThrottlerGuard)
+  @Throttle({ default: { limit: 20, ttl: 60_000 } })
+  @ApiOperation({
+    summary: "Manually pass an attempt (set grade + mark submitted) (ADMIN)",
+  })
+  @ApiParam({ name: "attemptId", required: true, type: Number })
+  @ApiBody({ type: ForcePassAttemptDto, required: false })
+  @ApiResponse({ status: 201, description: "Attempt force-passed" })
+  @ApiResponse({ status: 403, description: "Not an admin" })
+  @ApiResponse({ status: 404, description: "Attempt not found" })
+  async forcePass(
+    @Param("attemptId", ParseIntPipe) attemptId: number,
+    @Body() body: ForcePassAttemptDto,
+    @Req() request: UserSessionRequest,
+  ) {
+    const adminEmail = request.userSession?.userId ?? "unknown";
+    const gradePercent = body.gradePercent ?? 100;
+    return this.attemptAdminService.forcePass(
+      attemptId,
+      gradePercent,
+      adminEmail,
+    );
+  }
+}

--- a/apps/api/src/api/admin/dto/force-pass-attempt.dto.ts
+++ b/apps/api/src/api/admin/dto/force-pass-attempt.dto.ts
@@ -1,0 +1,16 @@
+import { IsInt, IsOptional, Max, Min } from "class-validator";
+
+/**
+ * Body for the admin force-pass action.
+ *
+ * `gradePercent` is on the 0-100 scale (same convention the regrading-approve
+ * flow uses) and is stored as a 0-1 fraction on the attempt. Omitting it means
+ * "pass at 100%", the common case for a manual pass.
+ */
+export class ForcePassAttemptDto {
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  @Max(100)
+  gradePercent?: number;
+}

--- a/apps/api/src/api/admin/services/attempt-admin.service.spec.ts
+++ b/apps/api/src/api/admin/services/attempt-admin.service.spec.ts
@@ -5,6 +5,7 @@ import { AttemptAdminService } from "./attempt-admin.service";
 const prisma = {
   assignmentAttempt: {
     findUnique: jest.fn(),
+    findMany: jest.fn(),
     update: jest.fn(),
   },
   gradingProgress: {
@@ -35,6 +36,7 @@ describe("AttemptAdminService.forcePass", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     prisma.assignmentAttempt.findUnique.mockResolvedValue(attempt);
+    prisma.assignmentAttempt.findMany.mockResolvedValue([]);
     prisma.assignmentAttempt.update.mockResolvedValue({});
     prisma.gradingProgress.upsert.mockResolvedValue({});
     prisma.ltiGradeSync.findFirst.mockResolvedValue(null);
@@ -54,8 +56,10 @@ describe("AttemptAdminService.forcePass", () => {
 
     expect(prisma.assignmentAttempt.update).toHaveBeenCalledWith({
       where: { id: 7 },
-      data: { grade: 1, submitted: true },
+      data: { grade: 1, submitted: true, expiresAt: expect.any(Date) },
     });
+    // The grade and grading-progress writes must go through one transaction.
+    expect(prisma.$transaction).toHaveBeenCalledTimes(1);
     expect(result).toMatchObject({ success: true, grade: 1, submitted: true });
   });
 
@@ -85,7 +89,7 @@ describe("AttemptAdminService.forcePass", () => {
 
     expect(prisma.assignmentAttempt.update).toHaveBeenCalledWith({
       where: { id: 7 },
-      data: { grade: 0.8, submitted: true },
+      data: { grade: 0.8, submitted: true, expiresAt: expect.any(Date) },
     });
   });
 
@@ -100,7 +104,7 @@ describe("AttemptAdminService.forcePass", () => {
   it("re-syncs the grade reusing the latest auth cookie", async () => {
     prisma.ltiGradeSync.findFirst.mockResolvedValue({ authCookie: "cookie-1" });
     ltiGradeSyncService.createAndSync.mockResolvedValue({
-      status: LtiSyncStatus.COMPLETED,
+      status: LtiSyncStatus.SUCCESS,
       message: "ok",
     });
 
@@ -115,8 +119,28 @@ describe("AttemptAdminService.forcePass", () => {
     });
     expect(result.lti).toMatchObject({
       attempted: true,
-      status: LtiSyncStatus.COMPLETED,
+      status: LtiSyncStatus.SUCCESS,
     });
+  });
+
+  it("pushes the highest grade across the learner's attempts, not the raw one", async () => {
+    // A previous attempt already scored higher than this force-pass grade; the
+    // LMS gradebook must not regress to the lower value.
+    prisma.assignmentAttempt.findMany.mockResolvedValue([
+      { grade: 0.9 },
+      { grade: 0.6 },
+    ]);
+    prisma.ltiGradeSync.findFirst.mockResolvedValue({ authCookie: "cookie-1" });
+    ltiGradeSyncService.createAndSync.mockResolvedValue({
+      status: LtiSyncStatus.SUCCESS,
+      message: "ok",
+    });
+
+    await make().forcePass(7, 60, "admin@x");
+
+    expect(ltiGradeSyncService.createAndSync).toHaveBeenCalledWith(
+      expect.objectContaining({ grade: 0.9 }),
+    );
   });
 
   it("still passes the attempt when the LMS sync throws", async () => {

--- a/apps/api/src/api/admin/services/attempt-admin.service.spec.ts
+++ b/apps/api/src/api/admin/services/attempt-admin.service.spec.ts
@@ -1,0 +1,137 @@
+import { NotFoundException } from "@nestjs/common";
+import { GradingStatus, LtiSyncStatus } from "@prisma/client";
+import { AttemptAdminService } from "./attempt-admin.service";
+
+const prisma = {
+  assignmentAttempt: {
+    findUnique: jest.fn(),
+    update: jest.fn(),
+  },
+  gradingProgress: {
+    upsert: jest.fn(),
+  },
+  ltiGradeSync: {
+    findFirst: jest.fn(),
+  },
+  // The service batches the attempt + grading-progress writes in a transaction;
+  // run the operations as-is so the per-table mocks still observe their calls.
+  $transaction: jest.fn((ops: unknown[]) => Promise.all(ops)),
+};
+const ltiGradeSyncService = {
+  createAndSync: jest.fn(),
+};
+
+const make = () =>
+  new AttemptAdminService(prisma as never, ltiGradeSyncService as never);
+
+const attempt = {
+  id: 7,
+  userId: "user-1",
+  assignmentId: 42,
+  questionOrder: [1, 2, 3],
+};
+
+describe("AttemptAdminService.forcePass", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    prisma.assignmentAttempt.findUnique.mockResolvedValue(attempt);
+    prisma.assignmentAttempt.update.mockResolvedValue({});
+    prisma.gradingProgress.upsert.mockResolvedValue({});
+    prisma.ltiGradeSync.findFirst.mockResolvedValue(null);
+  });
+
+  it("throws NotFound when the attempt does not exist", async () => {
+    prisma.assignmentAttempt.findUnique.mockResolvedValue(null);
+
+    await expect(make().forcePass(7, 100, "admin@x")).rejects.toBeInstanceOf(
+      NotFoundException,
+    );
+    expect(prisma.assignmentAttempt.update).not.toHaveBeenCalled();
+  });
+
+  it("sets the grade as a 0-1 fraction and marks the attempt submitted", async () => {
+    const result = await make().forcePass(7, 100, "admin@x");
+
+    expect(prisma.assignmentAttempt.update).toHaveBeenCalledWith({
+      where: { id: 7 },
+      data: { grade: 1, submitted: true },
+    });
+    expect(result).toMatchObject({ success: true, grade: 1, submitted: true });
+  });
+
+  it("forces grading progress to COMPLETED so stale progress is not shown", async () => {
+    await make().forcePass(7, 100, "admin@x");
+
+    expect(prisma.gradingProgress.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { attemptId: 7 },
+        create: expect.objectContaining({
+          attemptId: 7,
+          totalQuestions: 3,
+          status: GradingStatus.COMPLETED,
+          progress: 100,
+        }),
+        update: expect.objectContaining({
+          status: GradingStatus.COMPLETED,
+          progress: 100,
+          error: null,
+        }),
+      }),
+    );
+  });
+
+  it("honours an explicit gradePercent", async () => {
+    await make().forcePass(7, 80, "admin@x");
+
+    expect(prisma.assignmentAttempt.update).toHaveBeenCalledWith({
+      where: { id: 7 },
+      data: { grade: 0.8, submitted: true },
+    });
+  });
+
+  it("skips the LMS sync when the attempt has no prior sync", async () => {
+    const result = await make().forcePass(7, 100, "admin@x");
+
+    expect(ltiGradeSyncService.createAndSync).not.toHaveBeenCalled();
+    expect(result.lti.attempted).toBe(false);
+    expect(result.lti.status).toBeNull();
+  });
+
+  it("re-syncs the grade reusing the latest auth cookie", async () => {
+    prisma.ltiGradeSync.findFirst.mockResolvedValue({ authCookie: "cookie-1" });
+    ltiGradeSyncService.createAndSync.mockResolvedValue({
+      status: LtiSyncStatus.COMPLETED,
+      message: "ok",
+    });
+
+    const result = await make().forcePass(7, 100, "admin@x");
+
+    expect(ltiGradeSyncService.createAndSync).toHaveBeenCalledWith({
+      attemptId: 7,
+      userId: "user-1",
+      assignmentId: 42,
+      grade: 1,
+      authCookie: "cookie-1",
+    });
+    expect(result.lti).toMatchObject({
+      attempted: true,
+      status: LtiSyncStatus.COMPLETED,
+    });
+  });
+
+  it("still passes the attempt when the LMS sync throws", async () => {
+    prisma.ltiGradeSync.findFirst.mockResolvedValue({ authCookie: "cookie-1" });
+    ltiGradeSyncService.createAndSync.mockRejectedValue(
+      new Error("gateway down"),
+    );
+
+    const result = await make().forcePass(7, 100, "admin@x");
+
+    expect(result.success).toBe(true);
+    expect(result.lti).toMatchObject({
+      attempted: true,
+      status: LtiSyncStatus.FAILED,
+    });
+    expect(result.lti.message).toContain("gateway down");
+  });
+});

--- a/apps/api/src/api/admin/services/attempt-admin.service.ts
+++ b/apps/api/src/api/admin/services/attempt-admin.service.ts
@@ -72,7 +72,12 @@ export class AttemptAdminService {
     await this.prisma.$transaction([
       this.prisma.assignmentAttempt.update({
         where: { id: attemptId },
-        data: { grade, submitted: true },
+        // expiresAt closes the attempt window, matching every other
+        // finalization path (commit/auto-grade-on-expiry). Without it a
+        // force-passed in-progress timed attempt keeps a future expiresAt,
+        // which the retake-cooldown check keys off and would over-block the
+        // learner from starting a new attempt.
+        data: { grade, submitted: true, expiresAt: new Date() },
       }),
       this.prisma.gradingProgress.upsert({
         where: { attemptId },
@@ -134,12 +139,33 @@ export class AttemptAdminService {
       };
     }
 
+    // The LMS gradebook holds the learner's HIGHEST grade across all their
+    // attempts for this assignment (see attempt-submission.service's normal
+    // sync path). Pushing this attempt's grade raw could regress a
+    // previously-synced better attempt, so push the max instead. The
+    // force-pass grade is already persisted on the attempt before this runs,
+    // so the query includes it; request.grade is folded in explicitly to stay
+    // correct under read-replica lag.
+    const userAttempts = await this.prisma.assignmentAttempt.findMany({
+      where: { userId, assignmentId: request.assignmentId },
+      select: { grade: true },
+    });
+    let highestOverall = 0;
+    for (const userAttempt of userAttempts) {
+      if (userAttempt.grade && userAttempt.grade > highestOverall) {
+        highestOverall = userAttempt.grade;
+      }
+    }
+    if (request.grade > highestOverall) {
+      highestOverall = request.grade;
+    }
+
     try {
       const result = await this.ltiGradeSyncService.createAndSync({
         attemptId: request.attemptId,
         userId,
         assignmentId: request.assignmentId,
-        grade: request.grade,
+        grade: highestOverall,
         authCookie: lastSync.authCookie,
       });
       return {

--- a/apps/api/src/api/admin/services/attempt-admin.service.ts
+++ b/apps/api/src/api/admin/services/attempt-admin.service.ts
@@ -1,0 +1,162 @@
+import { Injectable, Logger, NotFoundException } from "@nestjs/common";
+import { GradingStatus, LtiSyncStatus } from "@prisma/client";
+import { PrismaService } from "../../../database/prisma.service";
+import { LtiGradeSyncService } from "../../attempt/services/lti-grade-sync.service";
+
+export interface ForcePassResult {
+  success: true;
+  attemptId: number;
+  grade: number;
+  submitted: boolean;
+  lti: {
+    attempted: boolean;
+    status: LtiSyncStatus | null;
+    message: string;
+  };
+}
+
+/**
+ * Admin-only operations that act directly on a single learner attempt.
+ * Kept separate from the large AdminService so the force-pass write path has a
+ * narrow, well-tested surface and its own dependency on the LTI sync service.
+ */
+@Injectable()
+export class AttemptAdminService {
+  private readonly logger = new Logger(AttemptAdminService.name);
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly ltiGradeSyncService: LtiGradeSyncService,
+  ) {}
+
+  /**
+   * Force an attempt to a passing (or explicit) grade and mark it submitted.
+   *
+   * This is the manual override for the case where grading never completed or
+   * produced the wrong outcome and the learner should be passed by hand. It:
+   *  1. sets the attempt grade (0-1 fraction) and submitted=true in Mark's DB,
+   *     and forces the attempt's GradingProgress to COMPLETED in the same
+   *     transaction so the learner-facing progress UI doesn't keep reporting a
+   *     stale PROCESSING/FAILED state for an attempt that has now been passed,
+   *  2. best-effort re-syncs the grade to the LMS by reusing the most recent
+   *     auth cookie captured for this attempt — if none exists (e.g. the attempt
+   *     never reached a sync), the LMS is left untouched and the caller is told.
+   *
+   * @param attemptId   Attempt to override.
+   * @param gradePercent 0-100 grade to set (defaults to 100 = pass).
+   * @param adminEmail  Acting admin, for the audit log.
+   */
+  async forcePass(
+    attemptId: number,
+    gradePercent: number,
+    adminEmail: string,
+  ): Promise<ForcePassResult> {
+    const attempt = await this.prisma.assignmentAttempt.findUnique({
+      where: { id: attemptId },
+    });
+
+    if (!attempt) {
+      throw new NotFoundException(`Attempt ${attemptId} not found`);
+    }
+
+    const grade = gradePercent / 100;
+
+    // Set the grade and force the grading-progress row to COMPLETED atomically.
+    // The two are a single logical state: a force-pass that left GradingProgress
+    // at PROCESSING/FAILED would show the learner a "still grading"/"grading
+    // failed" UI for an attempt that has actually been passed. upsert (not
+    // update) because the attempt may never have started grading and so may have
+    // no progress row yet; totalQuestions is required on create and matches the
+    // attempt's question count.
+    const totalQuestions = attempt.questionOrder?.length ?? 0;
+    await this.prisma.$transaction([
+      this.prisma.assignmentAttempt.update({
+        where: { id: attemptId },
+        data: { grade, submitted: true },
+      }),
+      this.prisma.gradingProgress.upsert({
+        where: { attemptId },
+        create: {
+          attemptId,
+          totalQuestions,
+          status: GradingStatus.COMPLETED,
+          progress: 100,
+          currentStage: "Grading complete!",
+          completedAt: new Date(),
+        },
+        update: {
+          status: GradingStatus.COMPLETED,
+          progress: 100,
+          currentStage: "Grading complete!",
+          error: null,
+          completedAt: new Date(),
+        },
+      }),
+    ]);
+
+    const lti = await this.resyncGrade(attempt.userId, {
+      attemptId,
+      assignmentId: attempt.assignmentId,
+      grade,
+    });
+
+    // Audit: who, which attempt, resulting grade, and what happened with the
+    // LMS sync. No learner PII beyond the userId already on the attempt.
+    this.logger.log(
+      `force-pass: admin=${adminEmail} attempt=${attemptId} ` +
+        `grade=${grade} lti=${lti.attempted ? lti.status : "skipped"}`,
+    );
+
+    return { success: true, attemptId, grade, submitted: true, lti };
+  }
+
+  /**
+   * Best-effort grade push to the LTI gateway, reusing the auth cookie from the
+   * attempt's most recent sync record. A force-pass must still succeed in Mark
+   * even when the LMS cannot be reached, so every failure here is reported, not
+   * thrown.
+   */
+  private async resyncGrade(
+    userId: string,
+    request: { attemptId: number; assignmentId: number; grade: number },
+  ): Promise<ForcePassResult["lti"]> {
+    const lastSync = await this.prisma.ltiGradeSync.findFirst({
+      where: { attemptId: request.attemptId, authCookie: { not: "" } },
+      orderBy: { createdAt: "desc" },
+    });
+
+    if (!lastSync?.authCookie) {
+      return {
+        attempted: false,
+        status: null,
+        message:
+          "No prior LTI sync for this attempt; grade saved in Mark but not pushed to the LMS.",
+      };
+    }
+
+    try {
+      const result = await this.ltiGradeSyncService.createAndSync({
+        attemptId: request.attemptId,
+        userId,
+        assignmentId: request.assignmentId,
+        grade: request.grade,
+        authCookie: lastSync.authCookie,
+      });
+      return {
+        attempted: true,
+        status: result.status,
+        message: result.message,
+      };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "unknown error";
+      this.logger.warn(
+        `force-pass LTI resync failed for attempt ${request.attemptId}: ${message}`,
+      );
+      return {
+        attempted: true,
+        status: LtiSyncStatus.FAILED,
+        message: `LTI resync failed: ${message}`,
+      };
+    }
+  }
+}

--- a/apps/web/components/insights/AssignmentInsightsContent.tsx
+++ b/apps/web/components/insights/AssignmentInsightsContent.tsx
@@ -39,6 +39,7 @@ import {
   ArrowDown,
 } from "lucide-react";
 import {
+  forcePassAttempt,
   getAuthorAssignmentInsights,
   getCurrentAdminUser,
   getDetailedAssignmentInsights,
@@ -231,6 +232,13 @@ export function AssignmentInsightsContent({
   const [isFeedbackModalOpen, setIsFeedbackModalOpen] = useState(false);
   const [isReportModalOpen, setIsReportModalOpen] = useState(false);
 
+  // Admin force-pass action state. sessionToken is captured from the admin
+  // fetch so the per-attempt action can reuse it.
+  const [sessionToken, setSessionToken] = useState<string | null>(null);
+  const [confirmingPassId, setConfirmingPassId] = useState<number | null>(null);
+  const [passingId, setPassingId] = useState<number | null>(null);
+  const [passError, setPassError] = useState<number | null>(null);
+
   useEffect(() => {
     // Author mode: normal app session (cookie). The endpoint is
     // ownership-scoped server-side and returns no admin-only data, so there is
@@ -263,6 +271,8 @@ export function AssignmentInsightsContent({
         clearAdminSessionStorage();
         router.replace(buildAdminLoginRedirect(window.location.pathname));
       };
+
+      setSessionToken(stored.sessionToken);
 
       try {
         const user = await getCurrentAdminUser(stored.sessionToken);
@@ -303,6 +313,44 @@ export function AssignmentInsightsContent({
       void fetchAdminInsights();
     }
   }, [assignmentId, router, mode]);
+
+  // A grade is "passing" at or above the assignment's passing grade
+  // (stored 0-100, attempt grades are 0-1 fractions); fall back to the 60%
+  // threshold this view uses elsewhere when no passing grade is configured.
+  const passThreshold =
+    data?.assignment.passingGrade != null
+      ? data.assignment.passingGrade / 100
+      : 0.6;
+  const isAttemptPassing = (grade: number | null) =>
+    grade !== null && grade >= passThreshold;
+
+  // Force-pass a single attempt. The insights payload is cached server-side for
+  // ~60s, so a refetch would return the stale grade and clobber the change;
+  // instead optimistically update the row in place (the backend set grade=100%
+  // and submitted=true). Admin-only; the button is hidden in author mode.
+  const handleForcePass = async (attemptId: number) => {
+    if (!sessionToken) return;
+    setPassError(null);
+    setPassingId(attemptId);
+    try {
+      await forcePassAttempt(sessionToken, attemptId);
+      setConfirmingPassId(null);
+      setData((prev) =>
+        prev
+          ? {
+              ...prev,
+              attempts: prev.attempts.map((a) =>
+                a.id === attemptId ? { ...a, grade: 1, submitted: true } : a,
+              ),
+            }
+          : prev,
+      );
+    } catch {
+      setPassError(attemptId);
+    } finally {
+      setPassingId(null);
+    }
+  };
 
   const formatCurrency = (amount: number | undefined | null) => {
     return new Intl.NumberFormat("en-US", {
@@ -1309,13 +1357,16 @@ export function AssignmentInsightsContent({
                           ))}
                       </div>
                     </TableHead>
+                    {isUserAdmin && (
+                      <TableHead className="text-right">Actions</TableHead>
+                    )}
                   </TableRow>
                 </TableHeader>
                 <TableBody>
                   {filteredAttempts.length === 0 ? (
                     <TableRow>
                       <TableCell
-                        colSpan={6}
+                        colSpan={isUserAdmin ? 6 : 5}
                         className="text-center py-8 text-muted-foreground"
                       >
                         No attempts match the current filters
@@ -1358,6 +1409,57 @@ export function AssignmentInsightsContent({
                             ? formatDuration(attempt.timeSpent)
                             : "N/A"}
                         </TableCell>
+                        {isUserAdmin && (
+                          <TableCell className="text-right">
+                            {isAttemptPassing(attempt.grade) ? (
+                              <span className="text-xs text-muted-foreground">
+                                —
+                              </span>
+                            ) : confirmingPassId === attempt.id ? (
+                              <div className="flex items-center justify-end gap-2">
+                                <span className="text-xs text-muted-foreground">
+                                  Pass this attempt at 100%?
+                                </span>
+                                <Button
+                                  variant="default"
+                                  size="sm"
+                                  disabled={passingId === attempt.id}
+                                  onClick={() => handleForcePass(attempt.id)}
+                                >
+                                  {passingId === attempt.id
+                                    ? "Passing…"
+                                    : "Confirm"}
+                                </Button>
+                                <Button
+                                  variant="ghost"
+                                  size="sm"
+                                  disabled={passingId === attempt.id}
+                                  onClick={() => setConfirmingPassId(null)}
+                                >
+                                  Cancel
+                                </Button>
+                              </div>
+                            ) : (
+                              <div className="flex items-center justify-end gap-2">
+                                {passError === attempt.id && (
+                                  <span className="text-xs text-red-600">
+                                    Failed. Try again.
+                                  </span>
+                                )}
+                                <Button
+                                  variant="outline"
+                                  size="sm"
+                                  onClick={() => {
+                                    setPassError(null);
+                                    setConfirmingPassId(attempt.id);
+                                  }}
+                                >
+                                  Force Pass
+                                </Button>
+                              </div>
+                            )}
+                          </TableCell>
+                        )}
                       </TableRow>
                     ))
                   )}

--- a/apps/web/components/insights/AssignmentInsightsContent.tsx
+++ b/apps/web/components/insights/AssignmentInsightsContent.tsx
@@ -346,6 +346,9 @@ export function AssignmentInsightsContent({
           : prev,
       );
     } catch {
+      // Leave confirm mode so the row falls back to the default action arm,
+      // which is the only place the "Failed. Try again." message renders.
+      setConfirmingPassId(null);
       setPassError(attemptId);
     } finally {
       setPassingId(null);

--- a/apps/web/components/insights/AssignmentInsightsContent.tsx
+++ b/apps/web/components/insights/AssignmentInsightsContent.tsx
@@ -1358,7 +1358,9 @@ export function AssignmentInsightsContent({
                       </div>
                     </TableHead>
                     {isUserAdmin && (
-                      <TableHead className="text-right">Actions</TableHead>
+                      <TableHead className="text-right w-[300px] whitespace-nowrap">
+                        Actions
+                      </TableHead>
                     )}
                   </TableRow>
                 </TableHeader>
@@ -1410,7 +1412,7 @@ export function AssignmentInsightsContent({
                             : "N/A"}
                         </TableCell>
                         {isUserAdmin && (
-                          <TableCell className="text-right">
+                          <TableCell className="text-right w-[300px] whitespace-nowrap">
                             {isAttemptPassing(attempt.grade) ? (
                               <span className="text-xs text-muted-foreground">
                                 —
@@ -1418,7 +1420,7 @@ export function AssignmentInsightsContent({
                             ) : confirmingPassId === attempt.id ? (
                               <div className="flex items-center justify-end gap-2">
                                 <span className="text-xs text-muted-foreground">
-                                  Pass this attempt at 100%?
+                                  Pass at 100%?
                                 </span>
                                 <Button
                                   variant="default"

--- a/apps/web/lib/shared.ts
+++ b/apps/web/lib/shared.ts
@@ -2227,3 +2227,42 @@ export async function removeFailedJob(
     },
   });
 }
+
+export interface ForcePassResult {
+  success: true;
+  attemptId: number;
+  grade: number;
+  submitted: boolean;
+  lti: {
+    attempted: boolean;
+    status: string | null;
+    message: string;
+  };
+}
+
+/**
+ * Admin action: manually pass a single attempt (set its grade + mark it
+ * submitted, force grading progress to COMPLETED, best-effort re-sync to the
+ * LMS). `gradePercent` is on the 0-100 scale; omit it to pass at 100%.
+ */
+export async function forcePassAttempt(
+  sessionToken: string,
+  attemptId: number,
+  gradePercent?: number,
+): Promise<ForcePassResult> {
+  const url = `${getBaseApiPath(
+    "v1",
+  )}/admin-dashboard/attempts/${encodeURIComponent(
+    String(attemptId),
+  )}/force-pass`;
+  return apiClient.post(
+    url,
+    gradePercent === undefined ? {} : { gradePercent },
+    {
+      headers: {
+        "Content-Type": "application/json",
+        "x-admin-token": sessionToken,
+      },
+    },
+  );
+}


### PR DESCRIPTION
<!-- This is helper text. It won't appear in the rendered output, but it will be visible when editing the Markdown file. -->

## **PR Description**
Adds an admin-only force-pass action that sets a learner attempt's grade, marks it submitted, forces grading progress to COMPLETED,
  best-effort re-syncs to the LMS, and surfaces it as a "Force Pass" button in the admin Assignment Insights attempts table.
### **Overview:**
Backend (apps/api)
  - New POST /v1/admin-dashboard/attempts/:attemptId/force-pass (AttemptAdminController, AdminGuard + throttle).
  - AttemptAdminService.forcePass(): in one txn sets grade (0-1) + submitted=true and upserts GradingProgress→COMPLETED; then
  best-effort LTI re-sync reusing the attempt's last authCookie; audit-logs admin + attempt + grade.
  - DTO gradePercent (0-100, optional, default 100). Wired LtiSyncModule into AdminModule. Spec covers 404, grade fraction, explicit
  grade, grading-progress, sync reuse, and sync-failure-still-passes (7 tests).

  Frontend (apps/web)
  - forcePassAttempt() helper in shared.ts.
  - "Force Pass" button in the Insights attempts table (admin-only), two-step inline confirm; optimistic row update on success; hidden
  for already-passing attempts.

  Caveats
  - LMS re-sync only fires if the attempt has a prior sync record with an auth cookie; otherwise grade is saved in Mark but not pushed
  (reported back). Reused cookie may be expired → sync can fail (still passes in Mark).
  - Insights are cached server-side per-pod for ~60s; other admins' analytics view can show the old grade until TTL expiry (TODO
  breadcrumb left in admin.service.ts). Acting admin sees it immediately via optimistic UI.
  - Endpoint lives under admin-dashboard/* (cookie + x-admin-token), not /admin/* (gateway JWT) — intentional, matches the dashboard
  auth path.
  
<!-- Select all that applies -->

#### **Type of Issue:**

- [ ] **Feature (`feat`)**: New functionality or feature added.
- [ ] **Bug Fix (`bug`)**: Issue or bug resolved.
- [ ] **Chore (`chore`)**: Maintenance, refactoring, or non-functional changes.
- [ ] **Documentation Update (`doc`)**: Documentation improvements or additions.

#### **Change Type:**

- [ ] **Major:** Significant changes that introduce new features, large refactoring, or breaking changes. Requires thorough review and testing.
- [ ] **Minor:** Small to medium changes, such as adding new functionality that is backward-compatible or minor refactoring. Moderate review needed.
- [ ] **Patch:** Bug fixes, small tweaks, or documentation updates. Light review is sufficient.

## Test Coverage
- [ ] Unit tests updated
- [ ] Manual verification done

Evidence:
<!-- commands, screenshots, GIFs if UI -->

## Impact / Risk
<!-- subsystems touched, breaking potential -->

## Rollback
<!-- git revert <sha> if needed or config toggle -->

## Reviewer Focus
<!-- specific files or logic to inspect -->