### PR TITLE
fix(export): include answer choices in quiz CSV export

### DIFF
--- a/apps/web/app/author/[assignmentId]/review/page.tsx
+++ b/apps/web/app/author/[assignmentId]/review/page.tsx
@@ -1245,9 +1245,18 @@ function Component() {
 
     if (data.questions) {
       csv += "Questions\n";
-      csv += "Type,Question,Response Type,Total Points\n";
+      csv += "Type,Question,Response Type,Total Points,Answer Choices\n";
       data.questions.forEach((q: any) => {
-        csv += `${q.type},"${q.question?.replace(/"/g, '""') || ""}",${q.responseType},${q.totalPoints}\n`;
+        const choices =
+          q.choices && q.choices.length > 0
+            ? q.choices
+                .map(
+                  (c: any, i: number) =>
+                    `${i + 1}. ${c.choice}${c.isCorrect ? " [Correct]" : ""}`,
+                )
+                .join(" | ")
+            : "";
+        csv += `${q.type},"${q.question?.replace(/"/g, '""') || ""}",${q.responseType},${q.totalPoints},"${choices.replace(/"/g, '""')}"\n`;
       });
     }
 


### PR DESCRIPTION
## Summary

- The CSV export was silently dropping the Answer Choices column — selecting "Question Choices" in the export modal had no effect on the CSV output
- Added a 5th column (`Answer Choices`) to the CSV header and populated it with each choice formatted as `1. text [Correct] | 2. text | 3. text`
- Free-response questions (no choices) get an empty cell in that column

## Test plan

- [ ] Open an assignment with multiple-choice questions
- [ ] Export as CSV with "Question Choices" checked — confirm new `Answer Choices` column appears with correct labels and `[Correct]` markers
- [ ] Export with "Question Choices" unchecked — column is present but empty
- [ ] Export a free-response question — Answer Choices cell is empty, no errors