### PR TITLE
feat: show generate and import buttons in empty questions state

### DIFF
--- a/apps/web/app/author/(components)/AuthorQuestionsPage/index.tsx
+++ b/apps/web/app/author/(components)/AuthorQuestionsPage/index.tsx
@@ -1375,9 +1375,36 @@ const AuthorQuestionsPage: FC<Props> = ({
                     </div>
                   )}
                 </div>
+
+                <button
+                  onClick={() => setFileUploadModalOpen(true)}
+                  className="px-4 py-2 border border-gray-300 rounded-lg hover:shadow-md transition-all justify-center flex duration-300 ease-in-out w-full text-sm font-medium bg-white text-gray-700 hover:bg-violet-100 hover:text-violet-600"
+                >
+                  <span className="flex items-center gap-2 text-wrap">
+                    <div className="flex items-center gap-1">
+                      <SparklesIcon className="w-4 h-4 text-violet-600" />
+                    </div>
+                    <span className="text-sm font-medium">
+                      Generate Questions using AI (Beta)
+                    </span>
+                  </span>
+                </button>
+
+                <button
+                  onClick={() => setIsImportModalOpen(true)}
+                  className="px-4 py-2 border border-gray-300 rounded-lg hover:shadow-sm transition-all justify-center flex duration-300 ease-in-out w-full text-sm font-medium bg-white text-gray-700 hover:bg-violet-50 hover:text-violet-600"
+                >
+                  <span className="flex items-center gap-2 text-wrap">
+                    <div className="flex items-center gap-1">
+                      <DocumentArrowDownIcon className="w-4 h-4 text-violet-600" />
+                    </div>
+                    <span className="text-sm font-medium">
+                      Import Questions (Beta)
+                    </span>
+                  </span>
+                </button>
               </>
             )}
-
           </div>
         </div>
       </div>

--- a/apps/web/app/author/(components)/AuthorQuestionsPage/index.tsx
+++ b/apps/web/app/author/(components)/AuthorQuestionsPage/index.tsx
@@ -1274,6 +1274,31 @@ const AuthorQuestionsPage: FC<Props> = ({
                 </Transition>
               </Menu>
             </div>
+
+            {questions.length === 0 && (
+              <>
+                <div className="bg-white w-fit whitespace-nowrap border-gray-200 border border-solid shadow-sm hover:shadow-md rounded-md flex justify-center items-center">
+                  <button
+                    type="button"
+                    className="hover:no-underline text-gray-600 hover:text-gray-600 typography-btn px-4 py-2 focus:ring-offset-2 focus:ring-violet-600 focus:ring-2 focus:outline-none rounded-md focus:rounded-md bg-white hover:bg-gray-100 ring-offset-white flex items-center gap-2"
+                    onClick={() => setFileUploadModalOpen(true)}
+                  >
+                    <SparklesIcon className="w-4 h-4 text-violet-600" />
+                    Generate Questions using AI (Beta)
+                  </button>
+                </div>
+                <div className="bg-white w-fit whitespace-nowrap border-gray-200 border border-solid shadow-sm hover:shadow-md rounded-md flex justify-center items-center">
+                  <button
+                    type="button"
+                    className="hover:no-underline text-gray-600 hover:text-gray-600 typography-btn px-4 py-2 focus:ring-offset-2 focus:ring-violet-600 focus:ring-2 focus:outline-none rounded-md focus:rounded-md bg-white hover:bg-gray-100 ring-offset-white flex items-center gap-2"
+                    onClick={() => setIsImportModalOpen(true)}
+                  >
+                    <DocumentArrowDownIcon className="w-4 h-4 text-violet-600" />
+                    Import Questions (Beta)
+                  </button>
+                </div>
+              </>
+            )}
           </div>
         </div>
 
@@ -1350,36 +1375,9 @@ const AuthorQuestionsPage: FC<Props> = ({
                     </div>
                   )}
                 </div>
-
-                <button
-                  onClick={() => setFileUploadModalOpen(true)}
-                  className="px-4 py-2 border border-gray-300 rounded-lg hover:shadow-md transition-all justify-center flex duration-300 ease-in-out w-full text-sm font-medium bg-white text-gray-700 hover:bg-violet-100 hover:text-violet-600"
-                >
-                  <span className="flex items-center gap-2 text-wrap">
-                    <div className="flex items-center gap-1">
-                      <SparklesIcon className="w-4 h-4 text-violet-600" />
-                    </div>
-                    <span className="text-sm font-medium">
-                      Generate Questions using AI (Beta)
-                    </span>
-                  </span>
-                </button>
-
-                <button
-                  onClick={() => setIsImportModalOpen(true)}
-                  className="px-4 py-2 border border-gray-300 rounded-lg hover:shadow-sm transition-all justify-center flex duration-300 ease-in-out w-full text-sm font-medium bg-white text-gray-700 hover:bg-violet-50 hover:text-violet-600"
-                >
-                  <span className="flex items-center gap-2 text-wrap">
-                    <div className="flex items-center gap-1">
-                      <DocumentArrowDownIcon className="w-4 h-4 text-violet-600" />
-                    </div>
-                    <span className="text-sm font-medium">
-                      Import Questions (Beta)
-                    </span>
-                  </span>
-                </button>
               </>
             )}
+
           </div>
         </div>
       </div>


### PR DESCRIPTION
Shows **Generate Questions using AI (Beta)** and **Import Questions (Beta)** inline with the **Add Question** button when the questions tab is empty. All three use the same button style (border, shadow, typography). The two extra buttons disappear once any question is added.