### PR TITLE
fix(api): widen bare-optional Zod fields for strict structured outputs

### DIFF
--- a/apps/api-gateway/.eslintrc.cjs
+++ b/apps/api-gateway/.eslintrc.cjs
@@ -8,11 +8,13 @@ module.exports = {
     warnOnUnsupportedTypeScriptVersion: false,
   },
   extends: [
-    "prettier",
     "eslint:recommended",
     "plugin:@typescript-eslint/recommended",
     "plugin:@typescript-eslint/recommended-requiring-type-checking",
     "plugin:unicorn/recommended",
+    // Must come last so it disables every formatting rule (e.g.
+    // unicorn/number-literal-case) that fights the pre-commit prettier pass.
+    "prettier",
   ],
   rules: {
     "unicorn/prefer-top-level-await": "off",

--- a/apps/api/.eslintrc.cjs
+++ b/apps/api/.eslintrc.cjs
@@ -8,11 +8,13 @@ module.exports = {
     warnOnUnsupportedTypeScriptVersion: false,
   },
   extends: [
-    "prettier",
     "eslint:recommended",
     "plugin:@typescript-eslint/recommended",
     "plugin:@typescript-eslint/recommended-requiring-type-checking",
     "plugin:unicorn/recommended",
+    // Must come last so it disables every formatting rule (e.g.
+    // unicorn/number-literal-case) that fights the pre-commit prettier pass.
+    "prettier",
   ],
   rules: {
     "unicorn/prefer-top-level-await": "off",

--- a/apps/api/src/api/llm/core/services/structured-output.util.spec.ts
+++ b/apps/api/src/api/llm/core/services/structured-output.util.spec.ts
@@ -1,6 +1,26 @@
 import { HumanMessage } from "@langchain/core/messages";
+import { createRequire } from "node:module";
 import { z } from "zod";
-import { invokeStructuredChatModel } from "./structured-output.util";
+import {
+  CriterionGradeSchema,
+  EvidenceValidationSchema,
+  GradeSummarySchema,
+  JudgeCritiqueSchema,
+} from "../../features/grading/types/criterion-evidence.types";
+import {
+  invokeStructuredChatModel,
+  normalizeWidenedOutput,
+  widenOptionalsForStrictOutput,
+} from "./structured-output.util";
+
+// LangChain serializes schemas with its own nested copy of the openai SDK,
+// whose strict-mode serializer is the one that rejects bare `.optional()` in
+// production — the workspace-root openai is older and silently permissive, so
+// resolve the copy LangChain actually uses.
+const langchainRequire = createRequire(require.resolve("@langchain/openai"));
+const { zodResponseFormat } = langchainRequire("openai/helpers/zod") as {
+  zodResponseFormat: (schema: z.ZodTypeAny, name: string) => unknown;
+};
 
 describe("invokeStructuredChatModel", () => {
   const schema = z.object({ grade: z.number() });
@@ -79,5 +99,134 @@ describe("invokeStructuredChatModel", () => {
       ),
     ).rejects.toThrow("boom");
     expect(logger.error).toHaveBeenCalled();
+  });
+
+  it("throws instead of returning null when the model output fails schema parsing", async () => {
+    const model = {
+      withStructuredOutput: jest.fn().mockReturnValue({
+        invoke: jest.fn().mockResolvedValue({ raw: {}, parsed: null }),
+      }),
+    } as never;
+    const logger = makeLogger();
+
+    await expect(
+      invokeStructuredChatModel(
+        model,
+        [new HumanMessage("x")],
+        schema,
+        { countTokens: () => 1 } as never,
+        logger as never,
+        "gpt-5-mini",
+      ),
+    ).rejects.toThrow("produced no result");
+    expect(logger.error).toHaveBeenCalled();
+  });
+
+  it("widens bare-optional fields before binding and maps model nulls back to undefined", async () => {
+    const optionalSchema = z.object({
+      rationale: z.string(),
+      nextStep: z.string().optional(),
+      evidence: z.string().nullable(),
+      criteria: z.array(z.object({ note: z.string().optional() })),
+    });
+    const structuredInvoke = jest.fn().mockResolvedValue({
+      raw: { usage_metadata: { input_tokens: 2, output_tokens: 2 } },
+      parsed: {
+        rationale: "ok",
+        nextStep: null,
+        evidence: null,
+        criteria: [{ note: null }, { note: "kept" }],
+      },
+    });
+    const withStructuredOutput = jest
+      .fn()
+      .mockReturnValue({ invoke: structuredInvoke });
+    const model = { withStructuredOutput } as never;
+
+    const result = await invokeStructuredChatModel(
+      model,
+      [new HumanMessage("grade this")],
+      optionalSchema,
+      { countTokens: jest.fn().mockReturnValue(3) } as never,
+      makeLogger() as never,
+      "gpt-5.4-mini-2026-03-17",
+    );
+
+    const boundSchema = withStructuredOutput.mock.calls[0][0] as z.ZodTypeAny;
+    expect(() =>
+      zodResponseFormat(boundSchema, "structured_response"),
+    ).not.toThrow();
+
+    expect(result.parsed).toEqual({
+      rationale: "ok",
+      // Widened optional: model null becomes undefined (key dropped).
+      evidence: null,
+      criteria: [{}, { note: "kept" }],
+    });
+    expect("nextStep" in (result.parsed as Record<string, unknown>)).toBe(
+      false,
+    );
+  });
+});
+
+describe("widenOptionalsForStrictOutput", () => {
+  it("returns the same schema instance when nothing needs widening", () => {
+    const clean = z.object({
+      grade: z.number(),
+      evidence: z.string().nullable(),
+      items: z.array(z.object({ label: z.string() })),
+    });
+    expect(widenOptionalsForStrictOutput(clean)).toBe(clean);
+  });
+
+  it("is rejected by the OpenAI strict serializer before widening and accepted after", () => {
+    const bare = z.object({ nextStep: z.string().min(10).optional() });
+    expect(() => zodResponseFormat(bare, "structured_response")).toThrow(
+      /optional\(\)/,
+    );
+    expect(() =>
+      zodResponseFormat(
+        widenOptionalsForStrictOutput(bare),
+        "structured_response",
+      ),
+    ).not.toThrow();
+  });
+
+  it.each([
+    ["CriterionGradeSchema", CriterionGradeSchema],
+    ["EvidenceValidationSchema", EvidenceValidationSchema],
+    ["JudgeCritiqueSchema", JudgeCritiqueSchema],
+    ["GradeSummarySchema", GradeSummarySchema],
+  ])(
+    "makes the production grading schema %s strict-serializable",
+    (_name, gradingSchema) => {
+      expect(() =>
+        zodResponseFormat(
+          widenOptionalsForStrictOutput(gradingSchema),
+          "structured_response",
+        ),
+      ).not.toThrow();
+    },
+  );
+
+  it("round-trips widened output back to the original schema's types", () => {
+    const widened = widenOptionalsForStrictOutput(CriterionGradeSchema);
+    const modelOutput = widened.parse({
+      score: 2,
+      rationale: "Meets the criterion with clear supporting evidence shown.",
+      citations: ["chunk-1"],
+      confidence: "high",
+      nextStep: null,
+    });
+    const normalized = normalizeWidenedOutput(
+      CriterionGradeSchema,
+      modelOutput,
+    );
+    expect(CriterionGradeSchema.parse(normalized)).toEqual({
+      score: 2,
+      rationale: "Meets the criterion with clear supporting evidence shown.",
+      citations: ["chunk-1"],
+      confidence: "high",
+    });
   });
 });

--- a/apps/api/src/api/llm/core/services/structured-output.util.ts
+++ b/apps/api/src/api/llm/core/services/structured-output.util.ts
@@ -1,9 +1,181 @@
 import { HumanMessage } from "@langchain/core/messages";
 import { ChatOpenAI } from "@langchain/openai";
 import { Logger } from "winston";
-import type { ZodTypeAny } from "zod";
+import {
+  ZodArray,
+  ZodDefault,
+  ZodEffects,
+  ZodNullable,
+  ZodObject,
+  ZodOptional,
+  ZodRawShape,
+  ZodRecord,
+  ZodTypeAny,
+  ZodUnion,
+} from "zod";
 import { LlmStructuredResponse } from "../interfaces/llm-provider.interface";
 import { ITokenCounter } from "../interfaces/token-counter.interface";
+
+/**
+ * OpenAI strict structured outputs require every schema field to be present
+ * in `required`, so the SDK rejects any Zod schema that uses `.optional()`
+ * without `.nullable()` before a request is even sent. Widen each optional
+ * field to also accept null for the API call; `normalizeWidenedOutput` maps
+ * the nulls the model emits for those fields back to undefined so callers
+ * keep the original schema's types. Subtrees that need no widening are
+ * returned as-is, so already-compatible schemas pass through unchanged.
+ */
+export function widenOptionalsForStrictOutput(schema: ZodTypeAny): ZodTypeAny {
+  if (schema instanceof ZodOptional) {
+    const inner = schema.unwrap() as ZodTypeAny;
+    const widenedInner = widenOptionalsForStrictOutput(inner);
+    if (widenedInner === inner && inner.isNullable()) {
+      return schema;
+    }
+    return new ZodOptional({
+      ...schema._def,
+      innerType: widenedInner.isNullable()
+        ? widenedInner
+        : ZodNullable.create(widenedInner),
+    });
+  }
+  if (schema instanceof ZodNullable) {
+    const inner = schema.unwrap() as ZodTypeAny;
+    const widenedInner = widenOptionalsForStrictOutput(inner);
+    return widenedInner === inner
+      ? schema
+      : new ZodNullable({ ...schema._def, innerType: widenedInner });
+  }
+  if (schema instanceof ZodDefault) {
+    const inner = schema.removeDefault() as ZodTypeAny;
+    const widenedInner = widenOptionalsForStrictOutput(inner);
+    return widenedInner === inner
+      ? schema
+      : new ZodDefault({ ...schema._def, innerType: widenedInner });
+  }
+  if (schema instanceof ZodEffects) {
+    const inner = schema.innerType() as ZodTypeAny;
+    const widenedInner = widenOptionalsForStrictOutput(inner);
+    return widenedInner === inner
+      ? schema
+      : new ZodEffects({ ...schema._def, schema: widenedInner });
+  }
+  if (schema instanceof ZodObject) {
+    const shape = schema.shape as ZodRawShape;
+    let changed = false;
+    const widenedShape: ZodRawShape = {};
+    for (const [key, value] of Object.entries(shape)) {
+      const widened = widenOptionalsForStrictOutput(value);
+      widenedShape[key] = widened;
+      changed = changed || widened !== value;
+    }
+    return changed
+      ? new ZodObject({ ...schema._def, shape: () => widenedShape })
+      : schema;
+  }
+  if (schema instanceof ZodArray) {
+    const element = schema.element as ZodTypeAny;
+    const widened = widenOptionalsForStrictOutput(element);
+    return widened === element
+      ? schema
+      : new ZodArray({ ...schema._def, type: widened });
+  }
+  if (schema instanceof ZodRecord) {
+    const value = schema.valueSchema as ZodTypeAny;
+    const widened = widenOptionalsForStrictOutput(value);
+    return widened === value
+      ? schema
+      : new ZodRecord({ ...schema._def, valueType: widened });
+  }
+  if (schema instanceof ZodUnion) {
+    const options = schema.options as ZodTypeAny[];
+    const widenedOptions = options.map((option) =>
+      widenOptionalsForStrictOutput(option),
+    );
+    return widenedOptions.every((option, index) => option === options[index])
+      ? schema
+      : new ZodUnion({
+          ...schema._def,
+          options: widenedOptions as [ZodTypeAny, ZodTypeAny, ...ZodTypeAny[]],
+        });
+  }
+  return schema;
+}
+
+/**
+ * Walk `value` alongside the ORIGINAL (pre-widening) schema and turn the
+ * nulls that only exist because of widening back into undefined. Fields the
+ * original schema already declared `.nullable()` keep their nulls.
+ */
+export function normalizeWidenedOutput(
+  schema: ZodTypeAny,
+  value: unknown,
+): unknown {
+  if (schema instanceof ZodOptional) {
+    const inner = schema.unwrap() as ZodTypeAny;
+    if (value === null && !inner.isNullable()) {
+      return undefined;
+    }
+    return normalizeWidenedOutput(inner, value);
+  }
+  if (schema instanceof ZodNullable) {
+    return value === null
+      ? null
+      : normalizeWidenedOutput(schema.unwrap() as ZodTypeAny, value);
+  }
+  if (schema instanceof ZodDefault) {
+    return normalizeWidenedOutput(schema.removeDefault() as ZodTypeAny, value);
+  }
+  if (schema instanceof ZodEffects) {
+    return normalizeWidenedOutput(schema.innerType() as ZodTypeAny, value);
+  }
+  if (schema instanceof ZodObject && isPlainObject(value)) {
+    const shape = schema.shape as ZodRawShape;
+    const normalized: Record<string, unknown> = {};
+    for (const [key, entry] of Object.entries(value)) {
+      const fieldSchema = shape[key];
+      if (!fieldSchema) {
+        normalized[key] = entry;
+        continue;
+      }
+      const normalizedEntry = normalizeWidenedOutput(fieldSchema, entry);
+      if (normalizedEntry !== undefined) {
+        normalized[key] = normalizedEntry;
+      }
+    }
+    return normalized;
+  }
+  if (schema instanceof ZodArray && Array.isArray(value)) {
+    const element = schema.element as ZodTypeAny;
+    return value.map((entry) => normalizeWidenedOutput(element, entry));
+  }
+  if (schema instanceof ZodRecord && isPlainObject(value)) {
+    const valueSchema = schema.valueSchema as ZodTypeAny;
+    return Object.fromEntries(
+      Object.entries(value).map(([key, entry]) => [
+        key,
+        normalizeWidenedOutput(valueSchema, entry),
+      ]),
+    );
+  }
+  return value;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+const widenedSchemaCache = new WeakMap<ZodTypeAny, ZodTypeAny>();
+
+function getWidenedSchema(schema: ZodTypeAny): ZodTypeAny {
+  const cached = widenedSchemaCache.get(schema);
+  if (cached) {
+    return cached;
+  }
+  const widened = widenOptionalsForStrictOutput(schema);
+  widenedSchemaCache.set(schema, widened);
+  return widened;
+}
 
 /**
  * Shared native-structured-output invocation for every ChatOpenAI-based
@@ -23,7 +195,7 @@ export async function invokeStructuredChatModel<T>(
   logger: Logger,
   modelName: string,
 ): Promise<LlmStructuredResponse<T>> {
-  const structuredModel = model.withStructuredOutput(schema, {
+  const structuredModel = model.withStructuredOutput(getWidenedSchema(schema), {
     name: "structured_response",
     includeRaw: true,
   });
@@ -49,14 +221,24 @@ export async function invokeStructuredChatModel<T>(
       raw: {
         usage_metadata?: { input_tokens?: number; output_tokens?: number };
       };
-      parsed: T;
+      parsed: T | null | undefined;
     };
+
+    // With includeRaw, LangChain reports schema-parse failures as
+    // parsed=null instead of throwing. Surface that as an error so callers
+    // hit their retry/fallback paths instead of crashing on a null grade.
+    if (result.parsed === null || result.parsed === undefined) {
+      throw new Error(
+        "Structured output parsing produced no result (model output did not match the schema)",
+      );
+    }
+
+    const parsed = normalizeWidenedOutput(schema, result.parsed) as T;
 
     const usage = result.raw?.usage_metadata;
     const inputUsed = usage?.input_tokens ?? inputTokens;
     const outputUsed =
-      usage?.output_tokens ??
-      tokenCounter.countTokens(JSON.stringify(result.parsed));
+      usage?.output_tokens ?? tokenCounter.countTokens(JSON.stringify(parsed));
 
     logger.info("openai.invokeStructured.complete", {
       model_name: modelName,
@@ -66,7 +248,7 @@ export async function invokeStructuredChatModel<T>(
     });
 
     return {
-      parsed: result.parsed,
+      parsed,
       tokenUsage: { input: inputUsed, output: outputUsed },
     };
   } catch (error) {

--- a/apps/jobs/.eslintrc.cjs
+++ b/apps/jobs/.eslintrc.cjs
@@ -8,11 +8,13 @@ module.exports = {
     warnOnUnsupportedTypeScriptVersion: false,
   },
   extends: [
-    "prettier",
     "eslint:recommended",
     "plugin:@typescript-eslint/recommended",
     "plugin:@typescript-eslint/recommended-requiring-type-checking",
     "plugin:unicorn/recommended",
+    // Must come last so it disables every formatting rule (e.g.
+    // unicorn/number-literal-case) that fights the pre-commit prettier pass.
+    "prettier",
   ],
   rules: {
     "unicorn/prefer-top-level-await": "off",


### PR DESCRIPTION
LangChain's nested openai SDK serializes every withStructuredOutput call in strict mode and rejects any schema field using .optional() without .nullable() client-side, before the request is sent. Since 2.5.0 wired structured output into all ChatOpenAI providers, every grading schema with a bare optional field (criterion nextStep, evidence note, judge summary, and others) failed on every invocation: file grading silently fell back to legacy grading and criteria-based text grading, which has no fallback, failed learner-visibly at ~3k gradings/day.

Fix at the shared choke point instead of editing every schema: widenOptionalsForStrictOutput rewrites optional fields to also accept null for the API call only, and normalizeWidenedOutput walks the original schema to map the model's nulls on those fields back to undefined, so callers keep the original inferred types. Fields that were already .nullable() keep their nulls. Schemas that need no widening pass through as the same instance.

Also surface LangChain's includeRaw parse failures (parsed: null) as a thrown error instead of returning a null grade to callers.

The spec resolves the openai SDK copy nested under @langchain/openai: the workspace-root openai is older, does not enforce the strict rule, and makes the repro assertions pass vacuously.
