### PR TITLE
fix: prevent interactive child clicks from triggering question focus …

### DIFF
--- a/apps/web/app/author/(components)/AuthorQuestionsPage/index.tsx
+++ b/apps/web/app/author/(components)/AuthorQuestionsPage/index.tsx
@@ -713,7 +713,10 @@ const AuthorQuestionsPage: FC<Props> = ({
                 ? "border-1 border-violet-600 shadow-md"
                 : "shadow-sm"
             }`}
-            onClick={() => handleFocus(question.id)}
+            onClick={(e) => {
+              if ((e.target as HTMLElement).closest('button, input, textarea, select, a, [role="button"], [role="combobox"], [role="listbox"], [contenteditable]')) return;
+              handleFocus(question.id);
+            }}
           >
             <div className="absolute flex self-center max-w-8 w-8 px-2 left-0">
               <div

--- a/apps/web/app/learner/(components)/Question/QuestionContainer.tsx
+++ b/apps/web/app/learner/(components)/Question/QuestionContainer.tsx
@@ -260,8 +260,9 @@ function Component(props: Props) {
   return (
     <section
       id={`item-${questionNumber}`}
-      onClick={() => {
+      onClick={(e) => {
         if (questionDisplay === "ALL_PER_PAGE") {
+          if ((e.target as HTMLElement).closest('button, input, textarea, select, a, [role="button"], [role="combobox"], [role="listbox"], [contenteditable]')) return;
           setActiveQuestionNumber(questionNumber);
         }
       }}


### PR DESCRIPTION
Clicking buttons, inputs, or other interactive elements inside a question card was bubbling up to the card's `onClick` handler, causing the focused question to change unexpectedly.

Fixed by guarding the `onClick` on both the quiz editor question card (`AuthorQuestionsPage`) and the learner question container (`QuestionContainer`) — clicks originating from interactive elements (`button`, `input`, `textarea`, `select`, `a`, ARIA roles) are ignored so only direct clicks on the card background trigger focus/selection.