### PR TITLE
fix: scope attempt score denominator to served questions

### DIFF
--- a/apps/api/src/api/attempt/services/attempt-submission.service.spec.ts
+++ b/apps/api/src/api/attempt/services/attempt-submission.service.spec.ts
@@ -765,18 +765,54 @@ describe("AttemptSubmissionService - Grading Validation", () => {
       buildSpy.mockRestore();
     });
 
-    it("keeps the denominator >= earned when a served question was deleted after submission", async () => {
+    it("excludes unserved and duplicate responses from the displayed numerator", async () => {
+      mockPrisma.assignmentAttempt.findUnique.mockResolvedValue({
+        ...assignmentAttempt,
+        questionOrder: [101],
+        questionResponses: [
+          { id: 1, questionId: 101, points: 3 },
+          { id: 2, questionId: 101, points: 5 },
+          { id: 3, questionId: 202, points: 5 },
+        ],
+      });
+      mockAttemptAccessCacheService.getQuestionDtosForAttemptAccess.mockResolvedValue(
+        [
+          { id: 101, totalPoints: 5 },
+          { id: 202, totalPoints: 5 },
+        ],
+      );
+      const buildSpy = jest
+        .spyOn(AttemptQuestionsMapper, "buildQuestionsWithResponses")
+        .mockResolvedValue([{ id: 101, totalPoints: 5 }]);
+
+      const result = await service.getLearnerAssignmentAttempt(71, {
+        userId: "learner-1",
+        role: UserRole.LEARNER,
+        assignmentId: 99,
+        groupId: "group-1",
+      });
+
+      expect(result.totalPossiblePoints).toBe(5);
+      expect(result.totalPointsEarned).toBe(5);
+
+      buildSpy.mockRestore();
+    });
+
+    it("uses the original maximum when a served question was deleted after submission", async () => {
       // Non-versioned assignment: Q202 was served (in questionOrder) and graded,
       // but the author deleted it afterwards so it is gone from the question
-      // cache. The numerator still counts its response via pass-through, so the
-      // denominator must count it too — otherwise the score renders above 100%.
+      // cache. Its grading metadata preserves the original maximum.
       mockPrisma.assignmentAttempt.findUnique.mockResolvedValue({
         ...assignmentAttempt,
         grade: 0.9,
         questionOrder: [101, 202],
         questionResponses: [
           { questionId: 101, points: 5 },
-          { questionId: 202, points: 4 }, // question deleted from the cache
+          {
+            questionId: 202,
+            points: 4,
+            metadata: { maxPossiblePoints: 5 },
+          }, // question deleted from the cache
         ],
       });
       mockAttemptAccessCacheService.getQuestionDtosForAttemptAccess.mockResolvedValue(
@@ -805,12 +841,82 @@ describe("AttemptSubmissionService - Grading Validation", () => {
         groupId: "group-1",
       });
 
-      // 5 (cached Q101) + 4 (Q202's earned points, mirrored) = 9, not 5.
-      expect(result.totalPossiblePoints).toBe(9);
+      expect(result.totalPossiblePoints).toBe(10);
       expect(result.totalPointsEarned).toBe(9);
       expect(result.totalPointsEarned).toBeLessThanOrEqual(
         result.totalPossiblePoints as number,
       );
+
+      buildSpy.mockRestore();
+    });
+
+    it("falls back to an archived question row when response metadata is missing", async () => {
+      mockPrisma.assignmentAttempt.findUnique.mockResolvedValue({
+        ...assignmentAttempt,
+        questionOrder: [101, 202],
+        questionResponses: [
+          { questionId: 101, points: 5 },
+          { questionId: 202, points: 4, metadata: null },
+        ],
+      });
+      mockAttemptAccessCacheService.getQuestionDtosForAttemptAccess.mockResolvedValue(
+        [{ id: 101, totalPoints: 5 }],
+      );
+      mockPrisma.question.findMany.mockResolvedValue([
+        { id: 202, totalPoints: 5 },
+      ]);
+      const buildSpy = jest
+        .spyOn(AttemptQuestionsMapper, "buildQuestionsWithResponses")
+        .mockResolvedValue([{ id: 101, totalPoints: 5 }]);
+
+      const result = await service.getLearnerAssignmentAttempt(71, {
+        userId: "learner-1",
+        role: UserRole.LEARNER,
+        assignmentId: 99,
+        groupId: "group-1",
+      });
+
+      expect(mockPrisma.question.findMany).toHaveBeenCalledWith({
+        where: { id: { in: [202] } },
+        select: { id: true, totalPoints: true },
+      });
+      expect(result.totalPossiblePoints).toBe(10);
+      expect(result.totalPointsEarned).toBe(9);
+
+      buildSpy.mockRestore();
+    });
+
+    it("parses persisted metadata when a deleted served question earned zero", async () => {
+      mockPrisma.assignmentAttempt.findUnique.mockResolvedValue({
+        ...assignmentAttempt,
+        grade: 0.5,
+        questionOrder: [101, 202],
+        questionResponses: [
+          { questionId: 101, points: 5 },
+          {
+            questionId: 202,
+            points: 0,
+            metadata: JSON.stringify({ maxPossiblePoints: 5 }),
+          },
+        ],
+      });
+      mockAttemptAccessCacheService.getQuestionDtosForAttemptAccess.mockResolvedValue(
+        [{ id: 101, totalPoints: 5 }],
+      );
+      const buildSpy = jest
+        .spyOn(AttemptQuestionsMapper, "buildQuestionsWithResponses")
+        .mockResolvedValue([{ id: 101, totalPoints: 5 }]);
+
+      const result = await service.getLearnerAssignmentAttempt(71, {
+        userId: "learner-1",
+        role: UserRole.LEARNER,
+        assignmentId: 99,
+        groupId: "group-1",
+      });
+
+      expect(result.totalPossiblePoints).toBe(10);
+      expect(result.totalPointsEarned).toBe(5);
+      expect(result.grade).toBe(0.5);
 
       buildSpy.mockRestore();
     });
@@ -904,6 +1010,7 @@ describe("AttemptSubmissionService - Grading Validation", () => {
     it("omits totalPointsEarned when showAssignmentScore=false", async () => {
       mockPrisma.assignmentAttempt.findUnique.mockResolvedValue({
         ...assignmentAttempt,
+        questionOrder: [101],
         questionResponses: [{ questionId: 101, points: 4 }],
       });
       mockAttemptAccessCacheService.getQuestionDtosForAttemptAccess.mockResolvedValue(
@@ -1450,7 +1557,7 @@ describe("AttemptSubmissionService - Grading Validation", () => {
     });
   });
 
-  describe("updateLearnerAttempt - already-submitted short-circuit", () => {
+  describe("updateLearnerAttempt - submission validation", () => {
     it("throws ConflictException before grading when the attempt is already submitted", async () => {
       mockPrisma.assignmentAttempt.findUnique.mockResolvedValue({
         id: 555,
@@ -1487,6 +1594,53 @@ describe("AttemptSubmissionService - Grading Validation", () => {
       expect(
         mockTranslationService.preTranslateQuestions,
       ).not.toHaveBeenCalled();
+    });
+
+    it("rejects unserved and duplicate question IDs before grading", async () => {
+      mockPrisma.assignmentAttempt.findUnique.mockResolvedValue({
+        id: 555,
+        submitted: false,
+        expiresAt: new Date(Date.now() + 60_000),
+        questionOrder: [101],
+        questionVariants: [],
+      });
+      mockPrisma.assignment.findUnique.mockResolvedValue({
+        id: 2580,
+        questionOrder: [101, 202],
+        questions: [{ id: 101 }, { id: 202 }],
+        currentVersion: { correctAnswerVisibility: "ALWAYS" },
+      });
+      mockValidationService.isAttemptExpired.mockReturnValue(false);
+
+      const updateDto = {
+        responsesForQuestions: [{ id: 101 }, { id: 101 }, { id: 202 }],
+        language: "en",
+      } as never;
+      const request = {
+        userSession: { userId: "learner@example.com", role: "Learner" },
+      } as never;
+
+      await expect(
+        (
+          service as unknown as {
+            updateLearnerAttempt: (
+              attemptId: number,
+              assignmentId: number,
+              updateDto: unknown,
+              authCookie: string,
+              gradingCallbackRequired: boolean,
+              request: unknown,
+            ) => Promise<unknown>;
+          }
+        ).updateLearnerAttempt(555, 2580, updateDto, "cookie", true, request),
+      ).rejects.toThrow(
+        "unserved question IDs [202]; duplicate question IDs [101]",
+      );
+
+      expect(
+        mockTranslationService.preTranslateQuestions,
+      ).not.toHaveBeenCalled();
+      expect(mockLtiGradeSyncService.createAndSync).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/api/src/api/attempt/services/attempt-submission.service.spec.ts
+++ b/apps/api/src/api/attempt/services/attempt-submission.service.spec.ts
@@ -712,6 +712,109 @@ describe("AttemptSubmissionService - Grading Validation", () => {
       buildSpy.mockRestore();
     });
 
+    it("scopes totalPossiblePoints to the questions served this attempt, not the whole question bank", async () => {
+      // Question-bank assignment: bank of 3 cached questions, but only 2 were
+      // drawn for this attempt (questionOrder). The denominator must be the 2
+      // served (10), not the full bank of 3 (15) — otherwise the success page
+      // shows an inflated "X/15" when only 2 questions were answered.
+      mockPrisma.assignmentAttempt.findUnique.mockResolvedValue({
+        ...assignmentAttempt,
+        questionOrder: [101, 202],
+        questionResponses: [
+          { questionId: 101, points: 5 },
+          { questionId: 202, points: 5 },
+        ],
+      });
+      mockAttemptAccessCacheService.getQuestionDtosForAttemptAccess.mockResolvedValue(
+        [
+          { id: 101, totalPoints: 5 },
+          { id: 202, totalPoints: 5 },
+          { id: 303, totalPoints: 5 }, // in the bank, not served this attempt
+        ],
+      );
+      const buildSpy = jest
+        .spyOn(AttemptQuestionsMapper, "buildQuestionsWithResponses")
+        .mockResolvedValue([
+          { id: 101, totalPoints: 5 },
+          { id: 202, totalPoints: 5 },
+        ]);
+      mockPrisma.assignment.findUnique.mockResolvedValue({
+        id: 99,
+        questionOrder: [101, 202, 303],
+        displayOrder: null,
+        passingGrade: 50,
+        showAssignmentScore: true,
+        showSubmissionFeedback: true,
+        showQuestionScore: true,
+        showQuestions: true,
+        updatedAt: new Date("2026-04-26T00:00:00.000Z"),
+        currentVersion: { correctAnswerVisibility: "ALWAYS" },
+      });
+
+      const result = await service.getLearnerAssignmentAttempt(71, {
+        userId: "learner-1",
+        role: UserRole.LEARNER,
+        assignmentId: 99,
+        groupId: "group-1",
+      });
+
+      expect(result.totalPossiblePoints).toBe(10);
+      expect(result.totalPointsEarned).toBe(10);
+      expect(result.grade).toBe(0.9);
+
+      buildSpy.mockRestore();
+    });
+
+    it("keeps the denominator >= earned when a served question was deleted after submission", async () => {
+      // Non-versioned assignment: Q202 was served (in questionOrder) and graded,
+      // but the author deleted it afterwards so it is gone from the question
+      // cache. The numerator still counts its response via pass-through, so the
+      // denominator must count it too — otherwise the score renders above 100%.
+      mockPrisma.assignmentAttempt.findUnique.mockResolvedValue({
+        ...assignmentAttempt,
+        grade: 0.9,
+        questionOrder: [101, 202],
+        questionResponses: [
+          { questionId: 101, points: 5 },
+          { questionId: 202, points: 4 }, // question deleted from the cache
+        ],
+      });
+      mockAttemptAccessCacheService.getQuestionDtosForAttemptAccess.mockResolvedValue(
+        [{ id: 101, totalPoints: 5 }], // 202 missing: deleted after submission
+      );
+      const buildSpy = jest
+        .spyOn(AttemptQuestionsMapper, "buildQuestionsWithResponses")
+        .mockResolvedValue([{ id: 101, totalPoints: 5 }]);
+      mockPrisma.assignment.findUnique.mockResolvedValue({
+        id: 99,
+        questionOrder: [101, 202],
+        displayOrder: null,
+        passingGrade: 50,
+        showAssignmentScore: true,
+        showSubmissionFeedback: true,
+        showQuestionScore: true,
+        showQuestions: true,
+        updatedAt: new Date("2026-04-26T00:00:00.000Z"),
+        currentVersion: { correctAnswerVisibility: "ALWAYS" },
+      });
+
+      const result = await service.getLearnerAssignmentAttempt(71, {
+        userId: "learner-1",
+        role: UserRole.LEARNER,
+        assignmentId: 99,
+        groupId: "group-1",
+      });
+
+      // 5 (cached Q101) + 4 (Q202's earned points, mirrored) = 9, not 5.
+      expect(result.totalPossiblePoints).toBe(9);
+      expect(result.totalPointsEarned).toBe(9);
+      expect(result.totalPointsEarned).toBeLessThanOrEqual(
+        result.totalPossiblePoints as number,
+      );
+
+      buildSpy.mockRestore();
+    });
+
     it("clamps a response graded above its question's max and recomputes the displayed grade so an already-graded attempt cannot show a false 100%", async () => {
       // Reproduces the multi-select overshoot: Q202 was graded 2 points on a
       // 1-point question, which inflated the attempt total so the +1 overshoot
@@ -719,6 +822,7 @@ describe("AttemptSubmissionService - Grading Validation", () => {
       mockPrisma.assignmentAttempt.findUnique.mockResolvedValue({
         ...assignmentAttempt,
         grade: 1, // stored grade was derived from the inflated points
+        questionOrder: [101, 202, 303], // all three served this attempt
         questionResponses: [
           { questionId: 101, points: 1 },
           { questionId: 202, points: 2 }, // over the question's max of 1

--- a/apps/api/src/api/attempt/services/attempt-submission.service.ts
+++ b/apps/api/src/api/attempt/services/attempt-submission.service.ts
@@ -612,10 +612,38 @@ export class AttemptSubmissionService {
     // Compute score totals before applyVisibilitySettings so they survive
     // even when showQuestions=false strips the questions array. Without this
     // the success page shows "0 / 0" because it can't sum the (empty) array.
-    const totalPossiblePoints = cachedQuestions.reduce(
-      (sum, q) => sum + (q.totalPoints ?? 0),
-      0,
-    );
+    //
+    // Scope the denominator to the questions actually served to this attempt.
+    // Question-bank assignments draw numberOfQuestionsPerAttempt (< bank size)
+    // questions, recorded in assignmentAttempt.questionOrder. Summing every
+    // cached question inflates the total to the full bank size (e.g. "15/20"
+    // when only 15 were served). Mirror the served-set precedence the
+    // questions mapper uses so numerator and denominator cover the same set.
+    const servedQuestionIds = assignmentAttempt.questionOrder?.length
+      ? assignmentAttempt.questionOrder
+      : assignment.questionOrder?.length
+        ? assignment.questionOrder
+        : cachedQuestions.map((q) => q.id);
+    const servedQuestionIdSet = new Set(servedQuestionIds);
+    let totalPossiblePoints = 0;
+    for (const questionId of servedQuestionIdSet) {
+      if (questionMaxById.has(questionId)) {
+        // Question is in the cache: use its defined max (null totalPoints
+        // stays 0, matching the historical denominator behavior).
+        totalPossiblePoints += questionMaxById.get(questionId) ?? 0;
+      } else {
+        // Served (in questionOrder) but absent from the cache — a question
+        // deleted after this attempt was submitted, which only happens on
+        // non-versioned assignments (versioned attempts read an immutable
+        // snapshot). The numerator still counts this response via pass-through,
+        // so mirror that here; otherwise the total could fall below the earned
+        // points and render a >100% score.
+        const deletedResponse = responses.find(
+          (r) => r.questionId === questionId,
+        );
+        totalPossiblePoints += deletedResponse?.points ?? 0;
+      }
+    }
     const effectiveGrade =
       totalPointsEarned < rawPointsEarned && totalPossiblePoints > 0
         ? totalPointsEarned / totalPossiblePoints

--- a/apps/api/src/api/attempt/services/attempt-submission.service.ts
+++ b/apps/api/src/api/attempt/services/attempt-submission.service.ts
@@ -596,12 +596,35 @@ export class AttemptSubmissionService {
       cachedQuestions.map((q) => [q.id, q.totalPoints]),
     );
     const responses = assignmentAttempt.questionResponses ?? [];
-    const rawPointsEarned = responses.reduce(
+    const servedQuestionIds = assignmentAttempt.questionOrder?.length
+      ? assignmentAttempt.questionOrder
+      : assignment.questionOrder?.length
+        ? assignment.questionOrder
+        : cachedQuestions.map((q) => q.id);
+    const servedQuestionIdSet = new Set(servedQuestionIds);
+
+    // Historical rows and crafted requests can contain duplicate or unserved
+    // responses. Keep only the newest served response so the numerator covers
+    // the same question set as the denominator.
+    const servedResponseByQuestionId = new Map<
+      number,
+      (typeof responses)[number]
+    >();
+    for (const response of responses) {
+      if (!servedQuestionIdSet.has(response.questionId)) continue;
+
+      const existing = servedResponseByQuestionId.get(response.questionId);
+      if (!existing || response.id > existing.id) {
+        servedResponseByQuestionId.set(response.questionId, response);
+      }
+    }
+    const servedResponses = [...servedResponseByQuestionId.values()];
+    const rawPointsEarned = servedResponses.reduce(
       (sum, response) => sum + (response.points ?? 0),
       0,
     );
     let totalPointsEarned = 0;
-    for (const response of responses) {
+    for (const response of servedResponses) {
       const questionMax = questionMaxById.get(response.questionId);
       const points = response.points ?? 0;
       totalPointsEarned +=
@@ -619,12 +642,26 @@ export class AttemptSubmissionService {
     // cached question inflates the total to the full bank size (e.g. "15/20"
     // when only 15 were served). Mirror the served-set precedence the
     // questions mapper uses so numerator and denominator cover the same set.
-    const servedQuestionIds = assignmentAttempt.questionOrder?.length
-      ? assignmentAttempt.questionOrder
-      : assignment.questionOrder?.length
-        ? assignment.questionOrder
-        : cachedQuestions.map((q) => q.id);
-    const servedQuestionIdSet = new Set(servedQuestionIds);
+    const missingMaxQuestionIds = [...servedQuestionIdSet].filter(
+      (questionId) =>
+        !questionMaxById.has(questionId) &&
+        this.getResponseMaxPossiblePoints(
+          servedResponseByQuestionId.get(questionId)?.metadata ?? null,
+        ) === undefined,
+    );
+    const missingMaxQuestions =
+      missingMaxQuestionIds.length > 0
+        ? await this.prisma.question.findMany({
+            where: { id: { in: missingMaxQuestionIds } },
+            select: { id: true, totalPoints: true },
+          })
+        : [];
+    const deletedQuestionMaxById = new Map(
+      missingMaxQuestions.map((question) => [
+        question.id,
+        question.totalPoints,
+      ]),
+    );
     let totalPossiblePoints = 0;
     for (const questionId of servedQuestionIdSet) {
       if (questionMaxById.has(questionId)) {
@@ -632,16 +669,25 @@ export class AttemptSubmissionService {
         // stays 0, matching the historical denominator behavior).
         totalPossiblePoints += questionMaxById.get(questionId) ?? 0;
       } else {
-        // Served (in questionOrder) but absent from the cache — a question
-        // deleted after this attempt was submitted, which only happens on
-        // non-versioned assignments (versioned attempts read an immutable
-        // snapshot). The numerator still counts this response via pass-through,
-        // so mirror that here; otherwise the total could fall below the earned
-        // points and render a >100% score.
-        const deletedResponse = responses.find(
-          (r) => r.questionId === questionId,
+        // Served (in questionOrder) but absent from the cache — normally a
+        // soft-deleted question on a non-versioned assignment. Preserve its
+        // actual maximum from grading metadata or the archived database row;
+        // earned points are not a valid substitute for possible points.
+        const responseMax = this.getResponseMaxPossiblePoints(
+          servedResponseByQuestionId.get(questionId)?.metadata ?? null,
         );
-        totalPossiblePoints += deletedResponse?.points ?? 0;
+        const deletedQuestionMax = deletedQuestionMaxById.get(questionId);
+        if (responseMax !== undefined) {
+          totalPossiblePoints += responseMax;
+          continue;
+        }
+        if (deletedQuestionMax === undefined) {
+          throw new InternalServerErrorException(
+            `Cannot calculate totalPossiblePoints: served Question ${questionId} ` +
+              "is absent from the attempt snapshot and database.",
+          );
+        }
+        totalPossiblePoints += deletedQuestionMax;
       }
     }
     const effectiveGrade =
@@ -735,6 +781,32 @@ export class AttemptSubmissionService {
         assignment.currentVersion?.correctAnswerVisibility || "NEVER",
       comments: assignmentAttempt.comments,
     };
+  }
+
+  private getResponseMaxPossiblePoints(
+    metadata: JsonValue | null,
+  ): number | undefined {
+    let parsedMetadata: unknown = metadata;
+    if (typeof parsedMetadata === "string") {
+      try {
+        parsedMetadata = JSON.parse(parsedMetadata) as unknown;
+      } catch {
+        return undefined;
+      }
+    }
+
+    if (!parsedMetadata || typeof parsedMetadata !== "object") {
+      return undefined;
+    }
+
+    const maxPossiblePoints = (
+      parsedMetadata as { maxPossiblePoints?: unknown }
+    ).maxPossiblePoints;
+    return typeof maxPossiblePoints === "number" &&
+      Number.isFinite(maxPossiblePoints) &&
+      maxPossiblePoints >= 0
+      ? maxPossiblePoints
+      : undefined;
   }
 
   /**
@@ -981,20 +1053,6 @@ export class AttemptSubmissionService {
         return expiredResult;
       }
 
-      if (progressCallback) {
-        await progressCallback("Pre-translating questions...", 10);
-      }
-
-      const preTranslatedQuestions =
-        await this.translationService.preTranslateQuestions(
-          updateDto.responsesForQuestions,
-          assignmentAttempt,
-          updateDto.language,
-          effectiveCache,
-        );
-
-      updateDto.preTranslatedQuestions = preTranslatedQuestions;
-
       const assignment = await this.prisma.assignment.findUnique({
         where: { id: assignmentId },
         include: {
@@ -1009,7 +1067,67 @@ export class AttemptSubmissionService {
         },
       });
 
-      if (assignment?.requireAllQuestions) {
+      if (!assignment) {
+        throw new NotFoundException(
+          `Assignment with Id ${assignmentId} not found.`,
+        );
+      }
+
+      const servedQuestionIds = assignmentAttempt.questionOrder?.length
+        ? assignmentAttempt.questionOrder
+        : assignment.questionOrder?.length
+          ? assignment.questionOrder
+          : assignment.questions.map((question) => question.id);
+      const servedQuestionIdSet = new Set(servedQuestionIds);
+      const submittedQuestionIds = updateDto.responsesForQuestions.map(
+        (response) => response.id,
+      );
+      const invalidQuestionIds = [
+        ...new Set(
+          submittedQuestionIds.filter(
+            (questionId) => !servedQuestionIdSet.has(questionId),
+          ),
+        ),
+      ];
+      const duplicateQuestionIds = [
+        ...new Set(
+          submittedQuestionIds.filter(
+            (questionId, index) =>
+              submittedQuestionIds.indexOf(questionId) !== index,
+          ),
+        ),
+      ];
+      if (invalidQuestionIds.length > 0 || duplicateQuestionIds.length > 0) {
+        throw new BadRequestException(
+          `Invalid question responses for attempt ${attemptId}: ` +
+            [
+              invalidQuestionIds.length > 0
+                ? `unserved question IDs [${invalidQuestionIds.join(", ")}]`
+                : null,
+              duplicateQuestionIds.length > 0
+                ? `duplicate question IDs [${duplicateQuestionIds.join(", ")}]`
+                : null,
+            ]
+              .filter((message): message is string => message !== null)
+              .join("; "),
+        );
+      }
+
+      if (progressCallback) {
+        await progressCallback("Pre-translating questions...", 10);
+      }
+
+      const preTranslatedQuestions =
+        await this.translationService.preTranslateQuestions(
+          updateDto.responsesForQuestions,
+          assignmentAttempt,
+          updateDto.language,
+          effectiveCache,
+        );
+
+      updateDto.preTranslatedQuestions = preTranslatedQuestions;
+
+      if (assignment.requireAllQuestions) {
         const optionalQuestionIdsValue: unknown =
           assignment.optionalQuestionIds;
         const optionalQuestionIdList = Array.isArray(optionalQuestionIdsValue)


### PR DESCRIPTION
Question-bank assignments (numberOfQuestionsPerAttempt < bank size) drew the correct subset of questions but summed totalPossiblePoints over the whole bank, so the learner success page showed an inflated denominator (e.g. 15/20 when only 15 questions were served). Scope the total to the questions in the attempt's questionOrder, mirroring the numerator for a served question deleted after submission so the score never exceeds 100%.

<!-- This is helper text. It won't appear in the rendered output, but it will be visible when editing the Markdown file. -->

## **PR Description**

### **Overview:**

<!-- Select all that applies -->

#### **Type of Issue:**

- [ ] **Feature (`feat`)**: New functionality or feature added.
- [x] **Bug Fix (`bug`)**: Issue or bug resolved.
- [ ] **Chore (`chore`)**: Maintenance, refactoring, or non-functional changes.
- [ ] **Documentation Update (`doc`)**: Documentation improvements or additions.

#### **Change Type:**

- [ ] **Major:** Significant changes that introduce new features, large refactoring, or breaking changes. Requires thorough review and testing.
- [x] **Minor:** Small to medium changes, such as adding new functionality that is backward-compatible or minor refactoring. Moderate review needed.
- [ ] **Patch:** Bug fixes, small tweaks, or documentation updates. Light review is sufficient.

## Test Coverage
- [ ] Unit tests updated
- [ ] Manual verification done

Evidence:
<!-- commands, screenshots, GIFs if UI -->

## Impact / Risk
<!-- subsystems touched, breaking potential -->

## Rollback
<!-- git revert <sha> if needed or config toggle -->

## Reviewer Focus
<!-- specific files or logic to inspect -->