### PR TITLE
fix: improve 403 error messages to suggest logging into AWB

### DIFF
--- a/apps/web/components/AccessRestricted.tsx
+++ b/apps/web/components/AccessRestricted.tsx
@@ -9,8 +9,8 @@ export default function AccessRestricted() {
   return (
     <LearnerNotice
       title="You don’t have access to this assignment"
-      description="Make sure you’re signed in to the right account and opening it from your course. You may need a valid enrollment or instructor access."
-      footnote="Still stuck? Relaunch the assignment from your course."
+      description="Your session may have expired or you may not be logged in to Author Workbench. Try logging into AWB again, then relaunch the assignment from your course."
+      footnote="Still stuck? Make sure you’re signed in to the right account and that you have a valid enrollment or instructor access."
     />
   );
 }

--- a/apps/web/lib/api-client.ts
+++ b/apps/web/lib/api-client.ts
@@ -170,7 +170,7 @@ export class APIClient {
             );
           } else if (response.status === 403) {
             toast.error(
-              `Forbidden: You don't have permission to access this Assessment.`,
+              `Access denied. Try logging into AWB again and relaunching the assignment.`,
             );
           } else {
             toast.error(

--- a/apps/web/lib/api-client.ts
+++ b/apps/web/lib/api-client.ts
@@ -170,7 +170,7 @@ export class APIClient {
             );
           } else if (response.status === 403) {
             toast.error(
-              `You don't have permission to access this. Try logging into AWB again and relaunching the assignment.`,
+              `You don't have permission to access this. Possibly try logging into AWB again and relaunching the assignment.`,
             );
           } else {
             toast.error(

--- a/apps/web/lib/api-client.ts
+++ b/apps/web/lib/api-client.ts
@@ -170,7 +170,7 @@ export class APIClient {
             );
           } else if (response.status === 403) {
             toast.error(
-              `Access denied. Try logging into AWB again and relaunching the assignment.`,
+              `You don't have permission to access this. Try logging into AWB again and relaunching the assignment.`,
             );
           } else {
             toast.error(


### PR DESCRIPTION
## What

Updates the 403 error messages shown to users when they don't have access to an assignment.

- **`AccessRestricted.tsx`**: description now leads with a suggestion to log into AWB and relaunch the assignment, rather than generic enrollment guidance.
- **`api-client.ts`** toast: changed from a bare "Forbidden" message to one that retains the permission context and prompts the user to try logging into AWB again.

## Why

The previous messages gave no actionable guidance for the most common cause — the user's AWB session having expired or not being active. Users were left with no clear next step.