### PR TITLE
Normalize random subset counts

### DIFF
--- a/apps/web/app/Helpers/checkQuestionsReady.ts
+++ b/apps/web/app/Helpers/checkQuestionsReady.ts
@@ -346,7 +346,8 @@ export const useQuestionsAreReadyToBePublished = (
       }
       if (
         !assignmentConfig.displayOrder &&
-        assignmentConfig.numberOfQuestionsPerAttempt !== null
+        assignmentConfig.numberOfQuestionsPerAttempt !== null &&
+        assignmentConfig.numberOfQuestionsPerAttempt !== undefined
       ) {
         message = `Question order is required.`;
         debugLog(message);

--- a/apps/web/app/author/(components)/AuthorQuestionsPage/index.tsx
+++ b/apps/web/app/author/(components)/AuthorQuestionsPage/index.tsx
@@ -998,6 +998,9 @@ const AuthorQuestionsPage: FC<Props> = ({
       updatedQuestions.forEach((q, index) => {
         q.index = index + 1;
       });
+      const activeQuestionCount = updatedQuestions.filter(
+        (question) => !question.isDeleted,
+      ).length;
 
       setQuestions(updatedQuestions);
       useAuthorStore
@@ -1081,9 +1084,31 @@ const AuthorQuestionsPage: FC<Props> = ({
             settingsUpdated = true;
           }
           if (assignmentData.config.numberOfQuestionsPerAttempt !== undefined) {
+            const importedQuestionsPerAttempt =
+              assignmentData.config.numberOfQuestionsPerAttempt;
+            const normalizedQuestionsPerAttempt =
+              typeof importedQuestionsPerAttempt === "number" &&
+              importedQuestionsPerAttempt > activeQuestionCount
+                ? activeQuestionCount > 0
+                  ? activeQuestionCount
+                  : null
+                : importedQuestionsPerAttempt;
+
             configStore.setNumberOfQuestionsPerAttempt(
-              assignmentData.config.numberOfQuestionsPerAttempt,
+              normalizedQuestionsPerAttempt,
             );
+            if (
+              typeof importedQuestionsPerAttempt === "number" &&
+              importedQuestionsPerAttempt !== normalizedQuestionsPerAttempt
+            ) {
+              const normalizedLabel =
+                normalizedQuestionsPerAttempt === null
+                  ? "unlimited"
+                  : normalizedQuestionsPerAttempt;
+              toast.warning(
+                `Questions per attempt was reduced from ${importedQuestionsPerAttempt} to ${normalizedLabel} because only ${activeQuestionCount} active question(s) are available.`,
+              );
+            }
             settingsUpdated = true;
           }
           if (assignmentData.config.displayOrder !== undefined) {

--- a/apps/web/app/author/(components)/Header/index.tsx
+++ b/apps/web/app/author/(components)/Header/index.tsx
@@ -562,6 +562,30 @@ function AuthorHeader() {
     removeEphemeralFields(clonedOriginalQuestions);
 
     clonedCurrentQuestions = calculateTotalPoints(clonedCurrentQuestions);
+    const activeQuestionCount = clonedCurrentQuestions.filter(
+      (question) => !question.isDeleted,
+    ).length;
+
+    const normalizedQuestionsPerAttempt =
+      typeof numberOfQuestionsPerAttempt === "number" &&
+      numberOfQuestionsPerAttempt > activeQuestionCount
+        ? activeQuestionCount > 0
+          ? activeQuestionCount
+          : null
+        : numberOfQuestionsPerAttempt;
+
+    if (normalizedQuestionsPerAttempt !== numberOfQuestionsPerAttempt) {
+      useAssignmentConfig
+        .getState()
+        .setNumberOfQuestionsPerAttempt?.(normalizedQuestionsPerAttempt);
+      const normalizedLabel =
+        normalizedQuestionsPerAttempt === null
+          ? "unlimited"
+          : normalizedQuestionsPerAttempt;
+      toast.warning(
+        `Questions per attempt was reduced from ${numberOfQuestionsPerAttempt} to ${normalizedLabel} because only ${activeQuestionCount} active question(s) are available.`,
+      );
+    }
 
     const questionsAreDifferent =
       JSON.stringify(clonedCurrentQuestions) !==
@@ -596,7 +620,7 @@ function AuthorHeader() {
       showQuestionScore,
       showAssignmentScore,
       correctAnswerVisibility,
-      numberOfQuestionsPerAttempt,
+      numberOfQuestionsPerAttempt: normalizedQuestionsPerAttempt,
       requireAllQuestions,
       optionalQuestionIds,
       questionControls,

--- a/apps/web/app/author/(components)/StepTwo/AssignmentQuestionOrder.tsx
+++ b/apps/web/app/author/(components)/StepTwo/AssignmentQuestionOrder.tsx
@@ -38,7 +38,9 @@ const Component: FC<Props> = ({ compact }) => {
     setSelectedRandomQuestions(true);
   }
 
-  const totalQuestions = useAuthorStore((s) => s.questions).length;
+  const totalQuestions = useAuthorStore(
+    (s) => s.questions.filter((question) => !question.isDeleted).length,
+  );
 
   const [popupMessage, setPopupMessage] = useState("");
   const [showPopup, setShowPopup] = useState(false);

--- a/apps/web/config/types.ts
+++ b/apps/web/config/types.ts
@@ -514,6 +514,7 @@ export interface Question extends CreateQuestionRequest {
   variants?: QuestionVariants[];
   authorComment?: string;
   randomizedChoices?: boolean;
+  isDeleted?: boolean;
   alreadyInBackend?: boolean;
   videoPresentationConfig?: videoPresentationConfig;
   liveRecordingConfig?: LiveRecordingConfig;

--- a/apps/web/stores/assignmentConfig.ts
+++ b/apps/web/stores/assignmentConfig.ts
@@ -14,7 +14,7 @@ type GradingDataActions = {
   setQuestionDisplay: (questionDisplay: QuestionDisplayType) => void;
   questionVariationNumber: number;
   setNumberOfQuestionsPerAttempt?: (
-    numberOfQuestionsPerAttempt: number | undefined,
+    numberOfQuestionsPerAttempt: number | null | undefined,
   ) => void;
   setQuestionVariationNumber: (questionVariationNumber: number) => void;
   setGraded: (graded: boolean) => void;


### PR DESCRIPTION
## Summary
- Normalize imported and publish-time random subset counts to the active question count.
- Avoid blocking publication when imported counts are stale after question deletion.

## Verification
- Pre-commit lint/build passed.