### PR TITLE
fix(attempt): author preview mirrors learner score visibility

### DIFF
--- a/apps/api/src/api/attempt/services/attempt-submission.service.spec.ts
+++ b/apps/api/src/api/attempt/services/attempt-submission.service.spec.ts
@@ -948,9 +948,9 @@ describe("AttemptSubmissionService - Grading Validation", () => {
       );
     });
 
-    it("returns the grade even when showAssignmentScore is false", async () => {
-      // The author is testing their own quiz: hiding the learner-facing score
-      // must not hide the preview grade, otherwise a perfect run renders as 0%.
+    it("withholds the grade when showAssignmentScore is false, mirroring the learner response", async () => {
+      // The preview is the author's only window into the learner experience,
+      // so it must apply the same visibility rules as the learner submit path.
       mockPrisma.assignment.findUnique.mockResolvedValue({
         id: assignmentId,
         questions: [],
@@ -985,9 +985,38 @@ describe("AttemptSubmissionService - Grading Validation", () => {
         authorRequest as UpdateAttemptRequest,
       );
 
-      expect(result.grade).toBe(1);
+      expect(result.grade).toBeUndefined();
       expect(result.totalPointsEarned).toBe(1);
       expect(result.totalPossiblePoints).toBe(1);
+    });
+
+    it("returns the grade when showAssignmentScore is true", async () => {
+      const updateDto = {
+        submitted: true,
+        language: "en",
+        responsesForQuestions: [{ id: 1, question: "Preview response" }],
+        authorQuestions: [{ id: 1, totalPoints: 2 }],
+      };
+
+      mockQuestionResponseService.submitQuestions.mockResolvedValue([
+        makeResponse({ questionId: 1, totalPoints: 2, metadata: undefined }),
+      ]);
+      mockGradingService.calculateGradeForAuthor.mockReturnValue({
+        grade: 1,
+        totalPointsEarned: 2,
+        totalPossiblePoints: 2,
+      });
+
+      const result = await service.updateAssignmentAttempt(
+        -1,
+        assignmentId,
+        updateDto as UpdateAttemptDto,
+        "",
+        false,
+        authorRequest as UpdateAttemptRequest,
+      );
+
+      expect(result.grade).toBe(1);
     });
 
     it("throws when preview responses reference questions missing from provided draft questions", async () => {

--- a/apps/api/src/api/attempt/services/attempt-submission.service.ts
+++ b/apps/api/src/api/attempt/services/attempt-submission.service.ts
@@ -1241,10 +1241,10 @@ export class AttemptSubmissionService {
         success: true,
         totalPointsEarned,
         totalPossiblePoints,
-        // showAssignmentScore hides the score from learners, not from the
-        // author previewing their own quiz — withholding it here made the
-        // success page render a null grade as 0% / Failed.
-        grade,
+        // The preview must mirror the learner submit response (including
+        // withholding the grade when the score is hidden) — it's often the
+        // author's only way to see what learners actually experience.
+        grade: assignment.showAssignmentScore ? grade : undefined,
         showQuestions: assignment.showQuestions,
         showSubmissionFeedback: assignment.showSubmissionFeedback,
         correctAnswerVisibility:

--- a/apps/web/app/learner/(components)/Question/Timer.tsx
+++ b/apps/web/app/learner/(components)/Question/Timer.tsx
@@ -184,6 +184,10 @@ function Timer(props: Props) {
     setTotalPointsPossible(res.totalPossiblePoints);
     if (grade !== undefined) {
       setGrade(grade * 100);
+    } else {
+      // No grade on this submission (score hidden): clear any grade left
+      // from a previous attempt so the success page doesn't show it.
+      setGrade(null);
     }
     setShowSubmissionFeedback(res.showSubmissionFeedback);
     for (const question of questions) {

--- a/apps/web/app/learner/[assignmentId]/successPage/[submissionId]/page.tsx
+++ b/apps/web/app/learner/[assignmentId]/successPage/[submissionId]/page.tsx
@@ -15,7 +15,11 @@ import {
   getUser,
   submitFeedback,
 } from "@/lib/talkToBackend";
-import { resolveStoreGrade } from "@/lib/gradeDisplay";
+import {
+  resolveMissingGradeReason,
+  resolveStoreGrade,
+  type MissingGradeReason,
+} from "@/lib/gradeDisplay";
 import Crown from "@/public/Crown.svg";
 import { useAssignmentDetails, useLearnerStore } from "@/stores/learner";
 import { Rating, RoundedStar } from "@smastrom/react-rating";
@@ -79,6 +83,10 @@ function SuccessPage() {
   );
 
   const [showQuestions, setShowQuestions] = useState<boolean>(false);
+  // Why the NaN-grade view is showing: score hidden by the author (default,
+  // matches every learner path) vs. grade data simply lost (preview reload).
+  const [missingGradeReason, setMissingGradeReason] =
+    useState<MissingGradeReason>("score-hidden");
 
   const [pageHeight, setPageHeight] = useState<number>(0);
   const [loading, setLoading] = useState(true);
@@ -279,6 +287,11 @@ function SuccessPage() {
           setShowQuestions(zustandShowQuestions);
           // A never-set store grade must render the hidden-score view, not 0%.
           setGrade(resolveStoreGrade(zustandGrade));
+          setMissingGradeReason(
+            resolveMissingGradeReason(
+              zustandAssignmentDetails?.showAssignmentScore,
+            ),
+          );
           setTotalPointsEarned(zustandTotalPointsEarned);
           setTotalPoints(zustandTotalPoints);
           setAssignmentDetails(zustandAssignmentDetails);
@@ -691,7 +704,7 @@ function SuccessPage() {
                 </motion.div>
               </div>
             </>
-          ) : (
+          ) : missingGradeReason === "score-hidden" ? (
             <motion.h1
               className="text-5xl font-extrabold text-gray-800"
               initial={{ opacity: 0, y: -30 }}
@@ -700,6 +713,25 @@ function SuccessPage() {
               Grades are currently unavailable as the author has disabled
               viewing them.
             </motion.h1>
+          ) : (
+            <>
+              <motion.h1
+                className="text-5xl font-extrabold text-gray-800"
+                initial={{ opacity: 0, y: -30 }}
+                animate={{ opacity: 1, y: 0 }}
+              >
+                Preview results are no longer available.
+              </motion.h1>
+              <motion.p
+                className="text-xl text-gray-600"
+                initial={{ opacity: 0, y: 30 }}
+                animate={{ opacity: 1, y: 0 }}
+              >
+                Preview attempts aren&apos;t saved, so their results don&apos;t
+                survive a page reload. Run the preview again to see what
+                learners get.
+              </motion.p>
+            </>
           )}
         </div>
 

--- a/apps/web/lib/__tests__/gradeDisplay.test.ts
+++ b/apps/web/lib/__tests__/gradeDisplay.test.ts
@@ -1,4 +1,21 @@
-import { resolveStoreGrade } from "@/lib/gradeDisplay";
+import {
+  resolveMissingGradeReason,
+  resolveStoreGrade,
+} from "@/lib/gradeDisplay";
+
+describe("resolveMissingGradeReason", () => {
+  it("reports score-hidden when the author disabled the assignment score", () => {
+    expect(resolveMissingGradeReason(false)).toBe("score-hidden");
+  });
+
+  it("reports results-missing when the score is visible (grade was lost, e.g. preview reload)", () => {
+    expect(resolveMissingGradeReason(true)).toBe("results-missing");
+  });
+
+  it("reports results-missing when visibility is unknown (no persisted assignment details)", () => {
+    expect(resolveMissingGradeReason(undefined)).toBe("results-missing");
+  });
+});
 
 describe("resolveStoreGrade", () => {
   it("passes a numeric grade through", () => {

--- a/apps/web/lib/gradeDisplay.ts
+++ b/apps/web/lib/gradeDisplay.ts
@@ -9,3 +9,18 @@
 export function resolveStoreGrade(grade: number | null | undefined): number {
   return typeof grade === "number" ? grade : Number.NaN;
 }
+
+export type MissingGradeReason = "score-hidden" | "results-missing";
+
+/**
+ * Explains why there is no grade to display, so the empty state can be
+ * honest. Only an explicit showAssignmentScore=false means the author hid
+ * the score; anything else means the grade was simply lost — e.g. reloading
+ * an author preview, whose results are never persisted — and blaming the
+ * visibility setting would be misleading.
+ */
+export function resolveMissingGradeReason(
+  showAssignmentScore: boolean | undefined,
+): MissingGradeReason {
+  return showAssignmentScore === false ? "score-hidden" : "results-missing";
+}


### PR DESCRIPTION
## Problem

Follow-up to #587. That fix stopped the author preview from rendering a hidden-score quiz as a fake "0% / Failed", but it did so by always returning the grade to the author. In practice the preview is often the only practical way to see what learners experience (learner tokens are hard to come by, especially when debugging production), so it needs to be a faithful simulation of the learner view — not an author-privileged one.

There was also a second misleading state: reloading a preview success page always showed "Grades are currently unavailable as the author has disabled viewing them," even for full-feedback quizzes. Preview attempts (id `-1`) are never persisted and the store intentionally doesn't persist the grade, so a reload simply loses the result — the visibility setting has nothing to do with it, and the message sends whoever is debugging down the wrong path.

## Fix

- **API** — the author-preview submit response now mirrors the learner response field-for-field: the grade is withheld when `Show assignment score` is off, exactly like the learner path.
- **Web (kept from #587)** — a missing grade renders the hidden-score view instead of a fake 0%, so a hidden-score preview now shows the same "Grades are currently unavailable…" screen a learner gets.
- **Web (new)** — the success page distinguishes *why* there's no grade, using the persisted assignment details: score hidden → the learner-identical message (correct simulation); otherwise → an honest "Preview results are no longer available — preview attempts aren't saved, run the preview again."

## Testing

- API: flipped the author-preview spec RED-first (`grade` must be `undefined` when the score is hidden), added a companion test for the visible case; full API suite 1368 passed.
- Web: RED-first unit tests for the new `resolveMissingGradeReason` helper; all 340 web tests pass.
- Typechecks clean in both apps (the six pre-existing web `tsc` errors on master are in untouched files).
- Staging (pre-rework, same code paths): hidden-score preview rendered the learner "grades unavailable" view via the store-fallback path. Worth a staging pass on the reload empty state: reload a full-feedback preview success page and confirm the "preview results aren't saved" message (not the disabled-by-author one).
