### PR TITLE
fix: stop propagation on duplicate and delete buttons to prevent moda…

### DIFF
--- a/apps/web/app/author/(components)/AuthorQuestionsPage/Question.tsx
+++ b/apps/web/app/author/(components)/AuthorQuestionsPage/Question.tsx
@@ -997,7 +997,8 @@ const Question: FC<QuestionProps> = ({
 
               <button
                 className="text-gray-500"
-                onClick={() => {
+                onClick={(e) => {
+                  e.stopPropagation();
                   try {
                     duplicateThisQuestion(question);
                   } catch (error) {
@@ -1010,7 +1011,10 @@ const Question: FC<QuestionProps> = ({
 
               <button
                 className="text-gray-500"
-                onClick={() => setToggleDeleteConfirmation(true)}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setToggleDeleteConfirmation(true);
+                }}
               >
                 <TrashIcon width={20} height={20} />
               </button>


### PR DESCRIPTION
Clicking the trash or duplicate button on an unfocused question caused the click to bubble up to the parent `handleFocus` wrapper. This triggered a Zustand store update, which re-rendered the parent and remounted the `Question` component (since `SortableItem` is defined inside the parent), destroying local state like `toggleDeleteConfirmation` before the modal could appear.

Added `e.stopPropagation()` to both buttons to prevent the bubble.