### PR TITLE
fix: reject publishing assignments whose numberOfQuestionsPerAttempt exceeds the question pool

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": null,
     "lines": null
   },
-  "generated_at": "2026-06-30T17:55:57Z",
+  "generated_at": "2026-07-03T20:33:55Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -645,7 +645,7 @@
       }
     ]
   },
-  "version": "0.13.1+ibm.62.dss",
+  "version": "0.13.1+ibm.64.dss",
   "word_list": {
     "file": null,
     "hash": null

--- a/apps/api/src/api/assignment/v2/services/__tests__/version-management.service.spec.ts
+++ b/apps/api/src/api/assignment/v2/services/__tests__/version-management.service.spec.ts
@@ -388,6 +388,139 @@ describe("VersionManagementService", () => {
     });
   });
 
+  describe("question-pool validation", () => {
+    const authorSession = {
+      userId: "author@example.com",
+      role: UserRole.AUTHOR,
+    } as never;
+
+    const buildAssignmentWithPool = (
+      numberOfQuestionsPerAttempt: number | null,
+      questionCount: number,
+    ) => ({
+      id: 1,
+      currentVersionId: null,
+      name: "Assignment",
+      numberOfQuestionsPerAttempt,
+      questionOrder: [],
+      questions: Array.from({ length: questionCount }, (_, index) => ({
+        id: index + 1,
+        totalPoints: 5,
+        authorComment: null,
+        type: "SINGLE_CORRECT",
+        responseType: "OTHER",
+        question: `Question ${index + 1}`,
+        maxWords: null,
+        scoring: null,
+        choices: null,
+        randomizedChoices: false,
+        answer: null,
+        gradingContextQuestionIds: [],
+        maxCharacters: null,
+        videoPresentationConfig: null,
+        liveRecordingConfig: null,
+      })),
+      versions: [],
+    });
+
+    it("createVersion rejects a non-draft version when numberOfQuestionsPerAttempt exceeds the pool", async () => {
+      mockPrismaService.assignment.findUnique.mockResolvedValue(
+        buildAssignmentWithPool(15, 5),
+      );
+
+      await expect(
+        service.createVersion(
+          1,
+          {
+            versionNumber: "1.0.0",
+            versionDescription: "v1",
+            isDraft: false,
+            shouldActivate: true,
+          },
+          authorSession,
+        ),
+      ).rejects.toThrow(BadRequestException);
+      expect(mockPrismaService.$transaction).not.toHaveBeenCalled();
+    });
+
+    it("createVersion allows a draft version even when the pool is too small", async () => {
+      mockPrismaService.assignment.findUnique.mockResolvedValue(
+        buildAssignmentWithPool(15, 5),
+      );
+      mockPrismaService.assignmentVersion.findFirst.mockResolvedValue(null);
+      const tx = {
+        assignmentVersion: {
+          create: jest.fn().mockResolvedValue({
+            id: 10,
+            versionNumber: "1.0.0",
+            versionDescription: "draft",
+            isDraft: true,
+            isActive: false,
+            published: false,
+            createdBy: "author@example.com",
+            createdAt: new Date(),
+          }),
+        },
+        questionVersion: { create: jest.fn().mockResolvedValue({ id: 100 }) },
+        versionHistory: { create: jest.fn().mockResolvedValue({}) },
+      };
+      mockPrismaService.$transaction.mockImplementation(async (callback) =>
+        callback(tx),
+      );
+
+      await expect(
+        service.createVersion(
+          1,
+          {
+            versionNumber: "1.0.0",
+            versionDescription: "draft",
+            isDraft: true,
+            shouldActivate: false,
+          },
+          authorSession,
+        ),
+      ).resolves.toBeDefined();
+    });
+
+    it("publishVersion rejects when the version's numberOfQuestionsPerAttempt exceeds its snapshot pool", async () => {
+      const version = {
+        id: 20,
+        assignmentId: 1,
+        versionNumber: "1.0.0",
+        versionDescription: "v1",
+        published: false,
+        isDraft: true,
+        isActive: false,
+        createdBy: "author@example.com",
+        createdAt: new Date(),
+        numberOfQuestionsPerAttempt: 15,
+        _count: { questionVersions: 5 },
+      };
+      mockPrismaService.assignmentVersion.findUnique.mockResolvedValue(version);
+      mockPrismaService.assignmentVersion.findFirst.mockResolvedValue(null);
+      // Functional tx so the un-guarded flow completes; the guard must reject
+      // before the transaction ever runs.
+      const tx = {
+        assignmentVersion: {
+          update: jest
+            .fn()
+            .mockResolvedValue({ ...version, published: true, isActive: true }),
+          updateMany: jest.fn().mockResolvedValue({ count: 0 }),
+        },
+        assignment: { update: jest.fn().mockResolvedValue({}) },
+        versionHistory: { create: jest.fn().mockResolvedValue({}) },
+      };
+      mockPrismaService.$transaction.mockImplementation(async (callback) =>
+        callback(tx),
+      );
+
+      await expect(
+        service.publishVersion(1, 20, { userSession: authorSession }),
+      ).rejects.toThrow(BadRequestException);
+      expect(tx.assignmentVersion.update).not.toHaveBeenCalled();
+    });
+  });
+
   describe("question ordering in version snapshots", () => {
     const mockUserSession = {
       userId: "user123",

--- a/apps/api/src/api/assignment/v2/services/assignment.service.ts
+++ b/apps/api/src/api/assignment/v2/services/assignment.service.ts
@@ -1,4 +1,5 @@
 import {
+  BadRequestException,
   ConflictException,
   Inject,
   Injectable,
@@ -286,6 +287,32 @@ export class AssignmentServiceV2 implements OnModuleDestroy {
     this.logger.info(
       `📦 PUBLISH REQUEST: Received updateDto with versionNumber: ${updateDto.versionNumber}, versionDescription: ${updateDto.versionDescription}`,
     );
+
+    // Reject configurations no learner could ever start: asking for more
+    // questions per attempt than the pool contains makes attempt creation
+    // throw for everyone (see AttemptSubmissionService.createAssignmentAttempt).
+    // Validated again at version-snapshot time in VersionManagementService for
+    // paths that bypass this handler.
+    const requestedPerAttempt = updateDto.numberOfQuestionsPerAttempt;
+    if (requestedPerAttempt && requestedPerAttempt > 0 && updateDto.questions) {
+      const availableQuestions = updateDto.questions.filter(
+        (question) => !question.isDeleted,
+      ).length;
+      if (requestedPerAttempt > availableQuestions) {
+        this.logger.warn(
+          `Publish rejected: numberOfQuestionsPerAttempt exceeds question pool`,
+          {
+            assignmentId,
+            requestedPerAttempt,
+            availableQuestions,
+            requestedByUserId: userId,
+          },
+        );
+        throw new BadRequestException(
+          `numberOfQuestionsPerAttempt (${requestedPerAttempt}) exceeds the number of available questions (${availableQuestions}). Reduce it or add more questions before publishing.`,
+        );
+      }
+    }
 
     // Deterministic per-assignment publish job id. BullMQ silently no-ops a
     // duplicate `add` when {jobId} matches an in-flight job, so this gives us

--- a/apps/api/src/api/assignment/v2/services/version-management.service.ts
+++ b/apps/api/src/api/assignment/v2/services/version-management.service.ts
@@ -177,6 +177,29 @@ export class VersionManagementService {
       );
     }
 
+    // A non-draft version is what learners get served. If it demands more
+    // questions per attempt than the pool holds, attempt creation throws for
+    // every learner (see AttemptSubmissionService.createAssignmentAttempt),
+    // so fail the snapshot instead. Drafts stay editable mid-authoring.
+    if (
+      !createVersionDto.isDraft &&
+      assignment.numberOfQuestionsPerAttempt &&
+      assignment.numberOfQuestionsPerAttempt > assignment.questions.length
+    ) {
+      this.logger.warn(
+        `Version creation rejected: numberOfQuestionsPerAttempt exceeds question pool`,
+        {
+          assignmentId,
+          numberOfQuestionsPerAttempt: assignment.numberOfQuestionsPerAttempt,
+          availableQuestions: assignment.questions.length,
+          userId: userSession.userId,
+        },
+      );
+      throw new BadRequestException(
+        `numberOfQuestionsPerAttempt (${assignment.numberOfQuestionsPerAttempt}) exceeds the number of available questions (${assignment.questions.length}). Reduce it or add more questions before publishing.`,
+      );
+    }
+
     let versionNumber: string;
 
     if (createVersionDto.versionNumber) {
@@ -808,6 +831,28 @@ export class VersionManagementService {
     if (version.published) {
       throw new BadRequestException(
         `Version ${version.versionNumber} is already published`,
+      );
+    }
+
+    // Same invariant as createVersion, but against this version's own
+    // snapshot: publishing a version whose numberOfQuestionsPerAttempt
+    // exceeds its snapshotted pool would make it unstartable for learners.
+    if (
+      version.numberOfQuestionsPerAttempt &&
+      version.numberOfQuestionsPerAttempt > version._count.questionVersions
+    ) {
+      this.logger.warn(
+        `Publish rejected: version's numberOfQuestionsPerAttempt exceeds its question pool`,
+        {
+          assignmentId,
+          versionId,
+          numberOfQuestionsPerAttempt: version.numberOfQuestionsPerAttempt,
+          availableQuestions: version._count.questionVersions,
+          userId: userSession?.userId,
+        },
+      );
+      throw new BadRequestException(
+        `numberOfQuestionsPerAttempt (${version.numberOfQuestionsPerAttempt}) exceeds the number of questions in this version (${version._count.questionVersions}). Reduce it or add more questions before publishing.`,
       );
     }
 

--- a/apps/api/src/api/assignment/v2/tests/unit/services/assignment.service.spec.ts
+++ b/apps/api/src/api/assignment/v2/tests/unit/services/assignment.service.spec.ts
@@ -3,6 +3,7 @@
 /* eslint-disable unicorn/no-useless-undefined */
 /* eslint-disable @typescript-eslint/unbound-method */
 
+import { BadRequestException } from "@nestjs/common";
 import { Test, TestingModule } from "@nestjs/testing";
 import { QuestionType } from "@prisma/client";
 import { WINSTON_MODULE_PROVIDER } from "nest-winston";
@@ -281,6 +282,46 @@ describe("AssignmentServiceV2 – full unit-suite", () => {
         status: "Failed",
         progress: "Failed to enqueue publish job: fail",
       });
+    });
+  });
+
+  describe("publishAssignment question-pool validation", () => {
+    it("rejects publish when numberOfQuestionsPerAttempt exceeds the question pool", async () => {
+      const dto = createMockUpdateAssignmentQuestionsDto({
+        numberOfQuestionsPerAttempt: 15,
+      });
+
+      await expect(
+        service.publishAssignment(1, dto, "author-123"),
+      ).rejects.toThrow(BadRequestException);
+      expect(jobStatusService.createPublishJob).not.toHaveBeenCalled();
+      expect(jobQueueService.enqueue).not.toHaveBeenCalled();
+    });
+
+    it("counts only non-deleted questions when validating the pool", async () => {
+      const dto = createMockUpdateAssignmentQuestionsDto({
+        numberOfQuestionsPerAttempt: 2,
+        questions: [
+          createMockQuestionDto(),
+          createMockQuestionDto({ id: 2, isDeleted: true }),
+        ],
+      });
+
+      await expect(
+        service.publishAssignment(1, dto, "author-123"),
+      ).rejects.toThrow(BadRequestException);
+      expect(jobQueueService.enqueue).not.toHaveBeenCalled();
+    });
+
+    it("allows publish when numberOfQuestionsPerAttempt is within the pool", async () => {
+      const dto = createMockUpdateAssignmentQuestionsDto({
+        numberOfQuestionsPerAttempt: 2,
+      });
+
+      const response = await service.publishAssignment(1, dto, "author-123");
+
+      expect(response).toEqual({ jobId: 1, message: "Publishing started" });
+      expect(jobQueueService.enqueue).toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION


Publishing an assignment configured to serve more questions per attempt than its pool contains made attempt creation throw for every learner ('Not enough questions available'). Validate at the three authoring chokepoints:

- publishAssignment: reject the payload before enqueueing the publish job
- createVersion: reject non-draft snapshots that exceed the non-deleted pool
- publishVersion: reject draft promotions whose snapshot pool is too small

Drafts remain saveable mid-authoring, and 0/null still means 'use all questions', so existing authoring clients are unaffected.
