### PR TITLE
fix(attempt): show the grade in author preview when learner score is hidden

### DIFF
--- a/apps/api/src/api/attempt/services/attempt-submission.service.spec.ts
+++ b/apps/api/src/api/attempt/services/attempt-submission.service.spec.ts
@@ -948,6 +948,48 @@ describe("AttemptSubmissionService - Grading Validation", () => {
       );
     });
 
+    it("returns the grade even when showAssignmentScore is false", async () => {
+      // The author is testing their own quiz: hiding the learner-facing score
+      // must not hide the preview grade, otherwise a perfect run renders as 0%.
+      mockPrisma.assignment.findUnique.mockResolvedValue({
+        id: assignmentId,
+        questions: [],
+        currentVersion: { correctAnswerVisibility: "NEVER" },
+        showAssignmentScore: false,
+        showQuestions: true,
+        showSubmissionFeedback: true,
+      });
+
+      const updateDto = {
+        submitted: true,
+        language: "en",
+        responsesForQuestions: [{ id: 1, question: "Preview response" }],
+        authorQuestions: [{ id: 1, totalPoints: 1 }],
+      };
+
+      mockQuestionResponseService.submitQuestions.mockResolvedValue([
+        makeResponse({ questionId: 1, totalPoints: 1, metadata: undefined }),
+      ]);
+      mockGradingService.calculateGradeForAuthor.mockReturnValue({
+        grade: 1,
+        totalPointsEarned: 1,
+        totalPossiblePoints: 1,
+      });
+
+      const result = await service.updateAssignmentAttempt(
+        -1,
+        assignmentId,
+        updateDto as UpdateAttemptDto,
+        "",
+        false,
+        authorRequest as UpdateAttemptRequest,
+      );
+
+      expect(result.grade).toBe(1);
+      expect(result.totalPointsEarned).toBe(1);
+      expect(result.totalPossiblePoints).toBe(1);
+    });
+
     it("throws when preview responses reference questions missing from provided draft questions", async () => {
       const updateDto = {
         submitted: true,

--- a/apps/api/src/api/attempt/services/attempt-submission.service.ts
+++ b/apps/api/src/api/attempt/services/attempt-submission.service.ts
@@ -1241,7 +1241,10 @@ export class AttemptSubmissionService {
         success: true,
         totalPointsEarned,
         totalPossiblePoints,
-        grade: assignment.showAssignmentScore ? grade : undefined,
+        // showAssignmentScore hides the score from learners, not from the
+        // author previewing their own quiz — withholding it here made the
+        // success page render a null grade as 0% / Failed.
+        grade,
         showQuestions: assignment.showQuestions,
         showSubmissionFeedback: assignment.showSubmissionFeedback,
         correctAnswerVisibility:

--- a/apps/web/app/learner/(components)/Header.tsx
+++ b/apps/web/app/learner/(components)/Header.tsx
@@ -341,6 +341,10 @@ function LearnerHeader() {
         setTotalPointsPossible(res.totalPossiblePoints);
         if (grade !== undefined) {
           setGrade(grade * 100);
+        } else {
+          // No grade on this submission (score hidden): clear any grade left
+          // from a previous attempt so the success page doesn't show it.
+          setGrade(null);
         }
         if (role === "learner") {
           setShowSubmissionFeedback(res.showSubmissionFeedback);

--- a/apps/web/app/learner/[assignmentId]/successPage/[submissionId]/page.tsx
+++ b/apps/web/app/learner/[assignmentId]/successPage/[submissionId]/page.tsx
@@ -15,6 +15,7 @@ import {
   getUser,
   submitFeedback,
 } from "@/lib/talkToBackend";
+import { resolveStoreGrade } from "@/lib/gradeDisplay";
 import Crown from "@/public/Crown.svg";
 import { useAssignmentDetails, useLearnerStore } from "@/stores/learner";
 import { Rating, RoundedStar } from "@smastrom/react-rating";
@@ -276,7 +277,8 @@ function SuccessPage() {
           setShowSubmissionFeedback(zustandShowSubmissionFeedback);
           setQuestions(zustandQuestions);
           setShowQuestions(zustandShowQuestions);
-          setGrade(zustandGrade);
+          // A never-set store grade must render the hidden-score view, not 0%.
+          setGrade(resolveStoreGrade(zustandGrade));
           setTotalPointsEarned(zustandTotalPointsEarned);
           setTotalPoints(zustandTotalPoints);
           setAssignmentDetails(zustandAssignmentDetails);

--- a/apps/web/lib/__tests__/gradeDisplay.test.ts
+++ b/apps/web/lib/__tests__/gradeDisplay.test.ts
@@ -1,0 +1,19 @@
+import { resolveStoreGrade } from "@/lib/gradeDisplay";
+
+describe("resolveStoreGrade", () => {
+  it("passes a numeric grade through", () => {
+    expect(resolveStoreGrade(87)).toBe(87);
+  });
+
+  it("passes a genuine 0% grade through", () => {
+    expect(resolveStoreGrade(0)).toBe(0);
+  });
+
+  it("maps a null grade (never provided) to NaN so the hidden-score view renders", () => {
+    expect(Number.isNaN(resolveStoreGrade(null))).toBe(true);
+  });
+
+  it("maps an undefined grade to NaN so the hidden-score view renders", () => {
+    expect(Number.isNaN(resolveStoreGrade(undefined))).toBe(true);
+  });
+});

--- a/apps/web/lib/gradeDisplay.ts
+++ b/apps/web/lib/gradeDisplay.ts
@@ -1,0 +1,11 @@
+/**
+ * Resolves a grade read back from the client store into a displayable value.
+ *
+ * A grade of 0 is a real result and must render as 0%. A null/undefined grade
+ * means no grade was ever provided (e.g. the API withheld it, or nothing was
+ * stored) — return NaN so the success page renders its hidden-score view
+ * instead of a fake "0%" / "Failed".
+ */
+export function resolveStoreGrade(grade: number | null | undefined): number {
+  return typeof grade === "number" ? grade : Number.NaN;
+}

--- a/apps/web/stores/learner.ts
+++ b/apps/web/stores/learner.ts
@@ -448,7 +448,7 @@ export type AssignmentDetailsState = {
 
 export type AssignmentDetailsActions = {
   setAssignmentDetails: (assignmentDetails: Assignment) => void;
-  setGrade: (grade: number) => void;
+  setGrade: (grade: number | null) => void;
 };
 
 const isQuestionEdited = (question: QuestionStore) => {


### PR DESCRIPTION
## Problem

A partner reported that previewing their quiz (assignment 3794) always shows **"Final Score: 5 / 5 (0%)" with status Failed**, even on a perfect run.

Learner grading is unaffected — prod attempts on this quiz store correct grades (5/5 → 1.0) and LTI passback is fine. The bug only hits the **author preview** of an assignment with **"Show assignment score" disabled**:

1. `updateAuthorAttempt` honors `showAssignmentScore=false` by returning `grade: undefined`, while still returning `totalPointsEarned` / `totalPossiblePoints`.
2. The shared submit handler only calls `setGrade` when the grade is defined, so the store grade stays at its `null` default (or worse, a stale value from a previous attempt).
3. The preview success page can't fetch the fake attempt id (`-1`), falls back to the client store, and renders the null grade as `Math.round(null)` → **0%**, with `null >= passingGrade` → **Failed**.

The earlier fix for hidden-score rendering (97c3838b) covered the learner GET-attempt path only; author preview never went through it.

## Fix

- **API**: author preview now returns the grade unconditionally. `showAssignmentScore` hides the score from learners, not from the author testing their own quiz.
- **Web (stale-grade hazard)**: when a submit response carries no grade, the store grade is cleared instead of silently keeping the previous attempt's value (`setGrade` widened to accept `null`).
- **Web (safe rendering)**: new `resolveStoreGrade` helper — a never-set store grade resolves to `NaN`, so the success page renders its existing "Grades are currently unavailable…" view instead of a fake 0%. A genuine 0% still renders as 0%.

## Testing

- New regression test: author preview with `showAssignmentScore=false` must return the grade (failed with `undefined` before the fix).
- Four unit tests for `resolveStoreGrade` (number passthrough, genuine 0, null → NaN, undefined → NaN).
- Full suites green: API attempt services 158/158, web 312/312; typechecks clean apart from three pre-existing errors already on master.
- Not yet driven in a browser — worth a staging pass: author-preview a hidden-score quiz and confirm the real grade shows, and that learners still see the hidden-score view.
