### PR TITLE
Fix: Provide Mark Chatbot with app/session context

### DIFF
--- a/apps/web/app/chatbot/store/useMarkChatStore.ts
+++ b/apps/web/app/chatbot/store/useMarkChatStore.ts
@@ -277,8 +277,12 @@ export const useMarkChatStore = create<MarkChatState>()(
           // so history reloads and post-refresh sessions restore tool access correctly.
           const conversationMessages: ChatMessage[] = [];
           for (const msg of conversation) {
-            if (msg.role === "system" && msg.id.includes("context")) continue;
-
+            // NOTE: do NOT drop `system-context-*` messages here. The backend
+            // (mark-chat.service.getSystemPromptParts) keys on
+            // `role === "system" && id.includes("context")` to build the LLM
+            // system prompt and detect assignment mode/id. Stripping them blinds
+            // the chatbot to the current app/session (assignment, question,
+            // responses, feedback). See useLearnerContext/useAuthorContext.
             if (
               msg.role === "user" &&
               msg.toolCalls?.type === "file_attachments"


### PR DESCRIPTION
<!-- This is helper text. It won't appear in the rendered output, but it will be visible when editing the Markdown file. -->

## **PR Description**
Mark stopped "seeing" the assignment you're working on, answering as if it had no idea what question, attempt, or feedback was on screen. This fixes a one-line regression that dropped the context message before it reached the backend.

### **Overview:**
useMarkChatStore.sendMessage was dropping the system-context-* message (the one carrying the live assignment/session info) before sending. It was likely an accidental carryover from #284's file-upload loop.

Fix: Removed that one line so the context message is sent again; file handling is untouched.

<!-- Select all that applies -->

#### **Type of Issue:**

- [ ] **Feature (`feat`)**: New functionality or feature added.
- [x] **Bug Fix (`bug`)**: Issue or bug resolved.
- [ ] **Chore (`chore`)**: Maintenance, refactoring, or non-functional changes.
- [ ] **Documentation Update (`doc`)**: Documentation improvements or additions.

#### **Change Type:**

- [ ] **Major:** Significant changes that introduce new features, large refactoring, or breaking changes. Requires thorough review and testing.
- [x] **Minor:** Small to medium changes, such as adding new functionality that is backward-compatible or minor refactoring. Moderate review needed.
- [ ] **Patch:** Bug fixes, small tweaks, or documentation updates. Light review is sufficient.

## Test Coverage
- [ ] Unit tests updated
- [x] Manual verification done

Evidence:
<!-- commands, screenshots, GIFs if UI -->

## Impact / Risk
<!-- subsystems touched, breaking potential -->

## Rollback
<!-- git revert <sha> if needed or config toggle -->

## Reviewer Focus
<!-- specific files or logic to inspect -->