### PR TITLE
Moderation verdicts: never block grades, never send severe content to completions

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -88,6 +88,7 @@
     "nest-winston": "^1.9.2",
     "node-xlsx": "^0.24.0",
     "nodemailer": "^8.0.11",
+    "openai": "^4.91.1",
     "passport": "^0.7.0",
     "passport-jwt": "^4.0.1",
     "pdf-lib": "^1.17.1",

--- a/apps/api/src/api/assignment/attempt/attempt.service.ts
+++ b/apps/api/src/api/assignment/attempt/attempt.service.ts
@@ -32,6 +32,7 @@ import { GradingKillSwitchService } from "src/api/ai-feature-flags/grading-kill-
 import { LlmFacadeService } from "src/api/llm/llm-facade.service";
 import { PresentationQuestionEvaluateModel } from "src/api/llm/model/presentation.question.evaluate.model";
 import { VideoPresentationQuestionEvaluateModel } from "src/api/llm/model/video-presentation.question.evaluate.model";
+import { hashSafetyIdentifier } from "src/api/llm/core/utils/safety-identifier.util";
 import {
   UserRole,
   UserSession,
@@ -576,6 +577,10 @@ export class AttemptServiceV1 implements OnModuleDestroy {
     request: UserSessionRequest,
   ): Promise<UpdateAssignmentAttemptResponseDto> {
     const { role, userId } = request.userSession;
+    // Owner of the attempt row, when one is loaded below (LEARNER role).
+    // Preferred over the session userId for the safety identifier, since it's
+    // the actual learner the attempt belongs to.
+    let attemptOwnerUserId: string | undefined;
     // Kill-switch: block submitting/grading an AI-graded attempt while grading
     // is disabled. The attempt is left un-submitted (progress preserved) and no
     // LLM call is made. Non-AI assignments pass through untouched.
@@ -601,6 +606,7 @@ export class AttemptServiceV1 implements OnModuleDestroy {
           `AssignmentAttempt with Id ${assignmentAttemptId} not found.`,
         );
       }
+      attemptOwnerUserId = assignmentAttempt.userId;
       const tenSecondsBeforeNow = new Date(Date.now() - 10 * 1000);
       if (
         assignmentAttempt.expiresAt &&
@@ -742,6 +748,7 @@ export class AttemptServiceV1 implements OnModuleDestroy {
       updateAssignmentAttemptDto.authorQuestions,
       updateAssignmentAttemptDto.authorAssignmentDetails,
       updateAssignmentAttemptDto.preTranslatedQuestions,
+      attemptOwnerUserId ?? userId,
     );
     const { grade, totalPointsEarned, totalPossiblePoints } =
       role === UserRole.LEARNER
@@ -1584,6 +1591,7 @@ export class AttemptServiceV1 implements OnModuleDestroy {
     authorQuestions?: QuestionDto[],
     assignmentDetails?: authorAssignmentDetailsDTO,
     preTranslatedQuestions?: Map<number, QuestionDto>,
+    userId?: string,
   ): Promise<CreateQuestionResponseAttemptResponseDto> {
     let question: QuestionDto;
     let assignmentContext: {
@@ -1673,6 +1681,7 @@ export class AttemptServiceV1 implements OnModuleDestroy {
       assignmentContext,
       assignmentId,
       language,
+      userId,
     );
     const learnerResponseJson = sanitizeUnicodeForJson(
       JSON.stringify(learnerResponse ?? ""),
@@ -2039,6 +2048,7 @@ export class AttemptServiceV1 implements OnModuleDestroy {
     authorQuestions?: QuestionDto[],
     assignmentDetails?: authorAssignmentDetailsDTO,
     preTranslatedQuestions?: Map<number, QuestionDto>,
+    userId?: string,
   ): Promise<CreateQuestionResponseAttemptResponseDto[]> {
     const questionResponsesPromise = responsesForQuestions.map(
       async (questionResponse) => {
@@ -2053,6 +2063,7 @@ export class AttemptServiceV1 implements OnModuleDestroy {
           authorQuestions,
           assignmentDetails,
           preTranslatedQuestions,
+          userId,
         );
       },
     );
@@ -2364,6 +2375,7 @@ export class AttemptServiceV1 implements OnModuleDestroy {
     },
     assignmentId: number,
     language: string,
+    userId?: string,
   ): Promise<{
     responseDto: CreateQuestionResponseAttemptResponseDto;
     learnerResponse:
@@ -2411,6 +2423,7 @@ export class AttemptServiceV1 implements OnModuleDestroy {
           assignmentContext,
           assignmentId,
           language,
+          userId,
         );
       }
       case QuestionType.LINK_FILE: {
@@ -2421,6 +2434,7 @@ export class AttemptServiceV1 implements OnModuleDestroy {
             assignmentContext,
             assignmentId,
             language,
+            userId,
           );
         } else if (
           createQuestionResponseAttemptRequestDto.learnerFileResponse
@@ -2431,6 +2445,7 @@ export class AttemptServiceV1 implements OnModuleDestroy {
             createQuestionResponseAttemptRequestDto,
             assignmentContext,
             language,
+            userId,
           );
         } else {
           throw new BadRequestException(
@@ -2445,6 +2460,7 @@ export class AttemptServiceV1 implements OnModuleDestroy {
             createQuestionResponseAttemptRequestDto,
             assignmentContext,
             assignmentId,
+            userId,
           );
         } else if (question.responseType === "PRESENTATION") {
           return this.handleVideoPresentationQuestionResponse(
@@ -2452,6 +2468,7 @@ export class AttemptServiceV1 implements OnModuleDestroy {
             createQuestionResponseAttemptRequestDto,
             assignmentContext,
             assignmentId,
+            userId,
           );
         } else {
           return this.handleFileUploadQuestionResponse(
@@ -2459,6 +2476,8 @@ export class AttemptServiceV1 implements OnModuleDestroy {
             question.type,
             createQuestionResponseAttemptRequestDto,
             assignmentContext,
+            undefined,
+            userId,
           );
         }
       }
@@ -2469,6 +2488,7 @@ export class AttemptServiceV1 implements OnModuleDestroy {
           assignmentContext,
           assignmentId,
           language,
+          userId,
         );
       }
       case QuestionType.TRUE_FALSE: {
@@ -2506,6 +2526,7 @@ export class AttemptServiceV1 implements OnModuleDestroy {
       questionAnswerContext: QuestionAnswerContext[];
     },
     assignmentId: number,
+    userId?: string,
   ): Promise<{
     responseDto: CreateQuestionResponseAttemptResponseDto;
     learnerResponse: LearnerPresentationResponse;
@@ -2530,6 +2551,9 @@ export class AttemptServiceV1 implements OnModuleDestroy {
         question.type,
         question.responseType ?? "OTHER",
       );
+    presentationQuestionEvaluateModel.safetyIdentifier = userId
+      ? hashSafetyIdentifier(userId)
+      : undefined;
 
     const model = await this.llmFacadeService.gradePresentationQuestion(
       presentationQuestionEvaluateModel,
@@ -2549,6 +2573,7 @@ export class AttemptServiceV1 implements OnModuleDestroy {
       questionAnswerContext: QuestionAnswerContext[];
     },
     assignmentId: number,
+    userId?: string,
   ): Promise<{
     responseDto: CreateQuestionResponseAttemptResponseDto;
     learnerResponse: LearnerPresentationResponse;
@@ -2574,6 +2599,9 @@ export class AttemptServiceV1 implements OnModuleDestroy {
         question.responseType ?? "OTHER",
         question.videoPresentationConfig,
       );
+    videoPresentationQuestionEvaluateModel.safetyIdentifier = userId
+      ? hashSafetyIdentifier(userId)
+      : undefined;
 
     const model = await this.llmFacadeService.gradeVideoPresentationQuestion(
       videoPresentationQuestionEvaluateModel,
@@ -2595,6 +2623,7 @@ export class AttemptServiceV1 implements OnModuleDestroy {
       questionAnswerContext: QuestionAnswerContext[];
     },
     language?: string,
+    userId?: string,
   ): Promise<{
     responseDto: CreateQuestionResponseAttemptResponseDto;
     learnerResponse: LearnerFileUpload[];
@@ -2619,6 +2648,9 @@ export class AttemptServiceV1 implements OnModuleDestroy {
       undefined,
       question.id,
     );
+    fileUploadQuestionEvaluateModel.safetyIdentifier = userId
+      ? hashSafetyIdentifier(userId)
+      : undefined;
     const model = await this.llmFacadeService.gradeFileBasedQuestion(
       fileUploadQuestionEvaluateModel,
       question.assignmentId,
@@ -2644,6 +2676,7 @@ export class AttemptServiceV1 implements OnModuleDestroy {
     },
     assignmentId: number,
     language?: string,
+    userId?: string,
   ): Promise<{
     responseDto: CreateQuestionResponseAttemptResponseDto;
     learnerResponse: string;
@@ -2663,6 +2696,9 @@ export class AttemptServiceV1 implements OnModuleDestroy {
       question.scoring,
       question.responseType ?? "OTHER",
     );
+    textBasedQuestionEvaluateModel.safetyIdentifier = userId
+      ? hashSafetyIdentifier(userId)
+      : undefined;
 
     const model = await this.llmFacadeService.gradeTextBasedQuestion(
       textBasedQuestionEvaluateModel,
@@ -2688,6 +2724,7 @@ export class AttemptServiceV1 implements OnModuleDestroy {
     },
     assignmentId: number,
     language?: string,
+    userId?: string,
   ): Promise<{
     responseDto: CreateQuestionResponseAttemptResponseDto;
     learnerResponse: string;
@@ -2721,6 +2758,9 @@ export class AttemptServiceV1 implements OnModuleDestroy {
       question.scoring,
       question.responseType ?? "OTHER",
     );
+    urlBasedQuestionEvaluateModel.safetyIdentifier = userId
+      ? hashSafetyIdentifier(userId)
+      : undefined;
 
     const model = await this.llmFacadeService.gradeUrlBasedQuestion(
       urlBasedQuestionEvaluateModel,

--- a/apps/api/src/api/attempt/common/interfaces/grading-context.interface.ts
+++ b/apps/api/src/api/attempt/common/interfaces/grading-context.interface.ts
@@ -43,4 +43,10 @@ export interface GradingContext {
    * Optional Prisma transactional client
    */
   tx?: PrismaTransactionalClient;
+
+  /**
+   * Attempt owner's userId (an email in this system). Used only to derive
+   * the hashed OpenAI safety identifier — never sent raw to providers.
+   */
+  userId?: string;
 }

--- a/apps/api/src/api/attempt/common/strategies/file-grading.strategy.moderation.spec.ts
+++ b/apps/api/src/api/attempt/common/strategies/file-grading.strategy.moderation.spec.ts
@@ -1,0 +1,90 @@
+import { FileGradingStrategy } from "./file-grading.strategy";
+import { FileBasedQuestionResponseModel } from "../../../llm/model/file.based.question.response.model";
+import { MODERATION_BLOCK_FEEDBACK } from "../../../llm/features/grading/constants";
+
+function mockLogger() {
+  const logger: any = {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+    child: jest.fn().mockReturnThis(),
+  };
+  return logger;
+}
+
+describe("FileGradingStrategy moderation short-circuit", () => {
+  it("does not run the judge loop when the facade returns a moderation-blocked result", async () => {
+    const strategy: any = Object.create(FileGradingStrategy.prototype);
+    strategy.logger = mockLogger();
+    strategy.recordGrading = jest.fn();
+
+    strategy.fileContentExtractionService = {
+      extractContentFromFiles: jest.fn().mockResolvedValue([
+        {
+          filename: "essay.txt",
+          content: "learner content",
+          fileType: "text/plain",
+          metadata: { size: 42 },
+        },
+      ]),
+    };
+
+    // The facade already applied the severe verdict and marked the result so
+    // downstream steps know not to re-send this content to a completion model.
+    const blockedModel = new FileBasedQuestionResponseModel(
+      0,
+      MODERATION_BLOCK_FEEDBACK,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      { moderationBlocked: true },
+    );
+    strategy.llmFacadeService = {
+      gradeFileBasedQuestion: jest.fn().mockResolvedValue(blockedModel),
+    };
+
+    const validateGrading = jest.fn();
+    strategy.gradingJudgeService = { validateGrading };
+
+    const question = {
+      id: 99,
+      question: "Upload your report",
+      totalPoints: 10,
+      scoring: null,
+      type: "UPLOAD",
+      responseType: "REPORT",
+    };
+
+    const learnerResponse = [
+      {
+        filename: "essay.txt",
+        content: "learner content",
+        key: "k",
+        bucket: "b",
+      },
+    ];
+
+    const responseDto = await strategy.gradeResponse(
+      question,
+      learnerResponse,
+      {
+        assignmentInstructions: "",
+        questionAnswerContext: [],
+        assignmentId: 1736,
+        userId: "learner@example.com",
+      },
+    );
+
+    expect(validateGrading).not.toHaveBeenCalled();
+    expect(
+      strategy.llmFacadeService.gradeFileBasedQuestion,
+    ).toHaveBeenCalledTimes(1);
+    expect(responseDto.totalPoints).toBe(0);
+    expect(responseDto.feedback[0].feedback).toBe(MODERATION_BLOCK_FEEDBACK);
+  });
+});

--- a/apps/api/src/api/attempt/common/strategies/file-grading.strategy.ts
+++ b/apps/api/src/api/attempt/common/strategies/file-grading.strategy.ts
@@ -16,6 +16,7 @@ import {
   ScoringDto,
 } from "src/api/assignment/dto/update.questions.request.dto";
 import { ScoringType } from "src/api/assignment/question/dto/create.update.question.request.dto";
+import { hashSafetyIdentifier } from "src/api/llm/core/utils/safety-identifier.util";
 import { LlmFacadeService } from "src/api/llm/llm-facade.service";
 import { FileUploadQuestionEvaluateModel } from "src/api/llm/model/file.based.question.evaluate.model";
 import { FileBasedQuestionResponseModel } from "src/api/llm/model/file.based.question.response.model";
@@ -321,6 +322,9 @@ export class FileGradingStrategy extends AbstractGradingStrategy<
       undefined,
       question.id,
     );
+    fileUploadQuestionEvaluateModel.safetyIdentifier = context.userId
+      ? hashSafetyIdentifier(context.userId)
+      : undefined;
 
     const gradingModel = await this.llmFacadeService.gradeFileBasedQuestion(
       fileUploadQuestionEvaluateModel,
@@ -836,6 +840,9 @@ export class FileGradingStrategy extends AbstractGradingStrategy<
           judgeFeedback,
           gradingModel.questionId,
         );
+        regradeModel.safetyIdentifier = context.userId
+          ? hashSafetyIdentifier(context.userId)
+          : undefined;
 
         const regraded = await this.llmFacadeService.gradeFileBasedQuestion(
           regradeModel,

--- a/apps/api/src/api/attempt/common/strategies/file-grading.strategy.ts
+++ b/apps/api/src/api/attempt/common/strategies/file-grading.strategy.ts
@@ -699,6 +699,14 @@ export class FileGradingStrategy extends AbstractGradingStrategy<
       return currentResponseDto;
     }
 
+    if (initialResponseDto.metadata?.moderationBlocked) {
+      this.logger?.info(
+        "Skipping outer judge loop — submission was moderation-blocked",
+        { questionId: question.id },
+      );
+      return currentResponseDto;
+    }
+
     if (initialResponseDto.metadata?.gradingAudit) {
       this.logger?.info(
         "Skipping outer judge loop — evidence pipeline already judged internally",

--- a/apps/api/src/api/attempt/common/strategies/image-grading.strategy.ts
+++ b/apps/api/src/api/attempt/common/strategies/image-grading.strategy.ts
@@ -12,6 +12,7 @@ import { CreateQuestionResponseAttemptResponseDto } from "src/api/assignment/att
 import { AttemptHelper } from "src/api/assignment/attempt/helper/attempts.helper";
 import { QuestionDto } from "src/api/assignment/dto/update.questions.request.dto";
 import { ScoringType } from "src/api/assignment/question/dto/create.update.question.request.dto";
+import { hashSafetyIdentifier } from "src/api/llm/core/utils/safety-identifier.util";
 import { ImageGradingService } from "src/api/llm/features/grading/services/image-grading.service";
 import { UnsupportedImageFormatError } from "src/api/llm/features/grading/errors/unsupported-image-format.error";
 import {
@@ -152,6 +153,9 @@ export class ImageGradingStrategy extends AbstractGradingStrategy<
       primaryImage.imageData,
       textualResponse,
     );
+    imageBasedQuestionEvaluateModel.safetyIdentifier = context.userId
+      ? hashSafetyIdentifier(context.userId)
+      : undefined;
 
     const gradingResult =
       await this.imageGradingService.gradeImageBasedQuestion(

--- a/apps/api/src/api/attempt/common/strategies/presentation-grading.strategy.ts
+++ b/apps/api/src/api/attempt/common/strategies/presentation-grading.strategy.ts
@@ -10,6 +10,7 @@ import { CreateQuestionResponseAttemptRequestDto } from "src/api/assignment/atte
 import { CreateQuestionResponseAttemptResponseDto } from "src/api/assignment/attempt/dto/question-response/create.question.response.attempt.response.dto";
 import { AttemptHelper } from "src/api/assignment/attempt/helper/attempts.helper";
 import { QuestionDto } from "src/api/assignment/dto/update.questions.request.dto";
+import { hashSafetyIdentifier } from "src/api/llm/core/utils/safety-identifier.util";
 import { LlmFacadeService } from "src/api/llm/llm-facade.service";
 import { PresentationQuestionEvaluateModel } from "src/api/llm/model/presentation.question.evaluate.model";
 import { VideoPresentationQuestionEvaluateModel } from "src/api/llm/model/video-presentation.question.evaluate.model";
@@ -205,6 +206,9 @@ export class PresentationGradingStrategy extends AbstractGradingStrategy<Learner
         question.type,
         question.responseType ?? "OTHER",
       );
+    presentationQuestionEvaluateModel.safetyIdentifier = context.userId
+      ? hashSafetyIdentifier(context.userId)
+      : undefined;
 
     const gradingModel = await this.llmFacadeService.gradePresentationQuestion(
       presentationQuestionEvaluateModel,
@@ -248,6 +252,9 @@ export class PresentationGradingStrategy extends AbstractGradingStrategy<Learner
         question.responseType ?? "OTHER",
         question.videoPresentationConfig,
       );
+    videoPresentationQuestionEvaluateModel.safetyIdentifier = context.userId
+      ? hashSafetyIdentifier(context.userId)
+      : undefined;
 
     const gradingModel =
       await this.llmFacadeService.gradeVideoPresentationQuestion(

--- a/apps/api/src/api/attempt/common/strategies/text-grading.strategy.safety.spec.ts
+++ b/apps/api/src/api/attempt/common/strategies/text-grading.strategy.safety.spec.ts
@@ -1,0 +1,40 @@
+import { TextGradingStrategy } from "./text-grading.strategy";
+import { hashSafetyIdentifier } from "../../../llm/core/utils/safety-identifier.util";
+
+describe("TextGradingStrategy safety identifier", () => {
+  it("sets the hashed owner id on the evaluate model", async () => {
+    const strategy: any = Object.create(TextGradingStrategy.prototype);
+    strategy.logger = {
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      debug: jest.fn(),
+      child: jest.fn().mockReturnThis(),
+    };
+    strategy.tryReuseFromConsistency = jest.fn().mockResolvedValue(null);
+    strategy.recordGrading = jest.fn();
+    strategy.appendRationale = jest.fn();
+    let capturedModel: any;
+    strategy.llmFacadeService = {
+      gradeTextBasedQuestion: jest.fn().mockImplementation((model) => {
+        capturedModel = model;
+        return Promise.resolve({ points: 1, feedback: "ok" });
+      }),
+    };
+
+    await strategy.gradeResponse(
+      { question: "Q", totalPoints: 1, responseType: "OTHER", scoring: null },
+      "an answer",
+      {
+        assignmentInstructions: "",
+        questionAnswerContext: [],
+        assignmentId: 1736,
+        userId: "learner@example.com",
+      },
+    );
+
+    expect(capturedModel.safetyIdentifier).toBe(
+      hashSafetyIdentifier("learner@example.com"),
+    );
+  });
+});

--- a/apps/api/src/api/attempt/common/strategies/text-grading.strategy.ts
+++ b/apps/api/src/api/attempt/common/strategies/text-grading.strategy.ts
@@ -12,6 +12,7 @@ import { CreateQuestionResponseAttemptResponseDto } from "src/api/assignment/att
 import { AttemptHelper } from "src/api/assignment/attempt/helper/attempts.helper";
 import { QuestionDto } from "src/api/assignment/dto/update.questions.request.dto";
 import { GradingConsistencyService } from "src/api/assignment/v2/services/grading-consistency.service";
+import { hashSafetyIdentifier } from "src/api/llm/core/utils/safety-identifier.util";
 import { IGradingJudgeService } from "src/api/llm/features/grading/interfaces/grading-judge.interface";
 import { LlmFacadeService } from "src/api/llm/llm-facade.service";
 import { GRADING_JUDGE_SERVICE } from "src/api/llm/llm.constants";
@@ -115,6 +116,9 @@ export class TextGradingStrategy extends AbstractGradingStrategy<string> {
         question.scoring,
         question.responseType ?? "OTHER",
       );
+      textBasedQuestionEvaluateModel.safetyIdentifier = context.userId
+        ? hashSafetyIdentifier(context.userId)
+        : undefined;
 
       const gradingModel = await this.llmFacadeService.gradeTextBasedQuestion(
         textBasedQuestionEvaluateModel,

--- a/apps/api/src/api/attempt/common/strategies/url-grading.strategy.ts
+++ b/apps/api/src/api/attempt/common/strategies/url-grading.strategy.ts
@@ -15,6 +15,7 @@ import { CreateQuestionResponseAttemptResponseDto } from "src/api/assignment/att
 import { AttemptHelper } from "src/api/assignment/attempt/helper/attempts.helper";
 import { QuestionDto } from "src/api/assignment/dto/update.questions.request.dto";
 import { safeGet } from "src/api/attempt/common/utils/ssrf-safe-http";
+import { hashSafetyIdentifier } from "src/api/llm/core/utils/safety-identifier.util";
 import { LlmFacadeService } from "src/api/llm/llm-facade.service";
 import { UrlBasedQuestionEvaluateModel } from "src/api/llm/model/url.based.question.evaluate.model";
 import { UrlBasedQuestionResponseModel } from "src/api/llm/model/url.based.question.response.model";
@@ -202,6 +203,9 @@ export class UrlGradingStrategy extends AbstractGradingStrategy<string> {
       question.scoring,
       question.responseType ?? "OTHER",
     );
+    urlBasedQuestionEvaluateModel.safetyIdentifier = context.userId
+      ? hashSafetyIdentifier(context.userId)
+      : undefined;
 
     let gradingModel: UrlBasedQuestionResponseModel;
     try {

--- a/apps/api/src/api/attempt/services/attempt-submission.service.ts
+++ b/apps/api/src/api/attempt/services/attempt-submission.service.ts
@@ -111,6 +111,11 @@ export class AttemptSubmissionService {
         userSession.role,
         assignmentId,
         language,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        userSession.userId,
       );
     } catch (error) {
       // The grading layers deliberately let these typed terminal errors pass
@@ -1252,6 +1257,7 @@ export class AttemptSubmissionService {
           updateDto.language,
           updateDto.preTranslatedQuestions,
           effectiveCache,
+          assignmentAttempt.userId,
         );
 
       const successfulQuestionResponses = gradedItems.map((g) => g.responseDto);

--- a/apps/api/src/api/attempt/services/question-response/question-response.service.ts
+++ b/apps/api/src/api/attempt/services/question-response/question-response.service.ts
@@ -273,6 +273,7 @@ export class QuestionResponseService {
     language: string,
     preTranslatedQuestions?: Map<number, QuestionDto>,
     cache?: JobScopedCache,
+    userId?: string,
   ): Promise<GradedItem[]> {
     // Defense-in-depth: allocate a cache if the caller did not supply one.
     // The submission entrypoint (updateLearnerAttempt) now hoists this same
@@ -399,6 +400,7 @@ export class QuestionResponseService {
           language,
           UserRole.LEARNER,
           assignmentAttemptId,
+          userId,
         );
       },
     });
@@ -529,6 +531,7 @@ export class QuestionResponseService {
     authorQuestions?: QuestionDto[],
     assignmentDetails?: authorAssignmentDetailsDTO,
     preTranslatedQuestions?: Map<number, QuestionDto>,
+    userId?: string,
   ): Promise<CreateQuestionResponseAttemptResponseDto[]> {
     // ── Phase 1: Read (short transaction) ────────────────────────────────────
     const { questionDtos, sorted, adj, inDegree } =
@@ -643,6 +646,7 @@ export class QuestionResponseService {
           language,
           role,
           assignmentAttemptId,
+          userId,
         );
       },
     });
@@ -740,6 +744,7 @@ export class QuestionResponseService {
     assignmentDetails?: authorAssignmentDetailsDTO,
     preTranslatedQuestions?: Map<number, QuestionDto>,
     tx?: PrismaTransactionalClient,
+    userId?: string,
   ): Promise<CreateQuestionResponseAttemptResponseDto> {
     const questionId = createQuestionResponseAttemptRequestDto.id;
 
@@ -777,6 +782,7 @@ export class QuestionResponseService {
       language,
       role,
       assignmentAttemptId,
+      userId,
     );
 
     if (role !== UserRole.AUTHOR) {
@@ -811,6 +817,7 @@ export class QuestionResponseService {
     language: string,
     role: UserRole,
     assignmentAttemptId: number,
+    userId?: string,
   ): Promise<{
     learnerResponse: unknown;
     responseDto: CreateQuestionResponseAttemptResponseDto;
@@ -831,6 +838,7 @@ export class QuestionResponseService {
       assignmentId,
       language,
       userRole: role,
+      userId,
       metadata: {
         attemptId: assignmentAttemptId,
         questionType: question.type,

--- a/apps/api/src/api/llm/core/interfaces/llm-provider.interface.ts
+++ b/apps/api/src/api/llm/core/interfaces/llm-provider.interface.ts
@@ -22,6 +22,11 @@ export interface LlmRequestOptions {
    * should set this low so attempts do not multiply.
    */
   maxRetries?: number;
+  /**
+   * Hashed end-user id forwarded to OpenAI as safety_identifier so abuse
+   * attributes to one end user instead of the whole org account.
+   */
+  safetyIdentifier?: string;
 }
 
 export interface LlmResponse {

--- a/apps/api/src/api/llm/core/interfaces/moderation.interface.ts
+++ b/apps/api/src/api/llm/core/interfaces/moderation.interface.ts
@@ -1,6 +1,24 @@
+export type ModerationAction = "allow" | "allow_with_log" | "block_severe";
+
+export interface ModerationVerdict {
+  action: ModerationAction;
+  flaggedCategories: string[];
+  severeCategories: string[];
+}
+
 export interface IModerationService {
   /**
-   * Check if content passes moderation guidelines
+   * Get a category-level moderation verdict for content (and optionally
+   * images) using OpenAI's moderations API.
+   */
+  assessContent(
+    content: string,
+    imageUrls?: string[],
+  ): Promise<ModerationVerdict>;
+
+  /**
+   * Check if content passes moderation guidelines. Kept for authoring;
+   * resolves to false ONLY when a severe category is flagged.
    */
   validateContent(content: string): Promise<boolean>;
 
@@ -8,12 +26,4 @@ export interface IModerationService {
    * Sanitize content by removing potentially harmful elements
    */
   sanitizeContent(content: string): string;
-
-  /**
-   * Get detailed moderation results for content
-   */
-  moderateContent(content: string): Promise<{
-    flagged: boolean;
-    details: string;
-  }>;
 }

--- a/apps/api/src/api/llm/core/services/gpt5-llm.service.ts
+++ b/apps/api/src/api/llm/core/services/gpt5-llm.service.ts
@@ -13,6 +13,7 @@ import {
 } from "../interfaces/llm-provider.interface";
 import { ITokenCounter } from "../interfaces/token-counter.interface";
 import { invokeStructuredChatModel } from "./structured-output.util";
+import { safetyIdentifierKwargs } from "../utils/safety-identifier.util";
 
 /**
  * GPT-5 provider service targeting the next-generation GPT-5 model.
@@ -41,6 +42,7 @@ export class Gpt5LlmService implements IMultimodalLlmProvider {
       maxCompletionTokens: options?.maxTokens,
       timeout: options?.timeoutMs,
       maxRetries: options?.maxRetries,
+      modelKwargs: safetyIdentifierKwargs(options),
     });
   }
 

--- a/apps/api/src/api/llm/core/services/gpt5-mini-llm.service.ts
+++ b/apps/api/src/api/llm/core/services/gpt5-mini-llm.service.ts
@@ -13,6 +13,7 @@ import {
 } from "../interfaces/llm-provider.interface";
 import { ITokenCounter } from "../interfaces/token-counter.interface";
 import { invokeStructuredChatModel } from "./structured-output.util";
+import { safetyIdentifierKwargs } from "../utils/safety-identifier.util";
 
 /**
  * Provider for the GPT-5 mini model.
@@ -39,6 +40,7 @@ export class Gpt5MiniLlmService implements IMultimodalLlmProvider {
       maxCompletionTokens: options?.maxTokens ?? 4096,
       timeout: options?.timeoutMs,
       maxRetries: options?.maxRetries,
+      modelKwargs: safetyIdentifierKwargs(options),
     });
   }
 

--- a/apps/api/src/api/llm/core/services/gpt5-nano-llm.service.ts
+++ b/apps/api/src/api/llm/core/services/gpt5-nano-llm.service.ts
@@ -13,6 +13,7 @@ import {
 } from "../interfaces/llm-provider.interface";
 import { ITokenCounter } from "../interfaces/token-counter.interface";
 import { invokeStructuredChatModel } from "./structured-output.util";
+import { safetyIdentifierKwargs } from "../utils/safety-identifier.util";
 
 /**
  * GPT-5-nano provider service targeting the ultra-lightweight GPT-5-nano model.
@@ -40,6 +41,7 @@ export class Gpt5NanoLlmService implements IMultimodalLlmProvider {
       modelName: options?.modelName ?? Gpt5NanoLlmService.DEFAULT_MODEL,
       timeout: options?.timeoutMs,
       maxRetries: options?.maxRetries,
+      modelKwargs: safetyIdentifierKwargs(options),
     });
   }
 

--- a/apps/api/src/api/llm/core/services/gpt54-llm.service.ts
+++ b/apps/api/src/api/llm/core/services/gpt54-llm.service.ts
@@ -13,6 +13,7 @@ import {
 } from "../interfaces/llm-provider.interface";
 import { ITokenCounter } from "../interfaces/token-counter.interface";
 import { invokeStructuredChatModel } from "./structured-output.util";
+import { safetyIdentifierKwargs } from "../utils/safety-identifier.util";
 
 abstract class PinnedGpt54LlmService implements IMultimodalLlmProvider {
   protected readonly logger: Logger;
@@ -37,7 +38,10 @@ abstract class PinnedGpt54LlmService implements IMultimodalLlmProvider {
       // LangChain's installed OpenAI SDK types predate GPT-5.4's `none`
       // effort, so pass the documented Chat Completions field through its
       // forward-compatible model kwargs bag.
-      modelKwargs: { reasoning_effort: "none" },
+      modelKwargs: {
+        reasoning_effort: "none",
+        ...safetyIdentifierKwargs(options),
+      },
       maxCompletionTokens: options?.maxTokens ?? 4096,
       timeout: options?.timeoutMs,
       maxRetries: options?.maxRetries,

--- a/apps/api/src/api/llm/core/services/llm-provider-request-options.spec.ts
+++ b/apps/api/src/api/llm/core/services/llm-provider-request-options.spec.ts
@@ -1,5 +1,6 @@
 import { HumanMessage } from "@langchain/core/messages";
 import { ChatOpenAI } from "@langchain/openai";
+import { Gpt54MiniLlmService } from "./gpt54-llm.service";
 import { Gpt5LlmService } from "./gpt5-llm.service";
 import { Gpt5MiniLlmService } from "./gpt5-mini-llm.service";
 import { Gpt5NanoLlmService } from "./gpt5-nano-llm.service";
@@ -22,6 +23,7 @@ const PROVIDERS = [
   ["Gpt5NanoLlmService", Gpt5NanoLlmService],
   ["Gpt4VisionPreviewLlmService", Gpt4VisionPreviewLlmService],
   ["OpenAiLlmMiniService", OpenAiLlmMiniService],
+  ["Gpt54MiniLlmService", Gpt54MiniLlmService],
 ] as const;
 
 describe.each(PROVIDERS)("%s request options", (_name, Provider) => {
@@ -69,5 +71,54 @@ describe.each(PROVIDERS)("%s request options", (_name, Provider) => {
     ];
     expect(config.timeout).toBeUndefined();
     expect(config.maxRetries).toBeUndefined();
+  });
+
+  it("forwards safetyIdentifier as modelKwargs.safety_identifier", async () => {
+    const service = makeService();
+
+    await service.invoke([new HumanMessage("hi")], {
+      safetyIdentifier: "abc123",
+    });
+
+    expect(ChatOpenAI).toHaveBeenCalledWith(
+      expect.objectContaining({
+        modelKwargs: expect.objectContaining({ safety_identifier: "abc123" }),
+      }),
+    );
+  });
+});
+
+describe("Gpt54MiniLlmService modelKwargs merge", () => {
+  beforeEach(() => {
+    (ChatOpenAI as unknown as jest.Mock).mockClear();
+  });
+
+  it("keeps reasoning_effort alongside safety_identifier", async () => {
+    const tokenCounter = { countTokens: jest.fn().mockReturnValue(1) };
+    const logger = {
+      child: jest.fn(),
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    };
+    logger.child.mockReturnValue(logger);
+    const service = new Gpt54MiniLlmService(
+      tokenCounter as never,
+      logger as never,
+    );
+
+    await service.invoke([new HumanMessage("hi")], {
+      safetyIdentifier: "abc123",
+    });
+
+    expect(ChatOpenAI).toHaveBeenCalledWith(
+      expect.objectContaining({
+        modelKwargs: expect.objectContaining({
+          reasoning_effort: "none",
+          safety_identifier: "abc123",
+        }),
+      }),
+    );
   });
 });

--- a/apps/api/src/api/llm/core/services/moderation.service.spec.ts
+++ b/apps/api/src/api/llm/core/services/moderation.service.spec.ts
@@ -87,6 +87,24 @@ describe("ModerationService.assessContent", () => {
     expect(logger.error).toHaveBeenCalled();
   });
 
+  it("fails open (allow) when the client cannot be constructed (missing key)", async () => {
+    const service: any = Object.create(ModerationService.prototype);
+    service.logger = mockLogger();
+    service.severeCategories = new Set(["sexual/minors"]);
+    service.getClient = jest.fn(() => {
+      throw new Error("no key");
+    });
+
+    const verdict = await service.assessContent("x");
+
+    expect(verdict).toEqual({
+      action: "allow",
+      flaggedCategories: [],
+      severeCategories: [],
+    });
+    expect(service.logger.error).toHaveBeenCalled();
+  });
+
   it("allows empty content without calling the API", async () => {
     const create = jest.fn();
     const { service } = buildService(create);
@@ -95,6 +113,31 @@ describe("ModerationService.assessContent", () => {
 
     expect(verdict.action).toBe("allow");
     expect(create).not.toHaveBeenCalled();
+  });
+
+  it("aggregates flagged categories across multiple results", async () => {
+    const create = jest.fn().mockResolvedValue({
+      results: [
+        {
+          flagged: false,
+          categories: {},
+          category_scores: {},
+        },
+        {
+          flagged: true,
+          categories: { "sexual/minors": true },
+          category_scores: {},
+        },
+      ],
+    });
+    const { service } = buildService(create);
+
+    const verdict = await service.assessContent("caption", [
+      "data:image/png;base64,AAAA",
+    ]);
+
+    expect(verdict.action).toBe("block_severe");
+    expect(verdict.severeCategories).toEqual(["sexual/minors"]);
   });
 
   it("includes image parts in the moderation input", async () => {
@@ -155,6 +198,14 @@ describe("parseSevereCategories", () => {
     expect(parsed).toEqual(
       new Set(["sexual/minors", "harassment/threatening"]),
     );
+    expect(logger.warn).toHaveBeenCalled();
+  });
+
+  it("falls back to the default set when every name is unknown", () => {
+    const logger = mockLogger();
+    const parsed = parseSevereCategories("bogus-one, bogus-two", logger);
+
+    expect(parsed).toEqual(new Set(["sexual/minors"]));
     expect(logger.warn).toHaveBeenCalled();
   });
 });

--- a/apps/api/src/api/llm/core/services/moderation.service.spec.ts
+++ b/apps/api/src/api/llm/core/services/moderation.service.spec.ts
@@ -140,19 +140,56 @@ describe("ModerationService.assessContent", () => {
     expect(verdict.severeCategories).toEqual(["sexual/minors"]);
   });
 
-  it("includes image parts in the moderation input", async () => {
+  it("splits text and images into two separate moderation calls", async () => {
     const create = jest.fn().mockResolvedValue(moderationResponse({}));
     const { service } = buildService(create);
 
     await service.assessContent("caption", ["data:image/png;base64,AAAA"]);
 
-    expect(create).toHaveBeenCalledWith({
+    expect(create).toHaveBeenCalledTimes(2);
+    expect(create).toHaveBeenNthCalledWith(1, {
+      model: "omni-moderation-latest",
+      input: [{ type: "text", text: "caption" }],
+    });
+    expect(create).toHaveBeenNthCalledWith(2, {
       model: "omni-moderation-latest",
       input: [
-        { type: "text", text: "caption" },
         { type: "image_url", image_url: { url: "data:image/png;base64,AAAA" } },
       ],
     });
+  });
+
+  it("still moderates text via its own call when the image call fails, and does not fail open on the text verdict", async () => {
+    const create = jest
+      .fn()
+      .mockResolvedValueOnce(moderationResponse({}))
+      .mockRejectedValueOnce(new Error("could not fetch image url"));
+    const { service, logger } = buildService(create);
+
+    const verdict = await service.assessContent("clean caption", [
+      "https://example.com/unreachable.png",
+    ]);
+
+    expect(create).toHaveBeenCalledTimes(2);
+    expect(verdict.action).toBe("allow");
+    expect(logger.error).toHaveBeenCalledWith(expect.stringContaining("image"));
+  });
+
+  it("still returns block_severe from the text call when the image call fails", async () => {
+    const create = jest
+      .fn()
+      .mockResolvedValueOnce(moderationResponse({ "sexual/minors": true }))
+      .mockRejectedValueOnce(new Error("could not fetch image url"));
+    const { service, logger } = buildService(create);
+
+    const verdict = await service.assessContent("bad caption", [
+      "https://example.com/unreachable.png",
+    ]);
+
+    expect(create).toHaveBeenCalledTimes(2);
+    expect(verdict.action).toBe("block_severe");
+    expect(verdict.severeCategories).toEqual(["sexual/minors"]);
+    expect(logger.error).toHaveBeenCalledWith(expect.stringContaining("image"));
   });
 });
 

--- a/apps/api/src/api/llm/core/services/moderation.service.spec.ts
+++ b/apps/api/src/api/llm/core/services/moderation.service.spec.ts
@@ -1,0 +1,160 @@
+import { ModerationService, parseSevereCategories } from "./moderation.service";
+
+function mockLogger() {
+  const logger: any = {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+    child: jest.fn(),
+  };
+  logger.child.mockReturnValue(logger);
+  return logger;
+}
+
+function buildService(createMock: jest.Mock) {
+  const service: any = Object.create(ModerationService.prototype);
+  service.logger = mockLogger();
+  service.severeCategories = new Set(["sexual/minors"]);
+  service.openAiClient = { moderations: { create: createMock } };
+  return { service, logger: service.logger };
+}
+
+function moderationResponse(categories: Record<string, boolean>) {
+  return {
+    results: [
+      {
+        flagged: Object.values(categories).some(Boolean),
+        categories,
+        category_scores: {},
+      },
+    ],
+  };
+}
+
+describe("ModerationService.assessContent", () => {
+  it("allows clean content", async () => {
+    const create = jest.fn().mockResolvedValue(moderationResponse({}));
+    const { service } = buildService(create);
+
+    const verdict = await service.assessContent("a normal essay");
+
+    expect(verdict).toEqual({
+      action: "allow",
+      flaggedCategories: [],
+      severeCategories: [],
+    });
+    expect(create).toHaveBeenCalledWith({
+      model: "omni-moderation-latest",
+      input: [{ type: "text", text: "a normal essay" }],
+    });
+  });
+
+  it("returns allow_with_log for a non-severe flag (the rootkit case)", async () => {
+    const create = jest
+      .fn()
+      .mockResolvedValue(moderationResponse({ violence: true }));
+    const { service } = buildService(create);
+
+    const verdict = await service.assessContent("describe a rootkit");
+
+    expect(verdict.action).toBe("allow_with_log");
+    expect(verdict.flaggedCategories).toEqual(["violence"]);
+    expect(verdict.severeCategories).toEqual([]);
+  });
+
+  it("returns block_severe when a severe category flags", async () => {
+    const create = jest
+      .fn()
+      .mockResolvedValue(
+        moderationResponse({ "sexual/minors": true, sexual: true }),
+      );
+    const { service } = buildService(create);
+
+    const verdict = await service.assessContent("bad");
+
+    expect(verdict.action).toBe("block_severe");
+    expect(verdict.severeCategories).toEqual(["sexual/minors"]);
+  });
+
+  it("fails open (allow) when the moderation API errors", async () => {
+    const create = jest.fn().mockRejectedValue(new Error("api down"));
+    const { service, logger } = buildService(create);
+
+    const verdict = await service.assessContent("anything");
+
+    expect(verdict.action).toBe("allow");
+    expect(logger.error).toHaveBeenCalled();
+  });
+
+  it("allows empty content without calling the API", async () => {
+    const create = jest.fn();
+    const { service } = buildService(create);
+
+    const verdict = await service.assessContent("");
+
+    expect(verdict.action).toBe("allow");
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it("includes image parts in the moderation input", async () => {
+    const create = jest.fn().mockResolvedValue(moderationResponse({}));
+    const { service } = buildService(create);
+
+    await service.assessContent("caption", ["data:image/png;base64,AAAA"]);
+
+    expect(create).toHaveBeenCalledWith({
+      model: "omni-moderation-latest",
+      input: [
+        { type: "text", text: "caption" },
+        { type: "image_url", image_url: { url: "data:image/png;base64,AAAA" } },
+      ],
+    });
+  });
+});
+
+describe("ModerationService.validateContent (authoring gate)", () => {
+  it("passes ordinary flags and logs them", async () => {
+    const create = jest
+      .fn()
+      .mockResolvedValue(moderationResponse({ violence: true }));
+    const { service, logger } = buildService(create);
+
+    await expect(service.validateContent("pentest question")).resolves.toBe(
+      true,
+    );
+    expect(logger.warn).toHaveBeenCalledWith(
+      "authoring.moderation.flagged",
+      expect.objectContaining({ categories: ["violence"] }),
+    );
+  });
+
+  it("fails only on severe categories", async () => {
+    const create = jest
+      .fn()
+      .mockResolvedValue(moderationResponse({ "sexual/minors": true }));
+    const { service } = buildService(create);
+
+    await expect(service.validateContent("bad")).resolves.toBe(false);
+  });
+});
+
+describe("parseSevereCategories", () => {
+  it("defaults to sexual/minors", () => {
+    expect([...parseSevereCategories("", mockLogger())]).toEqual([
+      "sexual/minors",
+    ]);
+  });
+
+  it("parses a csv and ignores unknown names with a warning", () => {
+    const logger = mockLogger();
+    const parsed = parseSevereCategories(
+      "sexual/minors, harassment/threatening, not-a-category",
+      logger,
+    );
+    expect(parsed).toEqual(
+      new Set(["sexual/minors", "harassment/threatening"]),
+    );
+    expect(logger.warn).toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/api/llm/core/services/moderation.service.ts
+++ b/apps/api/src/api/llm/core/services/moderation.service.ts
@@ -95,43 +95,16 @@ export class ModerationService implements IModerationService {
     }
     if (input.length === 0) return allow;
 
+    let response: OpenAI.ModerationCreateResponse;
     try {
-      const response = await this.getClient().moderations.create({
+      response = await this.getClient().moderations.create({
         model: MODERATION_MODEL,
         input,
       });
-
-      const flagged = new Set<string>();
-      for (const result of response.results) {
-        for (const [category, isFlagged] of Object.entries(result.categories)) {
-          if (isFlagged) flagged.add(category);
-        }
-      }
-      const flaggedCategories = [...flagged].sort();
-      const severeCategories = flaggedCategories.filter((category) =>
-        this.severeCategories.has(category),
-      );
-
-      logAiInvocation(this.logger, {
-        modelKey: MODERATION_MODEL_KEY,
-        purpose: "moderation",
-        prompt: content,
-        response: JSON.stringify(flaggedCategories),
-      });
-
-      if (severeCategories.length > 0) {
-        return { action: "block_severe", flaggedCategories, severeCategories };
-      }
-      if (flaggedCategories.length > 0) {
-        return {
-          action: "allow_with_log",
-          flaggedCategories,
-          severeCategories: [],
-        };
-      }
-      return allow;
     } catch (error) {
-      // Fail open: OpenAI being unreachable must never stop grading.
+      // Fail open: OpenAI being unreachable must never stop grading. Scoped
+      // to only the API call so a downstream error (e.g. logging) can never
+      // downgrade an already-computed severe verdict to allow.
       this.logger.error(
         `Error validating content: ${
           error instanceof Error ? error.message : "Unknown error"
@@ -139,6 +112,36 @@ export class ModerationService implements IModerationService {
       );
       return allow;
     }
+
+    const flagged = new Set<string>();
+    for (const result of response.results) {
+      for (const [category, isFlagged] of Object.entries(result.categories)) {
+        if (isFlagged) flagged.add(category);
+      }
+    }
+    const flaggedCategories = [...flagged].sort();
+    const severeCategories = flaggedCategories.filter((category) =>
+      this.severeCategories.has(category),
+    );
+
+    logAiInvocation(this.logger, {
+      modelKey: MODERATION_MODEL_KEY,
+      purpose: "moderation",
+      prompt: content,
+      response: JSON.stringify(flaggedCategories),
+    });
+
+    if (severeCategories.length > 0) {
+      return { action: "block_severe", flaggedCategories, severeCategories };
+    }
+    if (flaggedCategories.length > 0) {
+      return {
+        action: "allow_with_log",
+        flaggedCategories,
+        severeCategories: [],
+      };
+    }
+    return allow;
   }
 
   async validateContent(content: string): Promise<boolean> {

--- a/apps/api/src/api/llm/core/services/moderation.service.ts
+++ b/apps/api/src/api/llm/core/services/moderation.service.ts
@@ -1,133 +1,161 @@
-import { HttpException, HttpStatus, Inject, Injectable } from "@nestjs/common";
+import { Inject, Injectable } from "@nestjs/common";
 import { sanitize } from "isomorphic-dompurify";
-import { OpenAIModerationChain } from "@langchain/classic/chains";
+import OpenAI from "openai";
 import { WINSTON_MODULE_PROVIDER } from "nest-winston";
 import { Logger } from "winston";
-import { IModerationService } from "../interfaces/moderation.interface";
+import {
+  IModerationService,
+  ModerationVerdict,
+} from "../interfaces/moderation.interface";
 import { logAiInvocation } from "../utils/ai-invocation-log.util";
 
+const MODERATION_MODEL = "omni-moderation-latest";
+
 /**
- * OpenAIModerationChain does not expose which moderation model the endpoint
- * ran, so invocations are logged under this generic key.
+ * The moderations endpoint does not expose which snapshot ran, so
+ * invocations are logged under this generic key.
  */
 const MODERATION_MODEL_KEY = "openai-moderation";
+
+const KNOWN_CATEGORIES = new Set([
+  "harassment",
+  "harassment/threatening",
+  "hate",
+  "hate/threatening",
+  "illicit",
+  "illicit/violent",
+  "self-harm",
+  "self-harm/instructions",
+  "self-harm/intent",
+  "sexual",
+  "sexual/minors",
+  "violence",
+  "violence/graphic",
+]);
+
+const DEFAULT_SEVERE_CATEGORIES = ["sexual/minors"];
+
+export function parseSevereCategories(
+  raw: string,
+  logger: Logger,
+): Set<string> {
+  const names = raw
+    .split(",")
+    .map((name) => name.trim())
+    .filter(Boolean);
+  if (names.length === 0) return new Set(DEFAULT_SEVERE_CATEGORIES);
+
+  const severe = new Set<string>();
+  for (const name of names) {
+    if (KNOWN_CATEGORIES.has(name)) {
+      severe.add(name);
+    } else {
+      logger.warn("moderation.severe_categories.unknown_name", { name });
+    }
+  }
+  return severe.size > 0 ? severe : new Set(DEFAULT_SEVERE_CATEGORIES);
+}
 
 @Injectable()
 export class ModerationService implements IModerationService {
   private readonly logger: Logger;
+  private readonly severeCategories: Set<string>;
+  private openAiClient?: OpenAI;
 
   constructor(@Inject(WINSTON_MODULE_PROVIDER) parentLogger: Logger) {
     this.logger = parentLogger.child({ context: ModerationService.name });
+    this.severeCategories = parseSevereCategories(
+      process.env.MODERATION_SEVERE_CATEGORIES ?? "",
+      this.logger,
+    );
   }
 
   /**
-   * Check if content passes the guard rails
+   * Lazy so a missing OPENAI_API_KEY fails open per-call instead of
+   * crashing module init in environments without a key.
    */
-  async validateContent(content: string): Promise<boolean> {
-    if (!content) return true;
+  private getClient(): OpenAI {
+    this.openAiClient ??= new OpenAI();
+    return this.openAiClient;
+  }
 
-    if (this.isEducationalContent(content)) {
-      this.logger.debug(
-        "Content appears to be educational/technical, allowing with less strict moderation",
-      );
-      return true;
+  async assessContent(
+    content: string,
+    imageUrls?: string[],
+  ): Promise<ModerationVerdict> {
+    const allow: ModerationVerdict = {
+      action: "allow",
+      flaggedCategories: [],
+      severeCategories: [],
+    };
+    const input: OpenAI.ModerationMultiModalInput[] = [];
+    if (content) input.push({ type: "text", text: content });
+    for (const url of imageUrls ?? []) {
+      input.push({ type: "image_url", image_url: { url } });
     }
+    if (input.length === 0) return allow;
 
     try {
-      const moderation = new OpenAIModerationChain();
-
-      const { output: guardRailsResponse } = await moderation.invoke({
-        input: content,
+      const response = await this.getClient().moderations.create({
+        model: MODERATION_MODEL,
+        input,
       });
+
+      const flagged = new Set<string>();
+      for (const result of response.results) {
+        for (const [category, isFlagged] of Object.entries(result.categories)) {
+          if (isFlagged) flagged.add(category);
+        }
+      }
+      const flaggedCategories = [...flagged].sort();
+      const severeCategories = flaggedCategories.filter((category) =>
+        this.severeCategories.has(category),
+      );
 
       logAiInvocation(this.logger, {
         modelKey: MODERATION_MODEL_KEY,
         purpose: "moderation",
         prompt: content,
-        response: String(guardRailsResponse),
+        response: JSON.stringify(flaggedCategories),
       });
 
-      const isViolation =
-        guardRailsResponse ===
-        "Text was found that violates OpenAI's content policy.";
-
-      if (isViolation) {
-        this.logger.warn(
-          `Content flagged by moderation: ${content.slice(0, 200)}...`,
-        );
+      if (severeCategories.length > 0) {
+        return { action: "block_severe", flaggedCategories, severeCategories };
       }
-
-      return !isViolation;
+      if (flaggedCategories.length > 0) {
+        return {
+          action: "allow_with_log",
+          flaggedCategories,
+          severeCategories: [],
+        };
+      }
+      return allow;
     } catch (error) {
+      // Fail open: OpenAI being unreachable must never stop grading.
       this.logger.error(
         `Error validating content: ${
           error instanceof Error ? error.message : "Unknown error"
         }`,
       );
-
-      return true;
+      return allow;
     }
   }
 
-  private isEducationalContent(content: string): boolean {
-    const educationalIndicators = [
-      "xss",
-      "cross-site scripting",
-      "security",
-      "vulnerability",
-      "penetration testing",
-      "cybersecurity",
-      "sql injection",
-      "csrf",
-      "owasp",
-      "security report",
-      "vulnerability assessment",
-      "security analysis",
-      "ethical hacking",
-
-      "algorithm",
-      "data structure",
-      "programming",
-      "software development",
-      "computer science",
-      "technical documentation",
-      "code example",
-      "tutorial",
-      "documentation",
-      "technical report",
-      "analysis",
-      "implementation",
-
-      "research",
-      "study",
-      "analysis",
-      "conclusion",
-      "methodology",
-      "findings",
-      "bibliography",
-      "references",
-      "abstract",
-      "introduction",
-    ];
-
-    const lowerContent = content.toLowerCase();
-    const matchCount = educationalIndicators.filter((indicator) =>
-      lowerContent.includes(indicator),
-    ).length;
-
-    return matchCount >= 2;
+  async validateContent(content: string): Promise<boolean> {
+    const verdict = await this.assessContent(content);
+    if (verdict.action === "allow_with_log") {
+      this.logger.warn("authoring.moderation.flagged", {
+        categories: verdict.flaggedCategories,
+      });
+    }
+    return verdict.action !== "block_severe";
   }
 
-  /**
-   * Sanitize the content by removing any potentially harmful or unnecessary elements.
-   * This method uses DOMPurify to remove scripts or other dangerous HTML content.
-   */
   sanitizeContent(content: string): string {
     if (!content) return "";
 
     try {
-      const sanitizedContent = sanitize(content);
-      return sanitizedContent;
+      return sanitize(content);
     } catch (error) {
       this.logger.error(
         `Error sanitizing content: ${
@@ -136,42 +164,6 @@ export class ModerationService implements IModerationService {
       );
 
       return content;
-    }
-  }
-
-  /**
-   * Moderate the content using OpenAI's moderation API
-   */
-  async moderateContent(
-    content: string,
-  ): Promise<{ flagged: boolean; details: string }> {
-    if (!content) {
-      return { flagged: false, details: "No content provided for moderation." };
-    }
-
-    try {
-      const moderationChain = new OpenAIModerationChain();
-      const moderationResult = await moderationChain.invoke({ input: content });
-
-      const flagged = moderationResult.output !== "No issues found.";
-      const details: string = moderationResult.output as string;
-
-      logAiInvocation(this.logger, {
-        modelKey: MODERATION_MODEL_KEY,
-        purpose: "moderation",
-        prompt: content,
-        response: details,
-      });
-
-      return { flagged, details };
-    } catch (error) {
-      this.logger.error(
-        `Content moderation failed: ${(error as Error).message}`,
-      );
-      throw new HttpException(
-        "Content moderation failed",
-        HttpStatus.INTERNAL_SERVER_ERROR,
-      );
     }
   }
 }

--- a/apps/api/src/api/llm/core/services/moderation.service.ts
+++ b/apps/api/src/api/llm/core/services/moderation.service.ts
@@ -88,36 +88,41 @@ export class ModerationService implements IModerationService {
       flaggedCategories: [],
       severeCategories: [],
     };
-    const input: OpenAI.ModerationMultiModalInput[] = [];
-    if (content) input.push({ type: "text", text: content });
-    for (const url of imageUrls ?? []) {
-      input.push({ type: "image_url", image_url: { url } });
-    }
-    if (input.length === 0) return allow;
 
-    let response: OpenAI.ModerationCreateResponse;
-    try {
-      response = await this.getClient().moderations.create({
-        model: MODERATION_MODEL,
-        input,
-      });
-    } catch (error) {
-      // Fail open: OpenAI being unreachable must never stop grading. Scoped
-      // to only the API call so a downstream error (e.g. logging) can never
-      // downgrade an already-computed severe verdict to allow.
-      this.logger.error(
-        `Error validating content: ${
-          error instanceof Error ? error.message : "Unknown error"
-        }`,
+    const hasText = !!content;
+    const images = imageUrls ?? [];
+    const hasImages = images.length > 0;
+    if (!hasText && !hasImages) return allow;
+
+    // Text and images are sent as two independent moderations.create calls
+    // rather than one combined call. A single call means OpenAI failing to
+    // fetch an image URL errors the WHOLE call, and the catch's fail-open
+    // would downgrade an already-computed severe TEXT verdict to allow too.
+    // Splitting scopes each call's failure to only its own input class.
+    // Single-input callers (text-only or image-only) still make one call.
+    const flaggedByClass: string[][] = [];
+    if (hasText) {
+      flaggedByClass.push(
+        await this.runModeration([{ type: "text", text: content }], "text"),
       );
-      return allow;
+    }
+    if (hasImages) {
+      flaggedByClass.push(
+        await this.runModeration(
+          images.map(
+            (url): OpenAI.ModerationMultiModalInput => ({
+              type: "image_url",
+              image_url: { url },
+            }),
+          ),
+          "image",
+        ),
+      );
     }
 
     const flagged = new Set<string>();
-    for (const result of response.results) {
-      for (const [category, isFlagged] of Object.entries(result.categories)) {
-        if (isFlagged) flagged.add(category);
-      }
+    for (const categories of flaggedByClass) {
+      for (const category of categories) flagged.add(category);
     }
     const flaggedCategories = [...flagged].sort();
     const severeCategories = flaggedCategories.filter((category) =>
@@ -142,6 +147,38 @@ export class ModerationService implements IModerationService {
       };
     }
     return allow;
+  }
+
+  /**
+   * Runs a single moderations.create call for one input class (text or
+   * images) and fails open ONLY for that class's content on error. Scoped
+   * so a failure here (e.g. an unfetchable image URL) can never downgrade a
+   * verdict already computed from the other class's call.
+   */
+  private async runModeration(
+    input: OpenAI.ModerationMultiModalInput[],
+    inputClass: "text" | "image",
+  ): Promise<string[]> {
+    try {
+      const response = await this.getClient().moderations.create({
+        model: MODERATION_MODEL,
+        input,
+      });
+      const flagged = new Set<string>();
+      for (const result of response.results) {
+        for (const [category, isFlagged] of Object.entries(result.categories)) {
+          if (isFlagged) flagged.add(category);
+        }
+      }
+      return [...flagged];
+    } catch (error) {
+      this.logger.error(
+        `Error validating content (${inputClass}): ${
+          error instanceof Error ? error.message : "Unknown error"
+        }`,
+      );
+      return [];
+    }
   }
 
   async validateContent(content: string): Promise<boolean> {

--- a/apps/api/src/api/llm/core/services/openai-llm-mini.service.ts
+++ b/apps/api/src/api/llm/core/services/openai-llm-mini.service.ts
@@ -13,6 +13,7 @@ import {
 } from "../interfaces/llm-provider.interface";
 import { ITokenCounter } from "../interfaces/token-counter.interface";
 import { invokeStructuredChatModel } from "./structured-output.util";
+import { safetyIdentifierKwargs } from "../utils/safety-identifier.util";
 
 /**
  * Light-weight provider that targets the smaller/faster gpt-4o-mini model.
@@ -39,6 +40,7 @@ export class OpenAiLlmMiniService implements IMultimodalLlmProvider {
       maxTokens: options?.maxTokens,
       timeout: options?.timeoutMs,
       maxRetries: options?.maxRetries,
+      modelKwargs: safetyIdentifierKwargs(options),
     });
   }
 

--- a/apps/api/src/api/llm/core/services/openai-llm-vision.service.ts
+++ b/apps/api/src/api/llm/core/services/openai-llm-vision.service.ts
@@ -13,6 +13,7 @@ import {
 } from "../interfaces/llm-provider.interface";
 import { ITokenCounter } from "../interfaces/token-counter.interface";
 import { invokeStructuredChatModel } from "./structured-output.util";
+import { safetyIdentifierKwargs } from "../utils/safety-identifier.util";
 
 @Injectable()
 export class Gpt4VisionPreviewLlmService implements IMultimodalLlmProvider {
@@ -40,6 +41,7 @@ export class Gpt4VisionPreviewLlmService implements IMultimodalLlmProvider {
       maxTokens: options?.maxTokens ?? 4096,
       timeout: options?.timeoutMs,
       maxRetries: options?.maxRetries,
+      modelKwargs: safetyIdentifierKwargs(options),
     });
   }
 

--- a/apps/api/src/api/llm/core/services/openai-llm.service.spec.ts
+++ b/apps/api/src/api/llm/core/services/openai-llm.service.spec.ts
@@ -56,6 +56,20 @@ describe("OpenAiLlmService request options", () => {
     expect(config.timeout).toBeUndefined();
     expect(config.maxRetries).toBeUndefined();
   });
+
+  it("forwards safetyIdentifier as modelKwargs.safety_identifier", async () => {
+    const service = makeService();
+
+    await service.invoke([new HumanMessage("hi")], {
+      safetyIdentifier: "abc123",
+    });
+
+    expect(ChatOpenAI).toHaveBeenCalledWith(
+      expect.objectContaining({
+        modelKwargs: expect.objectContaining({ safety_identifier: "abc123" }),
+      }),
+    );
+  });
 });
 
 describe("OpenAiLlmService.invokeStructured", () => {

--- a/apps/api/src/api/llm/core/services/openai-llm.service.ts
+++ b/apps/api/src/api/llm/core/services/openai-llm.service.ts
@@ -13,6 +13,7 @@ import {
 } from "../interfaces/llm-provider.interface";
 import { ITokenCounter } from "../interfaces/token-counter.interface";
 import { invokeStructuredChatModel } from "./structured-output.util";
+import { safetyIdentifierKwargs } from "../utils/safety-identifier.util";
 
 @Injectable()
 export class OpenAiLlmService implements IMultimodalLlmProvider {
@@ -41,6 +42,7 @@ export class OpenAiLlmService implements IMultimodalLlmProvider {
       // and outlives every caller-side deadline.
       timeout: options?.timeoutMs,
       maxRetries: options?.maxRetries,
+      modelKwargs: safetyIdentifierKwargs(options),
     });
   }
 

--- a/apps/api/src/api/llm/core/utils/safety-identifier.util.spec.ts
+++ b/apps/api/src/api/llm/core/utils/safety-identifier.util.spec.ts
@@ -1,0 +1,37 @@
+import {
+  hashSafetyIdentifier,
+  safetyIdentifierKwargs,
+} from "./safety-identifier.util";
+
+describe("hashSafetyIdentifier", () => {
+  it("returns a stable sha256 hex digest", () => {
+    const a = hashSafetyIdentifier("learner@example.com");
+    expect(a).toMatch(/^[0-9a-f]{64}$/);
+    expect(hashSafetyIdentifier("learner@example.com")).toBe(a);
+  });
+
+  it("normalizes case and whitespace so the identifier is stable", () => {
+    expect(hashSafetyIdentifier(" Learner@Example.com ")).toBe(
+      hashSafetyIdentifier("learner@example.com"),
+    );
+  });
+
+  it("never returns the raw input", () => {
+    expect(hashSafetyIdentifier("learner@example.com")).not.toContain(
+      "learner",
+    );
+  });
+});
+
+describe("safetyIdentifierKwargs", () => {
+  it("builds the safety_identifier kwarg when set", () => {
+    expect(safetyIdentifierKwargs({ safetyIdentifier: "abc123" })).toEqual({
+      safety_identifier: "abc123",
+    });
+  });
+
+  it("returns an empty object when unset", () => {
+    expect(safetyIdentifierKwargs(undefined)).toEqual({});
+    expect(safetyIdentifierKwargs({})).toEqual({});
+  });
+});

--- a/apps/api/src/api/llm/core/utils/safety-identifier.util.ts
+++ b/apps/api/src/api/llm/core/utils/safety-identifier.util.ts
@@ -1,0 +1,18 @@
+import { createHash } from "node:crypto";
+
+/**
+ * OpenAI's safety_identifier must be a stable, privacy-preserving end-user
+ * id. userId is an email in this system, so hash it — the raw address must
+ * never reach request options or OpenAI.
+ */
+export function hashSafetyIdentifier(userId: string): string {
+  return createHash("sha256").update(userId.trim().toLowerCase()).digest("hex");
+}
+
+export function safetyIdentifierKwargs(options?: {
+  safetyIdentifier?: string;
+}): Record<string, string> {
+  return options?.safetyIdentifier
+    ? { safety_identifier: options.safetyIdentifier }
+    : {};
+}

--- a/apps/api/src/api/llm/features/grading/constants.ts
+++ b/apps/api/src/api/llm/features/grading/constants.ts
@@ -45,3 +45,10 @@ export function resolveMaxSpreadsheetCellsPerSubmission(): number {
 
 export const MAX_SPREADSHEET_CELLS_PER_SUBMISSION =
   resolveMaxSpreadsheetCellsPerSubmission();
+
+/**
+ * Learner-facing feedback persisted when a submission trips a severe
+ * moderation category and is not sent to the grading model.
+ */
+export const MODERATION_BLOCK_FEEDBACK =
+  "Your submission was flagged by automated content review and could not be graded automatically. Please contact your instructor.";

--- a/apps/api/src/api/llm/features/grading/services/__tests__/file-grading-routing.service.spec.ts
+++ b/apps/api/src/api/llm/features/grading/services/__tests__/file-grading-routing.service.spec.ts
@@ -98,7 +98,11 @@ function buildService() {
   service.pdfAnnotationService = {};
   service.s3Service = {};
   service.moderationService = {
-    validateContent: jest.fn().mockResolvedValue(true),
+    assessContent: jest.fn().mockResolvedValue({
+      action: "allow",
+      flaggedCategories: [],
+      severeCategories: [],
+    }),
   };
   service.llmResolver = {
     getModelForGradingTask: jest.fn(),
@@ -419,7 +423,11 @@ describe("FileGradingService - deterministic grading runs before evidence-based"
       });
 
     // Need to stub all the methods used by gradeFileBasedQuestion
-    service.moderationService.validateContent.mockResolvedValue(true);
+    service.moderationService.assessContent.mockResolvedValue({
+      action: "allow",
+      flaggedCategories: [],
+      severeCategories: [],
+    });
     service.scaleFileBasedModelToQuestionMax = jest.fn().mockReturnValue({
       points: 5,
       feedback: "ok",
@@ -497,7 +505,11 @@ describe("FileGradingService - deterministic grading runs before evidence-based"
 
     const evidenceSpy = jest.spyOn(service, "gradeWithEvidenceBasedApproach");
 
-    service.moderationService.validateContent.mockResolvedValue(true);
+    service.moderationService.assessContent.mockResolvedValue({
+      action: "allow",
+      flaggedCategories: [],
+      severeCategories: [],
+    });
     service.scaleFileBasedModelToQuestionMax = jest
       .fn()
       .mockImplementation((m: any) => m);

--- a/apps/api/src/api/llm/features/grading/services/__tests__/image-grading-criteria-based.spec.ts
+++ b/apps/api/src/api/llm/features/grading/services/__tests__/image-grading-criteria-based.spec.ts
@@ -31,7 +31,11 @@ function buildService() {
   service.s3Service = { getObject };
 
   service.moderationService = {
-    validateContent: jest.fn().mockResolvedValue(true),
+    assessContent: jest.fn().mockResolvedValue({
+      action: "allow",
+      flaggedCategories: [],
+      severeCategories: [],
+    }),
   };
   service.chunkingService = {
     extractFromImages: jest

--- a/apps/api/src/api/llm/features/grading/services/__tests__/oversized-submission.spec.ts
+++ b/apps/api/src/api/llm/features/grading/services/__tests__/oversized-submission.spec.ts
@@ -31,7 +31,11 @@ function buildService() {
   service.pdfAnnotationService = {};
   service.s3Service = {};
   service.moderationService = {
-    validateContent: jest.fn().mockResolvedValue(true),
+    assessContent: jest.fn().mockResolvedValue({
+      action: "allow",
+      flaggedCategories: [],
+      severeCategories: [],
+    }),
   };
   service.llmResolver = {
     getModelForGradingTask: jest.fn(),

--- a/apps/api/src/api/llm/features/grading/services/file-grading.service.moderation.spec.ts
+++ b/apps/api/src/api/llm/features/grading/services/file-grading.service.moderation.spec.ts
@@ -1,0 +1,82 @@
+import { FileGradingService } from "./file-grading.service";
+
+function mockLogger() {
+  const logger: any = {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+    child: jest.fn(),
+  };
+  logger.child.mockReturnValue(logger);
+  return logger;
+}
+
+function buildService(assessContent: jest.Mock) {
+  const service: any = Object.create(FileGradingService.prototype);
+  service.logger = mockLogger();
+  service.moderationService = { assessContent };
+  service.promptProcessor = {
+    processPrompt: jest.fn(),
+    processPromptForFeature: jest.fn(),
+  };
+  return { service, mockLogger: service.logger };
+}
+
+function gradeModel() {
+  return {
+    question: "Upload your report",
+    learnerResponse: [{ content: "chapter one" }, { content: "chapter two" }],
+    totalPoints: 10,
+    scoringCriteriaType: "OTHER",
+    scoringCriteria: { rubrics: [] },
+    previousQuestionsAnswersContext: [],
+    assignmentInstrctions: "",
+    questionType: "UPLOAD",
+    responseType: "REPORT",
+  };
+}
+
+describe("FileGradingService moderation verdicts", () => {
+  it("no longer throws a 400 on a moderation flag", async () => {
+    const assessContent = jest.fn().mockResolvedValue({
+      action: "allow_with_log",
+      flaggedCategories: ["violence"],
+      severeCategories: [],
+    });
+    const { service, mockLogger } = buildService(assessContent);
+
+    await (service as any)
+      .gradeFileBasedQuestion(gradeModel(), 1736)
+      .catch((error: Error) => {
+        expect(error.message).not.toBe("Learner response validation failed");
+      });
+
+    expect(assessContent).toHaveBeenCalledWith("chapter one chapter two");
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      "grading.moderation.flagged",
+      expect.objectContaining({ assignmentId: 1736 }),
+    );
+  });
+
+  it("returns a 0-point result without calling the LLM on a severe flag", async () => {
+    const assessContent = jest.fn().mockResolvedValue({
+      action: "block_severe",
+      flaggedCategories: ["sexual/minors"],
+      severeCategories: ["sexual/minors"],
+    });
+    const { service } = buildService(assessContent);
+
+    const result = await (service as any).gradeFileBasedQuestion(
+      gradeModel(),
+      1736,
+    );
+
+    expect(result.points).toBe(0);
+    expect(result.feedback).toContain("flagged by automated content review");
+    expect(service.promptProcessor.processPrompt).not.toHaveBeenCalled();
+    expect(
+      service.promptProcessor.processPromptForFeature,
+    ).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/api/llm/features/grading/services/file-grading.service.ts
+++ b/apps/api/src/api/llm/features/grading/services/file-grading.service.ts
@@ -190,13 +190,29 @@ export class FileGradingService implements IFileGradingService {
     if (moderationVerdict.action === "block_severe") {
       this.logger.warn("grading.moderation.blocked_severe", {
         assignmentId,
+        questionId,
         categories: moderationVerdict.severeCategories,
       });
-      return new FileBasedQuestionResponseModel(0, MODERATION_BLOCK_FEEDBACK);
+      // Mark the block in metadata so the strategy layer can short-circuit
+      // its post-grade judge loop — that loop re-sends the learner's raw
+      // content to a completion model, which a severe verdict must prevent.
+      return new FileBasedQuestionResponseModel(
+        0,
+        MODERATION_BLOCK_FEEDBACK,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        { moderationBlocked: true },
+      );
     }
     if (moderationVerdict.action === "allow_with_log") {
       this.logger.warn("grading.moderation.flagged", {
         assignmentId,
+        questionId,
         categories: moderationVerdict.flaggedCategories,
       });
     }

--- a/apps/api/src/api/llm/features/grading/services/file-grading.service.ts
+++ b/apps/api/src/api/llm/features/grading/services/file-grading.service.ts
@@ -1,13 +1,7 @@
 import * as crypto from "node:crypto";
 import { Readable } from "node:stream";
 import { PromptTemplate } from "@langchain/core/prompts";
-import {
-  HttpException,
-  HttpStatus,
-  Inject,
-  Injectable,
-  Optional,
-} from "@nestjs/common";
+import { Inject, Injectable, Optional } from "@nestjs/common";
 import { AIUsageType, ResponseType } from "@prisma/client";
 import axios from "axios";
 import { StructuredOutputParser } from "@langchain/classic/output_parsers";
@@ -43,7 +37,10 @@ import {
   PROMPT_PROCESSOR,
   TOKEN_COUNTER,
 } from "../../../llm.constants";
-import { MAX_EVIDENCE_BLOCKS_PER_SUBMISSION } from "../constants";
+import {
+  MAX_EVIDENCE_BLOCKS_PER_SUBMISSION,
+  MODERATION_BLOCK_FEEDBACK,
+} from "../constants";
 import { OversizedSubmissionError } from "../errors/oversized-submission.error";
 import { IFileGradingService } from "../interfaces/file-grading.interface";
 import {
@@ -180,18 +177,28 @@ export class FileGradingService implements IFileGradingService {
       responseType,
       judgeFeedback,
       questionId,
+      safetyIdentifier,
     } = fileBasedQuestionEvaluateModel;
 
-    const validateLearnerResponse =
-      await this.moderationService.validateContent(
-        learnerResponse.map((item) => item.content).join(" "),
-      );
-
-    if (!validateLearnerResponse) {
-      throw new HttpException(
-        "Learner response validation failed",
-        HttpStatus.BAD_REQUEST,
-      );
+    // A moderation flag must not deny a learner their grade — legitimate
+    // coursework trips the general-purpose classifier. Only the severe
+    // categories are withheld from the grading model; those persist a
+    // zero with instructions to contact the instructor.
+    const moderationVerdict = await this.moderationService.assessContent(
+      learnerResponse.map((item) => item.content).join(" "),
+    );
+    if (moderationVerdict.action === "block_severe") {
+      this.logger.warn("grading.moderation.blocked_severe", {
+        assignmentId,
+        categories: moderationVerdict.severeCategories,
+      });
+      return new FileBasedQuestionResponseModel(0, MODERATION_BLOCK_FEEDBACK);
+    }
+    if (moderationVerdict.action === "allow_with_log") {
+      this.logger.warn("grading.moderation.flagged", {
+        assignmentId,
+        categories: moderationVerdict.flaggedCategories,
+      });
     }
 
     const questionMaxPoints = totalPoints;
@@ -436,6 +443,7 @@ export class FileGradingService implements IFileGradingService {
           maxTotalPoints,
           rubricMaxPoints,
           isCodeUploadRoute,
+          safetyIdentifier,
         );
       } else {
         response = await this.processPromptWithRetry(
@@ -445,6 +453,7 @@ export class FileGradingService implements IFileGradingService {
           maxTotalPoints,
           rubricMaxPoints,
           isCodeUploadRoute,
+          safetyIdentifier,
         );
       }
     } catch (retryError) {
@@ -571,6 +580,7 @@ export class FileGradingService implements IFileGradingService {
     _maxTotalPoints: number,
     _rubricMaxPoints?: { rubricQuestion: string; maxPoints: number }[],
     modelOverrideIsFinal = false,
+    safetyIdentifier?: string,
   ): Promise<string> {
     void _maxTotalPoints;
     void _rubricMaxPoints;
@@ -589,7 +599,7 @@ export class FileGradingService implements IFileGradingService {
               assignmentId,
               AIUsageType.ASSIGNMENT_GRADING,
               primaryModel,
-              { maxRetries: 1 },
+              { maxRetries: 1, safetyIdentifier },
             )
           : await this.promptProcessor.processPromptForFeature(
               prompt,
@@ -597,6 +607,7 @@ export class FileGradingService implements IFileGradingService {
               AIUsageType.ASSIGNMENT_GRADING,
               "file_grading",
               primaryModel,
+              { safetyIdentifier },
             );
 
         if (this.isValidLLMResponse(response)) {
@@ -661,6 +672,7 @@ export class FileGradingService implements IFileGradingService {
         AIUsageType.ASSIGNMENT_GRADING,
         "file_grading",
         fallbackModel,
+        { safetyIdentifier },
       );
 
       if (this.isValidLLMResponse(response)) {

--- a/apps/api/src/api/llm/features/grading/services/image-grading.service.moderation.spec.ts
+++ b/apps/api/src/api/llm/features/grading/services/image-grading.service.moderation.spec.ts
@@ -1,0 +1,82 @@
+import { ImageGradingService } from "./image-grading.service";
+
+function mockLogger() {
+  const logger: any = {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+    child: jest.fn(),
+  };
+  logger.child.mockReturnValue(logger);
+  return logger;
+}
+
+function buildService(assessContent: jest.Mock) {
+  const service: any = Object.create(ImageGradingService.prototype);
+  service.logger = mockLogger();
+  service.moderationService = { assessContent };
+  service.promptProcessor = {
+    processPromptWithImage: jest.fn().mockResolvedValue("{}"),
+  };
+  service.llmResolver = {
+    getModelKeyWithFallback: jest.fn().mockResolvedValue("gpt-4.1-mini"),
+  };
+  return { service, mockLogger: service.logger };
+}
+
+function gradeModel() {
+  return {
+    question: "Draw a diagram",
+    imageData: "data:image/png;base64,AAAA",
+    learnerResponse: "my diagram",
+    totalPoints: 5,
+    scoringCriteriaType: "OTHER",
+    scoringCriteria: { rubrics: [] },
+    previousQuestionsAnswersContext: [],
+    assignmentInstrctions: "",
+    learnerImageResponse: [],
+  };
+}
+
+describe("ImageGradingService moderation verdicts", () => {
+  it("passes the image urls to moderation", async () => {
+    const assessContent = jest.fn().mockResolvedValue({
+      action: "block_severe",
+      flaggedCategories: ["sexual/minors"],
+      severeCategories: ["sexual/minors"],
+    });
+    const { service } = buildService(assessContent);
+
+    await (service as any).gradeImageBasedQuestion(gradeModel(), 1736);
+
+    expect(assessContent).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.arrayContaining(["data:image/png;base64,AAAA"]),
+    );
+  });
+
+  it("returns a 0-point result without invoking the vision model on a severe flag", async () => {
+    const assessContent = jest.fn().mockResolvedValue({
+      action: "block_severe",
+      flaggedCategories: ["sexual/minors"],
+      severeCategories: ["sexual/minors"],
+    });
+    const { service, mockLogger } = buildService(assessContent);
+
+    const result = await (service as any).gradeImageBasedQuestion(
+      gradeModel(),
+      1736,
+    );
+
+    expect(result.points).toBe(0);
+    expect(result.feedback).toContain("flagged by automated content review");
+    expect(
+      service.promptProcessor.processPromptWithImage,
+    ).not.toHaveBeenCalled();
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      "grading.moderation.blocked_severe",
+      expect.objectContaining({ assignmentId: 1736 }),
+    );
+  });
+});

--- a/apps/api/src/api/llm/features/grading/services/image-grading.service.moderation.spec.ts
+++ b/apps/api/src/api/llm/features/grading/services/image-grading.service.moderation.spec.ts
@@ -1,3 +1,4 @@
+import sharp from "sharp";
 import { ImageGradingService } from "./image-grading.service";
 
 function mockLogger() {
@@ -69,6 +70,71 @@ describe("ImageGradingService moderation verdicts", () => {
       1736,
     );
 
+    expect(result.points).toBe(0);
+    expect(result.feedback).toContain("flagged by automated content review");
+    expect(
+      service.promptProcessor.processPromptWithImage,
+    ).not.toHaveBeenCalled();
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      "grading.moderation.blocked_severe",
+      expect.objectContaining({ assignmentId: 1736 }),
+    );
+  });
+
+  it("moderates a COS-stored image the up-front gate could not see, and never calls the vision model when it is severe", async () => {
+    // The up-front gate only accepts http/data: URL shapes. A COS-stored
+    // image arrives as the "InCos" sentinel, so imageUrlsForModeration is
+    // empty and the first assessContent call sees no images at all.
+    const assessContent = jest
+      .fn()
+      .mockResolvedValueOnce({
+        action: "allow",
+        flaggedCategories: [],
+        severeCategories: [],
+      })
+      .mockResolvedValueOnce({
+        action: "block_severe",
+        flaggedCategories: ["sexual/minors"],
+        severeCategories: ["sexual/minors"],
+      });
+    const { service, mockLogger } = buildService(assessContent);
+
+    const smallPng = await sharp({
+      create: {
+        width: 4,
+        height: 4,
+        channels: 3,
+        background: { r: 1, g: 2, b: 3 },
+      },
+    })
+      .png()
+      .toBuffer();
+    const getObject = jest.fn().mockResolvedValue({ Body: smallPng });
+    service.s3Service = { getObject };
+
+    const model = {
+      ...gradeModel(),
+      imageData: "",
+      learnerImageResponse: [
+        {
+          filename: "photo.png",
+          imageData: "InCos",
+          imageBucket: "submissions",
+          imageKey: "assignments/uuid-photo.png",
+          imageUrl: "",
+          mimeType: "image/png",
+        },
+      ],
+    };
+
+    const result = await (service as any).gradeImageBasedQuestion(model, 1736);
+
+    expect(assessContent).toHaveBeenCalledTimes(2);
+    expect(assessContent).toHaveBeenNthCalledWith(1, expect.any(String), []);
+    expect(assessContent).toHaveBeenNthCalledWith(2, "", [
+      expect.stringContaining("data:image/png;base64,"),
+    ]);
+    expect(getObject).toHaveBeenCalledTimes(1);
     expect(result.points).toBe(0);
     expect(result.feedback).toContain("flagged by automated content review");
     expect(

--- a/apps/api/src/api/llm/features/grading/services/image-grading.service.moderation.spec.ts
+++ b/apps/api/src/api/llm/features/grading/services/image-grading.service.moderation.spec.ts
@@ -145,4 +145,62 @@ describe("ImageGradingService moderation verdicts", () => {
       expect.objectContaining({ assignmentId: 1736 }),
     );
   });
+
+  it("moderates a primary image submitted as raw base64 (no data: prefix) that the up-front gate could not see, and never calls the vision model when it is severe", async () => {
+    // The up-front gate only accepts http/data: shaped strings. A learner
+    // (or a hostile client bypassing normal upload plumbing) can submit the
+    // primary image as bare base64 with no "data:" prefix — that string is
+    // truthy and not the "InCos" storage sentinel, so it is treated as an
+    // inline image, yet it also fails the gate's startsWith("http"/"data:")
+    // filter and is excluded from imageUrlsForModeration. Without the fix,
+    // this image would reach the vision model with no moderation at all.
+    const assessContent = jest
+      .fn()
+      .mockResolvedValueOnce({
+        action: "allow",
+        flaggedCategories: [],
+        severeCategories: [],
+      })
+      .mockResolvedValueOnce({
+        action: "block_severe",
+        flaggedCategories: ["sexual/minors"],
+        severeCategories: ["sexual/minors"],
+      });
+    const { service, mockLogger } = buildService(assessContent);
+
+    const smallPng = await sharp({
+      create: {
+        width: 4,
+        height: 4,
+        channels: 3,
+        background: { r: 4, g: 5, b: 6 },
+      },
+    })
+      .png()
+      .toBuffer();
+    const rawBase64 = smallPng.toString("base64");
+
+    const model = {
+      ...gradeModel(),
+      imageData: rawBase64,
+      learnerImageResponse: [],
+    };
+
+    const result = await (service as any).gradeImageBasedQuestion(model, 1736);
+
+    expect(assessContent).toHaveBeenCalledTimes(2);
+    expect(assessContent).toHaveBeenNthCalledWith(1, expect.any(String), []);
+    expect(assessContent).toHaveBeenNthCalledWith(2, "", [
+      expect.stringContaining("data:image/png;base64,"),
+    ]);
+    expect(result.points).toBe(0);
+    expect(result.feedback).toContain("flagged by automated content review");
+    expect(
+      service.promptProcessor.processPromptWithImage,
+    ).not.toHaveBeenCalled();
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      "grading.moderation.blocked_severe",
+      expect.objectContaining({ assignmentId: 1736 }),
+    );
+  });
 });

--- a/apps/api/src/api/llm/features/grading/services/image-grading.service.ts
+++ b/apps/api/src/api/llm/features/grading/services/image-grading.service.ts
@@ -493,13 +493,12 @@ ${parsed.guidance}
         ? learnerResponse
         : JSON.stringify(learnerResponse);
 
-    const isValid =
+    // A moderation flag must not deny a learner their grade: log it and grade
+    // anyway (see the text-grading path for the rationale and precedent).
+    const passedModeration =
       await this.moderationService.validateContent(contentToModerate);
-    if (!isValid) {
-      throw new HttpException(
-        "Learner response blocked",
-        HttpStatus.BAD_REQUEST,
-      );
+    if (!passedModeration) {
+      this.logger.warn("image.grading.moderation.flagged_but_proceeding");
     }
   }
 

--- a/apps/api/src/api/llm/features/grading/services/image-grading.service.ts
+++ b/apps/api/src/api/llm/features/grading/services/image-grading.service.ts
@@ -167,17 +167,22 @@ export class ImageGradingService implements IImageGradingService {
       );
     }
 
-    // Determine (before fetching) whether the resolved image will come from
-    // COS storage rather than an inline http/data: value — storage-backed
-    // images are exactly the ones the up-front gate above could not see
-    // (it only accepts http/data: URL shapes), so they were never actually
-    // moderated.
-    const primaryImageFromStorage = this.primaryImageComesFromStorage(
-      topImageData,
-      topBucket,
-      topKey,
-      learnerImages,
-    );
+    // Determine (before fetching) whether the specific source that will
+    // resolve as the primary image was already covered by the up-front gate
+    // above. The gate only accepts http/data: shaped strings, so it misses
+    // two distinct cases that resolve through the exact same precedence as
+    // getPrimaryImageForGrading: an image fetched from COS storage
+    // (bucket/key, arriving as the "InCos" sentinel), and a learner image
+    // submitted as raw/bare base64 with no "data:" prefix — the latter looks
+    // "inline" but was filtered out of imageUrlsForModeration and would
+    // otherwise reach the vision model unmoderated.
+    const primaryNeedsPostResolveModeration =
+      !this.primaryImageCoveredByUpfrontModeration(
+        topImageData,
+        topBucket,
+        topKey,
+        learnerImages,
+      );
 
     const primaryImage = await this.getPrimaryImageForGrading(
       topImageData,
@@ -186,23 +191,23 @@ export class ImageGradingService implements IImageGradingService {
       learnerImages,
     );
 
-    if (primaryImageFromStorage) {
-      const storageModerationVerdict =
+    if (primaryNeedsPostResolveModeration) {
+      const postResolveModerationVerdict =
         await this.moderationService.assessContent("", [primaryImage.base64]);
-      if (storageModerationVerdict.action === "block_severe") {
+      if (postResolveModerationVerdict.action === "block_severe") {
         this.logger.warn("grading.moderation.blocked_severe", {
           assignmentId,
-          categories: storageModerationVerdict.severeCategories,
+          categories: postResolveModerationVerdict.severeCategories,
         });
         return {
           points: 0,
           feedback: MODERATION_BLOCK_FEEDBACK,
         } as ImageBasedQuestionResponseModel;
       }
-      if (storageModerationVerdict.action === "allow_with_log") {
+      if (postResolveModerationVerdict.action === "allow_with_log") {
         this.logger.warn("grading.moderation.flagged", {
           assignmentId,
-          categories: storageModerationVerdict.flaggedCategories,
+          categories: postResolveModerationVerdict.flaggedCategories,
         });
       }
     }
@@ -558,29 +563,44 @@ ${parsed.guidance}
 
   /**
    * Mirrors the branch selection in getPrimaryImageForGrading, without doing
-   * any fetching, purely to know whether the image it will resolve comes
-   * from COS storage. Storage-fetched images are never present in the
-   * up-front imageUrlsForModeration list (their imageData is the "InCos"
-   * sentinel, normalized to "" — which fails that list's http/data: filter),
-   * so this flags exactly the images the up-front gate could not check.
+   * any fetching, purely to know whether the up-front imageUrlsForModeration
+   * gate (built earlier from topImageData and each learner image's
+   * imageData/imageUrl) already saw the specific value that will resolve as
+   * the primary image. That gate only accepts http/data: shaped strings, so
+   * it returns false — meaning a post-resolve moderation check is still
+   * required — for two cases that share the same resolution branch:
+   *  - COS storage (bucket/key): imageData arrives as the "InCos" sentinel
+   *    (normalized to "" by normalizeLearnerImages), which fails the filter.
+   *  - Raw/bare base64 with no "data:" prefix: a truthy, non-"InCos" string
+   *    that still fails the http/data: filter, so it was excluded from the
+   *    up-front list even though it resolves as an inline image.
    */
-  private primaryImageComesFromStorage(
+  private primaryImageCoveredByUpfrontModeration(
     topImageData: string,
     topBucket: string,
     topKey: string,
     learnerImages: LearnerImageUpload[],
   ): boolean {
-    if (topImageData && topImageData !== "InCos") return false;
+    let source: string | undefined;
 
-    if (learnerImages.length > 0) {
+    if (topImageData && topImageData !== "InCos") {
+      source = topImageData;
+    } else if (learnerImages.length > 0) {
       const firstImage = learnerImages[0];
       if (firstImage.imageData && firstImage.imageData !== "InCos") {
+        source = firstImage.imageData;
+      } else {
+        // Resolves via COS storage (bucket/key) — never in the up-front list.
         return false;
       }
-      return !!(firstImage.imageBucket && firstImage.imageKey);
+    } else {
+      // Resolves via COS storage (topBucket/topKey) — never in the up-front
+      // list. If neither is set either, there is no valid image source and
+      // getPrimaryImageForGrading throws before this value is ever used.
+      return !(topBucket && topKey);
     }
 
-    return !!(topBucket && topKey);
+    return source.startsWith("http") || source.startsWith("data:");
   }
 
   private async getPrimaryImageForGrading(

--- a/apps/api/src/api/llm/features/grading/services/image-grading.service.ts
+++ b/apps/api/src/api/llm/features/grading/services/image-grading.service.ts
@@ -29,6 +29,7 @@ import { IImageGradingService } from "../interfaces/image-grading.interface";
 import { EvidenceChunkingService } from "./evidence-chunking.service";
 import { CriterionEvidencePipelineService } from "./criterion-evidence-pipeline.service";
 import { RubricCriterion } from "../types/criterion-evidence.types";
+import { MODERATION_BLOCK_FEEDBACK } from "../constants";
 
 interface ProcessedImageData {
   buffer: Buffer;
@@ -77,6 +78,7 @@ export class ImageGradingService implements IImageGradingService {
       previousQuestionsAnswersContext,
       assignmentInstrctions,
       learnerImageResponse: rawImages,
+      safetyIdentifier,
     } = model;
 
     const learnerImages: LearnerImageUpload[] = this.normalizeLearnerImages(
@@ -93,7 +95,40 @@ export class ImageGradingService implements IImageGradingService {
       totalPoints,
     );
 
-    await this.moderateContent(learnerResponse);
+    const contentToModerate =
+      typeof learnerResponse === "string"
+        ? learnerResponse
+        : JSON.stringify(learnerResponse);
+    // Moderate the uploaded images too — they go to the vision model and
+    // were previously never checked. Only URL-shaped or data-URL values
+    // are accepted by the moderations endpoint.
+    const imageUrlsForModeration = [
+      topImageData,
+      ...learnerImages.map((img) => img.imageData || img.imageUrl),
+    ].filter(
+      (url): url is string =>
+        !!url && (url.startsWith("http") || url.startsWith("data:")),
+    );
+    const moderationVerdict = await this.moderationService.assessContent(
+      contentToModerate,
+      imageUrlsForModeration,
+    );
+    if (moderationVerdict.action === "block_severe") {
+      this.logger.warn("grading.moderation.blocked_severe", {
+        assignmentId,
+        categories: moderationVerdict.severeCategories,
+      });
+      return {
+        points: 0,
+        feedback: MODERATION_BLOCK_FEEDBACK,
+      } as ImageBasedQuestionResponseModel;
+    }
+    if (moderationVerdict.action === "allow_with_log") {
+      this.logger.warn("grading.moderation.flagged", {
+        assignmentId,
+        categories: moderationVerdict.flaggedCategories,
+      });
+    }
 
     const maxTotalPoints = this.calculateMaxPoints(
       scoringCriteria,
@@ -307,6 +342,7 @@ Respond with a JSON object containing:
           assignmentId,
           AIUsageType.ASSIGNMENT_GRADING,
           modelKey,
+          { safetyIdentifier },
         );
       } catch (visionError) {
         // Only the vision call's own errors can mean the provider rejected the
@@ -484,21 +520,6 @@ ${parsed.guidance}
 
     if (totalPoints == undefined || totalPoints < 0) {
       throw new HttpException("Invalid totalPoints", HttpStatus.BAD_REQUEST);
-    }
-  }
-
-  private async moderateContent(learnerResponse: any): Promise<void> {
-    const contentToModerate =
-      typeof learnerResponse === "string"
-        ? learnerResponse
-        : JSON.stringify(learnerResponse);
-
-    // A moderation flag must not deny a learner their grade: log it and grade
-    // anyway (see the text-grading path for the rationale and precedent).
-    const passedModeration =
-      await this.moderationService.validateContent(contentToModerate);
-    if (!passedModeration) {
-      this.logger.warn("image.grading.moderation.flagged_but_proceeding");
     }
   }
 

--- a/apps/api/src/api/llm/features/grading/services/image-grading.service.ts
+++ b/apps/api/src/api/llm/features/grading/services/image-grading.service.ts
@@ -167,12 +167,45 @@ export class ImageGradingService implements IImageGradingService {
       );
     }
 
+    // Determine (before fetching) whether the resolved image will come from
+    // COS storage rather than an inline http/data: value — storage-backed
+    // images are exactly the ones the up-front gate above could not see
+    // (it only accepts http/data: URL shapes), so they were never actually
+    // moderated.
+    const primaryImageFromStorage = this.primaryImageComesFromStorage(
+      topImageData,
+      topBucket,
+      topKey,
+      learnerImages,
+    );
+
     const primaryImage = await this.getPrimaryImageForGrading(
       topImageData,
       topBucket,
       topKey,
       learnerImages,
     );
+
+    if (primaryImageFromStorage) {
+      const storageModerationVerdict =
+        await this.moderationService.assessContent("", [primaryImage.base64]);
+      if (storageModerationVerdict.action === "block_severe") {
+        this.logger.warn("grading.moderation.blocked_severe", {
+          assignmentId,
+          categories: storageModerationVerdict.severeCategories,
+        });
+        return {
+          points: 0,
+          feedback: MODERATION_BLOCK_FEEDBACK,
+        } as ImageBasedQuestionResponseModel;
+      }
+      if (storageModerationVerdict.action === "allow_with_log") {
+        this.logger.warn("grading.moderation.flagged", {
+          assignmentId,
+          categories: storageModerationVerdict.flaggedCategories,
+        });
+      }
+    }
 
     const parser = StructuredOutputParser.fromZodSchema(
       z.object({
@@ -521,6 +554,33 @@ ${parsed.guidance}
     if (totalPoints == undefined || totalPoints < 0) {
       throw new HttpException("Invalid totalPoints", HttpStatus.BAD_REQUEST);
     }
+  }
+
+  /**
+   * Mirrors the branch selection in getPrimaryImageForGrading, without doing
+   * any fetching, purely to know whether the image it will resolve comes
+   * from COS storage. Storage-fetched images are never present in the
+   * up-front imageUrlsForModeration list (their imageData is the "InCos"
+   * sentinel, normalized to "" — which fails that list's http/data: filter),
+   * so this flags exactly the images the up-front gate could not check.
+   */
+  private primaryImageComesFromStorage(
+    topImageData: string,
+    topBucket: string,
+    topKey: string,
+    learnerImages: LearnerImageUpload[],
+  ): boolean {
+    if (topImageData && topImageData !== "InCos") return false;
+
+    if (learnerImages.length > 0) {
+      const firstImage = learnerImages[0];
+      if (firstImage.imageData && firstImage.imageData !== "InCos") {
+        return false;
+      }
+      return !!(firstImage.imageBucket && firstImage.imageKey);
+    }
+
+    return !!(topBucket && topKey);
   }
 
   private async getPrimaryImageForGrading(

--- a/apps/api/src/api/llm/features/grading/services/presentation-grading.service.moderation.spec.ts
+++ b/apps/api/src/api/llm/features/grading/services/presentation-grading.service.moderation.spec.ts
@@ -1,0 +1,74 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+import { PresentationGradingService } from "./presentation-grading.service";
+
+function mockLogger(): any {
+  const logger = {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+    child: jest.fn(),
+  };
+  logger.child.mockReturnValue(logger);
+  return logger;
+}
+
+function buildService(assessContent: jest.Mock): any {
+  const service = Object.create(PresentationGradingService.prototype);
+  service.logger = mockLogger();
+  service.moderationService = { assessContent };
+  service.promptProcessor = { processPromptForFeature: jest.fn() };
+  return { service, mockLogger: service.logger };
+}
+
+function gradeModel(transcript?: string): any {
+  return {
+    question: "Present your findings",
+    learnerResponse: { transcript },
+    totalPoints: 5,
+    scoringCriteriaType: "OTHER",
+    scoringCriteria: { rubrics: [] },
+    previousQuestionsAnswersContext: [],
+    assignmentInstrctions: "",
+    questionType: "TEXT",
+    responseType: "PRESENTATION",
+  };
+}
+
+describe("PresentationGradingService moderation verdicts", () => {
+  it("returns a 0-point result without calling the LLM on a severe flag", async () => {
+    const assessContent = jest.fn().mockResolvedValue({
+      action: "block_severe",
+      flaggedCategories: ["sexual/minors"],
+      severeCategories: ["sexual/minors"],
+    });
+    const { service, mockLogger } = buildService(assessContent);
+
+    const result = await (service as any).gradePresentationQuestion(
+      gradeModel("a transcript"),
+      1736,
+    );
+
+    expect(result.points).toBe(0);
+    expect(result.feedback).toContain("flagged by automated content review");
+    expect(
+      service.promptProcessor.processPromptForFeature,
+    ).not.toHaveBeenCalled();
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      "grading.moderation.blocked_severe",
+      expect.objectContaining({ assignmentId: 1736 }),
+    );
+  });
+
+  it("skips moderation when there is no transcript", async () => {
+    const assessContent = jest.fn();
+    const { service } = buildService(assessContent);
+
+    await (service as any)
+      .gradePresentationQuestion(gradeModel(undefined), 1736)
+      .catch(() => undefined);
+
+    expect(assessContent).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/api/llm/features/grading/services/presentation-grading.service.ts
+++ b/apps/api/src/api/llm/features/grading/services/presentation-grading.service.ts
@@ -12,6 +12,7 @@ import { LearnerLiveRecordingFeedback } from "../../../../assignment/attempt/dto
 import { IModerationService } from "../../../core/interfaces/moderation.interface";
 import { IPromptProcessor } from "../../../core/interfaces/prompt-processor.interface";
 import { MODERATION_SERVICE, PROMPT_PROCESSOR } from "../../../llm.constants";
+import { MODERATION_BLOCK_FEEDBACK } from "../constants";
 import { IPresentationGradingService } from "../interfaces/presentation-grading.interface";
 
 @Injectable()
@@ -55,15 +56,26 @@ export class PresentationGradingService implements IPresentationGradingService {
     const hasTranscript =
       learnerResponse?.transcript &&
       typeof learnerResponse.transcript === "string";
-    const validateLearnerResponse = hasTranscript
-      ? await this.moderationService.validateContent(learnerResponse.transcript)
-      : true;
-
-    if (!validateLearnerResponse) {
-      throw new HttpException(
-        "Learner response validation failed",
-        HttpStatus.BAD_REQUEST,
+    if (hasTranscript) {
+      const moderationVerdict = await this.moderationService.assessContent(
+        learnerResponse.transcript,
       );
+      if (moderationVerdict.action === "block_severe") {
+        this.logger.warn("grading.moderation.blocked_severe", {
+          assignmentId,
+          categories: moderationVerdict.severeCategories,
+        });
+        return {
+          points: 0,
+          feedback: MODERATION_BLOCK_FEEDBACK,
+        } as PresentationQuestionResponseModel;
+      }
+      if (moderationVerdict.action === "allow_with_log") {
+        this.logger.warn("grading.moderation.flagged", {
+          assignmentId,
+          categories: moderationVerdict.flaggedCategories,
+        });
+      }
     }
 
     const safeSpeechReport =
@@ -150,6 +162,8 @@ export class PresentationGradingService implements IPresentationGradingService {
       assignmentId,
       AIUsageType.ASSIGNMENT_GRADING,
       "presentation_grading",
+      undefined,
+      { safetyIdentifier: presentationQuestionEvaluateModel.safetyIdentifier },
     );
 
     try {

--- a/apps/api/src/api/llm/features/grading/services/presentation-grading.service.ts
+++ b/apps/api/src/api/llm/features/grading/services/presentation-grading.service.ts
@@ -47,6 +47,7 @@ export class PresentationGradingService implements IPresentationGradingService {
       previousQuestionsAnswersContext,
       assignmentInstrctions,
       responseType,
+      safetyIdentifier,
     } = presentationQuestionEvaluateModel;
 
     if (!question) {
@@ -163,7 +164,7 @@ export class PresentationGradingService implements IPresentationGradingService {
       AIUsageType.ASSIGNMENT_GRADING,
       "presentation_grading",
       undefined,
-      { safetyIdentifier: presentationQuestionEvaluateModel.safetyIdentifier },
+      { safetyIdentifier },
     );
 
     try {

--- a/apps/api/src/api/llm/features/grading/services/text-grading.service.spec.ts
+++ b/apps/api/src/api/llm/features/grading/services/text-grading.service.spec.ts
@@ -286,7 +286,11 @@ describe("TextGradingService.gradeTextBasedQuestion context-length fail-fast", (
       processStructuredPromptForFeature: processStructured,
     };
     service.moderationService = {
-      validateContent: jest.fn().mockResolvedValue(true),
+      assessContent: jest.fn().mockResolvedValue({
+        action: "allow",
+        flaggedCategories: [],
+        severeCategories: [],
+      }),
     };
     // No normalization / cache / judge needed to reach the loop, but the judge
     // is referenced after a successful grade; these paths are never hit here
@@ -393,17 +397,18 @@ describe("TextGradingService.gradeTextBasedQuestion context-length fail-fast", (
 });
 
 /*
- * A content-moderation flag on the learner's answer must NOT deny them a grade.
- * Legitimate coursework (e.g. a security course asking the learner to describe
- * a rootkit) trips the general-purpose moderation classifier; the answer is
- * only ever sent to the grading model, never republished. So a flag must log
- * and fall through to grading, not throw the old 400 "Learner response
- * validation failed".
+ * Content moderation now returns a category-level verdict instead of a bare
+ * pass/fail. An ordinary flag (allow_with_log) must NOT deny the learner a
+ * grade — legitimate coursework (e.g. a security course asking the learner to
+ * describe a rootkit) trips the general-purpose classifier, so it logs and
+ * falls through to grading. Only a severe category (block_severe) withholds
+ * the submission from the grading model entirely, returning a zero with
+ * instructions to contact the instructor.
  */
-describe("TextGradingService.gradeTextBasedQuestion moderation fail-open", () => {
+describe("TextGradingService.gradeTextBasedQuestion moderation verdicts", () => {
   function buildGradeService(
     processStructured: jest.Mock,
-    validateContent: jest.Mock,
+    assessContent: jest.Mock,
   ) {
     const { service, mockLogger } = buildService();
     service.maxRetries = 1;
@@ -411,7 +416,7 @@ describe("TextGradingService.gradeTextBasedQuestion moderation fail-open", () =>
     service.promptProcessor = {
       processStructuredPromptForFeature: processStructured,
     };
-    service.moderationService = { validateContent };
+    service.moderationService = { assessContent };
     service.gradingJudgeService = { validateGrading: jest.fn() };
     return { service, mockLogger };
   }
@@ -431,43 +436,78 @@ describe("TextGradingService.gradeTextBasedQuestion moderation fail-open", () =>
     };
   }
 
-  it("proceeds to grade (does not throw) when moderation flags the answer", async () => {
-    const validateContent = jest.fn().mockResolvedValue(false);
-    // The retry loop wraps a grading failure in its own post-loop throw, so the
-    // caller never sees this raw error — but processStructured being invoked at
-    // all proves we passed the moderation gate instead of the old 400.
+  it("grades normally on an allow verdict", async () => {
+    const assessContent = jest.fn().mockResolvedValue({
+      action: "allow",
+      flaggedCategories: [],
+      severeCategories: [],
+    });
+    const processStructured = jest
+      .fn()
+      .mockRejectedValue(new Error("downstream grading error"));
+    const { service } = buildGradeService(processStructured, assessContent);
+
+    await expect(
+      (service as any).gradeTextBasedQuestion(gradeModel(), 1736),
+    ).rejects.toThrow();
+    expect(processStructured).toHaveBeenCalledTimes(1);
+  });
+
+  it("logs and proceeds on an ordinary flag", async () => {
+    const assessContent = jest.fn().mockResolvedValue({
+      action: "allow_with_log",
+      flaggedCategories: ["violence"],
+      severeCategories: [],
+    });
     const processStructured = jest
       .fn()
       .mockRejectedValue(new Error("downstream grading error"));
     const { service, mockLogger } = buildGradeService(
       processStructured,
-      validateContent,
+      assessContent,
     );
 
     await expect(
       (service as any).gradeTextBasedQuestion(gradeModel(), 1736),
     ).rejects.toThrow();
-
-    expect(validateContent).toHaveBeenCalledTimes(1);
-    // Got past moderation into the grading LLM call (0 calls would mean the
-    // moderation 400 short-circuited before grading).
     expect(processStructured).toHaveBeenCalledTimes(1);
-    // The flag was recorded for observability.
     expect(mockLogger.warn).toHaveBeenCalledWith(
-      "text.grading.moderation.flagged_but_proceeding",
-      expect.objectContaining({ assignmentId: 1736, questionId: 4311 }),
+      "grading.moderation.flagged",
+      expect.objectContaining({
+        assignmentId: 1736,
+        questionId: 4311,
+        categories: ["violence"],
+      }),
     );
   });
 
-  it("never surfaces the old moderation 400 to the caller", async () => {
-    const validateContent = jest.fn().mockResolvedValue(false);
-    const processStructured = jest
-      .fn()
-      .mockRejectedValue(new Error("some downstream grading error"));
-    const { service } = buildGradeService(processStructured, validateContent);
+  it("returns a 0-point result without calling the LLM on a severe flag", async () => {
+    const assessContent = jest.fn().mockResolvedValue({
+      action: "block_severe",
+      flaggedCategories: ["sexual/minors"],
+      severeCategories: ["sexual/minors"],
+    });
+    const processStructured = jest.fn();
+    const { service, mockLogger } = buildGradeService(
+      processStructured,
+      assessContent,
+    );
 
-    await expect(
-      (service as any).gradeTextBasedQuestion(gradeModel(), 1736),
-    ).rejects.not.toThrow("Learner response validation failed");
+    const result = await (service as any).gradeTextBasedQuestion(
+      gradeModel(),
+      1736,
+    );
+
+    expect(result.points).toBe(0);
+    expect(result.feedback).toContain("flagged by automated content review");
+    expect(processStructured).not.toHaveBeenCalled();
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      "grading.moderation.blocked_severe",
+      expect.objectContaining({
+        assignmentId: 1736,
+        questionId: 4311,
+        categories: ["sexual/minors"],
+      }),
+    );
   });
 });

--- a/apps/api/src/api/llm/features/grading/services/text-grading.service.spec.ts
+++ b/apps/api/src/api/llm/features/grading/services/text-grading.service.spec.ts
@@ -391,3 +391,83 @@ describe("TextGradingService.gradeTextBasedQuestion context-length fail-fast", (
     expect(processStructured).toHaveBeenCalledTimes(3);
   });
 });
+
+/*
+ * A content-moderation flag on the learner's answer must NOT deny them a grade.
+ * Legitimate coursework (e.g. a security course asking the learner to describe
+ * a rootkit) trips the general-purpose moderation classifier; the answer is
+ * only ever sent to the grading model, never republished. So a flag must log
+ * and fall through to grading, not throw the old 400 "Learner response
+ * validation failed".
+ */
+describe("TextGradingService.gradeTextBasedQuestion moderation fail-open", () => {
+  function buildGradeService(
+    processStructured: jest.Mock,
+    validateContent: jest.Mock,
+  ) {
+    const { service, mockLogger } = buildService();
+    service.maxRetries = 1;
+    service.retryDelay = 1000;
+    service.promptProcessor = {
+      processStructuredPromptForFeature: processStructured,
+    };
+    service.moderationService = { validateContent };
+    service.gradingJudgeService = { validateGrading: jest.fn() };
+    return { service, mockLogger };
+  }
+
+  function gradeModel() {
+    return {
+      question: "Define a stealthier persistence technique than cron jobs.",
+      learnerResponse:
+        "A linux kernel module rootkit that hooks kernel functions.",
+      totalPoints: 4,
+      scoringCriteriaType: "OTHER",
+      scoringCriteria: { rubrics: [] },
+      previousQuestionsAnswersContext: [],
+      assignmentInstrctions: "Follow the rubric.",
+      responseType: "OTHER",
+      questionId: 4311,
+    };
+  }
+
+  it("proceeds to grade (does not throw) when moderation flags the answer", async () => {
+    const validateContent = jest.fn().mockResolvedValue(false);
+    // The retry loop wraps a grading failure in its own post-loop throw, so the
+    // caller never sees this raw error — but processStructured being invoked at
+    // all proves we passed the moderation gate instead of the old 400.
+    const processStructured = jest
+      .fn()
+      .mockRejectedValue(new Error("downstream grading error"));
+    const { service, mockLogger } = buildGradeService(
+      processStructured,
+      validateContent,
+    );
+
+    await expect(
+      (service as any).gradeTextBasedQuestion(gradeModel(), 1736),
+    ).rejects.toThrow();
+
+    expect(validateContent).toHaveBeenCalledTimes(1);
+    // Got past moderation into the grading LLM call (0 calls would mean the
+    // moderation 400 short-circuited before grading).
+    expect(processStructured).toHaveBeenCalledTimes(1);
+    // The flag was recorded for observability.
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      "text.grading.moderation.flagged_but_proceeding",
+      expect.objectContaining({ assignmentId: 1736, questionId: 4311 }),
+    );
+  });
+
+  it("never surfaces the old moderation 400 to the caller", async () => {
+    const validateContent = jest.fn().mockResolvedValue(false);
+    const processStructured = jest
+      .fn()
+      .mockRejectedValue(new Error("some downstream grading error"));
+    const { service } = buildGradeService(processStructured, validateContent);
+
+    await expect(
+      (service as any).gradeTextBasedQuestion(gradeModel(), 1736),
+    ).rejects.not.toThrow("Learner response validation failed");
+  });
+});

--- a/apps/api/src/api/llm/features/grading/services/text-grading.service.ts
+++ b/apps/api/src/api/llm/features/grading/services/text-grading.service.ts
@@ -35,6 +35,7 @@ import {
   PROMPT_PROCESSOR,
   RESPONSE_TYPE_SPECIFIC_INSTRUCTIONS,
 } from "../../../llm.constants";
+import { MODERATION_BLOCK_FEEDBACK } from "../constants";
 import {
   IAnswerNormalizationService,
   INormalizedAnswer,
@@ -157,23 +158,31 @@ export class TextGradingService implements ITextGradingService {
         scoringCriteria,
         scoringCriteriaType,
         questionId,
+        safetyIdentifier,
       } = textBasedQuestionEvaluateModel;
 
       const sanitizedLearnerResponse = this.sanitizeInput(learnerResponse);
 
-      // A moderation flag must not deny a learner their grade. The response is
-      // only sent to the grading model, never republished, and legitimate
-      // coursework trips the general-purpose classifier — a security course
-      // asking learners to describe a rootkit is flagged as policy-violating.
-      // Log the flag for observability and grade anyway, matching
-      // validateContent's existing fail-open behaviour when the API errors.
-      const passedModeration = await this.moderationService.validateContent(
+      // A moderation flag must not deny a learner their grade — legitimate
+      // coursework trips the general-purpose classifier. Only the severe
+      // categories are withheld from the grading model; those persist a
+      // zero with instructions to contact the instructor.
+      const moderationVerdict = await this.moderationService.assessContent(
         sanitizedLearnerResponse,
       );
-      if (!passedModeration) {
-        this.logger.warn("text.grading.moderation.flagged_but_proceeding", {
+      if (moderationVerdict.action === "block_severe") {
+        this.logger.warn("grading.moderation.blocked_severe", {
           assignmentId,
           questionId,
+          categories: moderationVerdict.severeCategories,
+        });
+        return new TextBasedQuestionResponseModel(0, MODERATION_BLOCK_FEEDBACK);
+      }
+      if (moderationVerdict.action === "allow_with_log") {
+        this.logger.warn("grading.moderation.flagged", {
+          assignmentId,
+          questionId,
+          categories: moderationVerdict.flaggedCategories,
         });
       }
 
@@ -313,6 +322,7 @@ export class TextGradingService implements ITextGradingService {
             contentHash,
             assignmentId,
             language,
+            safetyIdentifier,
           );
         } catch (error) {
           // A context_length_exceeded 400 is deterministic for a given prompt:
@@ -555,6 +565,7 @@ export class TextGradingService implements ITextGradingService {
     contentHash: string,
     assignmentId: number,
     language?: string,
+    safetyIdentifier?: string,
     previousJudgeFeedback?: string | null,
   ): Promise<GradingAttempt> {
     const {
@@ -709,7 +720,13 @@ export class TextGradingService implements ITextGradingService {
         // spends its completion budget on reasoning first, and the provider
         // default of 4096 truncates the JSON on large rubrics, failing the
         // grading after all retries.
-        { temperature: 0, top_p: 0, maxRetries: 1, maxTokens: 16_384 },
+        {
+          temperature: 0,
+          top_p: 0,
+          maxRetries: 1,
+          maxTokens: 16_384,
+          safetyIdentifier,
+        },
       );
 
     this.logger.info(

--- a/apps/api/src/api/llm/features/grading/services/text-grading.service.ts
+++ b/apps/api/src/api/llm/features/grading/services/text-grading.service.ts
@@ -161,14 +161,20 @@ export class TextGradingService implements ITextGradingService {
 
       const sanitizedLearnerResponse = this.sanitizeInput(learnerResponse);
 
-      const isValidResponse = await this.moderationService.validateContent(
+      // A moderation flag must not deny a learner their grade. The response is
+      // only sent to the grading model, never republished, and legitimate
+      // coursework trips the general-purpose classifier — a security course
+      // asking learners to describe a rootkit is flagged as policy-violating.
+      // Log the flag for observability and grade anyway, matching
+      // validateContent's existing fail-open behaviour when the API errors.
+      const passedModeration = await this.moderationService.validateContent(
         sanitizedLearnerResponse,
       );
-      if (!isValidResponse) {
-        throw new HttpException(
-          "Learner response validation failed",
-          HttpStatus.BAD_REQUEST,
-        );
+      if (!passedModeration) {
+        this.logger.warn("text.grading.moderation.flagged_but_proceeding", {
+          assignmentId,
+          questionId,
+        });
       }
 
       const maxPossiblePoints = this.calculateMaxPossiblePoints(

--- a/apps/api/src/api/llm/features/grading/services/url-grading.service.moderation.spec.ts
+++ b/apps/api/src/api/llm/features/grading/services/url-grading.service.moderation.spec.ts
@@ -1,0 +1,82 @@
+import { UrlGradingService } from "./url-grading.service";
+
+function mockLogger() {
+  const logger: any = {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+    child: jest.fn(),
+  };
+  logger.child.mockReturnValue(logger);
+  return logger;
+}
+
+function buildService(assessContent: jest.Mock) {
+  const service: any = Object.create(UrlGradingService.prototype);
+  service.logger = mockLogger();
+  service.moderationService = { assessContent };
+  service.promptProcessor = { processPromptForFeature: jest.fn() };
+  return { service, mockLogger: service.logger };
+}
+
+function gradeModel() {
+  return {
+    question: "Link your project",
+    urlProvided: "https://example.com/project",
+    isUrlFunctional: true,
+    urlBody: "<html>project</html>",
+    totalPoints: 5,
+    scoringCriteriaType: "OTHER",
+    scoringCriteria: { rubrics: [] },
+    previousQuestionsAnswersContext: [],
+    assignmentInstrctions: "",
+    responseType: "OTHER",
+  };
+}
+
+describe("UrlGradingService moderation verdicts", () => {
+  it("returns a 0-point result without calling the LLM on a severe flag", async () => {
+    const assessContent = jest.fn().mockResolvedValue({
+      action: "block_severe",
+      flaggedCategories: ["sexual/minors"],
+      severeCategories: ["sexual/minors"],
+    });
+    const { service, mockLogger } = buildService(assessContent);
+
+    const result = await (service as any).gradeUrlBasedQuestion(
+      gradeModel(),
+      1736,
+    );
+
+    expect(result.points).toBe(0);
+    expect(result.feedback).toContain("flagged by automated content review");
+    expect(
+      service.promptProcessor.processPromptForFeature,
+    ).not.toHaveBeenCalled();
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      "grading.moderation.blocked_severe",
+      expect.objectContaining({ assignmentId: 1736 }),
+    );
+  });
+
+  it("does not throw on an ordinary flag", async () => {
+    const assessContent = jest.fn().mockResolvedValue({
+      action: "allow_with_log",
+      flaggedCategories: ["violence"],
+      severeCategories: [],
+    });
+    const { service, mockLogger } = buildService(assessContent);
+
+    await (service as any)
+      .gradeUrlBasedQuestion(gradeModel(), 1736)
+      .catch((error: Error) => {
+        expect(error.message).not.toBe("Learner response validation failed");
+      });
+
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      "grading.moderation.flagged",
+      expect.objectContaining({ categories: ["violence"] }),
+    );
+  });
+});

--- a/apps/api/src/api/llm/features/grading/services/url-grading.service.ts
+++ b/apps/api/src/api/llm/features/grading/services/url-grading.service.ts
@@ -1,5 +1,5 @@
 import { PromptTemplate } from "@langchain/core/prompts";
-import { HttpException, HttpStatus, Inject, Injectable } from "@nestjs/common";
+import { Inject, Injectable } from "@nestjs/common";
 import { AIUsageType } from "@prisma/client";
 import { StructuredOutputParser } from "@langchain/classic/output_parsers";
 import { WINSTON_MODULE_PROVIDER } from "nest-winston";
@@ -18,6 +18,7 @@ import {
   PROMPT_PROCESSOR,
   RESPONSE_TYPE_SPECIFIC_INSTRUCTIONS,
 } from "../../../llm.constants";
+import { MODERATION_BLOCK_FEEDBACK } from "../constants";
 import { IUrlGradingService } from "../interfaces/url-grading.interface";
 
 @Injectable()
@@ -55,15 +56,27 @@ export class UrlGradingService implements IUrlGradingService {
       previousQuestionsAnswersContext,
       assignmentInstrctions,
       responseType,
+      safetyIdentifier,
     } = urlBasedQuestionEvaluateModel;
 
-    const validateLearnerResponse =
-      await this.moderationService.validateContent(urlProvided);
-    if (!validateLearnerResponse) {
-      throw new HttpException(
-        "Learner response validation failed",
-        HttpStatus.BAD_REQUEST,
-      );
+    const moderationVerdict =
+      await this.moderationService.assessContent(urlProvided);
+    if (moderationVerdict.action === "block_severe") {
+      this.logger.warn("grading.moderation.blocked_severe", {
+        assignmentId,
+        categories: moderationVerdict.severeCategories,
+      });
+      return {
+        points: 0,
+        feedback: MODERATION_BLOCK_FEEDBACK,
+        gradingRationale: MODERATION_BLOCK_FEEDBACK,
+      } as UrlBasedQuestionResponseModel;
+    }
+    if (moderationVerdict.action === "allow_with_log") {
+      this.logger.warn("grading.moderation.flagged", {
+        assignmentId,
+        categories: moderationVerdict.flaggedCategories,
+      });
     }
 
     const rubricCriteria = this.convertToRubricCriteria(
@@ -138,6 +151,7 @@ export class UrlGradingService implements IUrlGradingService {
         prompt,
         assignmentId,
         totalPoints,
+        safetyIdentifier,
       );
     } catch (retryError) {
       this.logger.error(
@@ -248,6 +262,7 @@ export class UrlGradingService implements IUrlGradingService {
     prompt: PromptTemplate,
     assignmentId: number,
     _totalPoints: number,
+    safetyIdentifier?: string,
   ): Promise<string> {
     void _totalPoints;
     const maxRetries = 3;
@@ -262,6 +277,8 @@ export class UrlGradingService implements IUrlGradingService {
           assignmentId,
           AIUsageType.ASSIGNMENT_GRADING,
           "url_grading",
+          undefined,
+          { safetyIdentifier },
         );
 
         if (this.isValidLLMResponse(response)) {

--- a/apps/api/src/api/llm/features/grading/services/video-grading.service.moderation.spec.ts
+++ b/apps/api/src/api/llm/features/grading/services/video-grading.service.moderation.spec.ts
@@ -1,0 +1,90 @@
+import { VideoPresentationGradingService } from "./video-grading.service";
+import { VideoPresentationQuestionResponseModel } from "../../../model/video-presentation.question.response.model";
+
+function mockLogger() {
+  const logger: any = {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+    child: jest.fn(),
+  };
+  logger.child.mockReturnValue(logger);
+  return logger;
+}
+
+function buildService(assessContent: jest.Mock) {
+  const service: any = Object.create(VideoPresentationGradingService.prototype);
+  service.logger = mockLogger();
+  service.moderationService = { assessContent };
+  service.promptProcessor = {
+    processPromptForFeature: jest
+      .fn()
+      .mockResolvedValue('{"points": 3, "feedback": "ok"}'),
+  };
+  return { service, mockLogger: service.logger };
+}
+
+function gradeModel() {
+  return {
+    question: "Present your findings",
+    learnerResponse: { transcript: "my presentation transcript" },
+    totalPoints: 5,
+    scoringCriteriaType: "OTHER",
+    scoringCriteria: { rubrics: [] },
+    previousQuestionsAnswersContext: [],
+    assignmentInstrctions: "",
+    questionType: "TEXT",
+    responseType: "PRESENTATION",
+    videoPresentationConfig: {
+      evaluateSlidesQuality: false,
+      evaluateTimeManagement: false,
+      targetTime: 5,
+    },
+  };
+}
+
+describe("VideoPresentationGradingService moderation verdicts", () => {
+  it("returns a 0-point result without calling the LLM on a severe flag", async () => {
+    const assessContent = jest.fn().mockResolvedValue({
+      action: "block_severe",
+      flaggedCategories: ["sexual/minors"],
+      severeCategories: ["sexual/minors"],
+    });
+    const { service, mockLogger } = buildService(assessContent);
+
+    const result = await (service as any).gradeVideoPresentationQuestion(
+      gradeModel(),
+      1736,
+    );
+
+    expect(result.points).toBe(0);
+    expect(result.feedback).toContain("flagged by automated content review");
+    expect(
+      service.promptProcessor.processPromptForFeature,
+    ).not.toHaveBeenCalled();
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      "grading.moderation.blocked_severe",
+      expect.objectContaining({ assignmentId: 1736 }),
+    );
+  });
+
+  it("logs and proceeds on an ordinary flag", async () => {
+    const assessContent = jest.fn().mockResolvedValue({
+      action: "allow_with_log",
+      flaggedCategories: ["violence"],
+      severeCategories: [],
+    });
+    const { service, mockLogger } = buildService(assessContent);
+
+    await (service as any)
+      .gradeVideoPresentationQuestion(gradeModel(), 1736)
+      .catch(() => undefined); // downstream parse may fail; moderation is what's under test
+
+    expect(service.promptProcessor.processPromptForFeature).toHaveBeenCalled();
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      "grading.moderation.flagged",
+      expect.objectContaining({ categories: ["violence"] }),
+    );
+  });
+});

--- a/apps/api/src/api/llm/features/grading/services/video-grading.service.ts
+++ b/apps/api/src/api/llm/features/grading/services/video-grading.service.ts
@@ -11,6 +11,7 @@ import { IModerationService } from "../../../core/interfaces/moderation.interfac
 import { IPromptProcessor } from "../../../core/interfaces/prompt-processor.interface";
 import { MODERATION_SERVICE, PROMPT_PROCESSOR } from "../../../llm.constants";
 import { IVideoPresentationGradingService } from "../interfaces/video-grading.interface";
+import { MODERATION_BLOCK_FEEDBACK } from "../constants";
 
 @Injectable()
 export class VideoPresentationGradingService
@@ -47,15 +48,27 @@ export class VideoPresentationGradingService
       assignmentInstrctions,
       responseType,
       videoPresentationConfig,
+      safetyIdentifier,
     } = videoPresentationQuestionEvaluateModel;
 
-    // A moderation flag must not deny a learner their grade: log it and grade
-    // anyway (see the text-grading path for the rationale and precedent).
-    const passedModeration = await this.moderationService.validateContent(
+    const moderationVerdict = await this.moderationService.assessContent(
       learnerResponse.transcript,
     );
-    if (!passedModeration) {
-      this.logger.warn("video.grading.moderation.flagged_but_proceeding");
+    if (moderationVerdict.action === "block_severe") {
+      this.logger.warn("grading.moderation.blocked_severe", {
+        assignmentId,
+        categories: moderationVerdict.severeCategories,
+      });
+      return new VideoPresentationQuestionResponseModel(
+        0,
+        MODERATION_BLOCK_FEEDBACK,
+      );
+    }
+    if (moderationVerdict.action === "allow_with_log") {
+      this.logger.warn("grading.moderation.flagged", {
+        assignmentId,
+        categories: moderationVerdict.flaggedCategories,
+      });
     }
 
     const parser = StructuredOutputParser.fromZodSchema(
@@ -99,6 +112,8 @@ export class VideoPresentationGradingService
       assignmentId,
       AIUsageType.ASSIGNMENT_GRADING,
       "video_grading",
+      undefined,
+      { safetyIdentifier },
     );
 
     try {

--- a/apps/api/src/api/llm/features/grading/services/video-grading.service.ts
+++ b/apps/api/src/api/llm/features/grading/services/video-grading.service.ts
@@ -49,14 +49,13 @@ export class VideoPresentationGradingService
       videoPresentationConfig,
     } = videoPresentationQuestionEvaluateModel;
 
-    const validateLearnerResponse =
-      await this.moderationService.validateContent(learnerResponse.transcript);
-
-    if (!validateLearnerResponse) {
-      throw new HttpException(
-        "Learner response validation failed",
-        HttpStatus.BAD_REQUEST,
-      );
+    // A moderation flag must not deny a learner their grade: log it and grade
+    // anyway (see the text-grading path for the rationale and precedent).
+    const passedModeration = await this.moderationService.validateContent(
+      learnerResponse.transcript,
+    );
+    if (!passedModeration) {
+      this.logger.warn("video.grading.moderation.flagged_but_proceeding");
     }
 
     const parser = StructuredOutputParser.fromZodSchema(

--- a/apps/api/src/api/llm/llm-facade.service.ts
+++ b/apps/api/src/api/llm/llm-facade.service.ts
@@ -96,15 +96,6 @@ export class LlmFacadeService {
   }
 
   /**
-   * Moderate content and get detailed results
-   */
-  async moderateContent(
-    content: string,
-  ): Promise<{ flagged: boolean; details: string }> {
-    return this.moderationService.moderateContent(content);
-  }
-
-  /**
    * Generate contextual relationships between questions for grading
    */
   async generateQuestionGradingContext(

--- a/apps/api/src/api/llm/model/base.question.evaluate.model.ts
+++ b/apps/api/src/api/llm/model/base.question.evaluate.model.ts
@@ -6,4 +6,10 @@ export interface QuestionAnswerContext {
 export interface BaseQuestionEvaluateModel {
   readonly previousQuestionsAnswersContext: QuestionAnswerContext[];
   readonly assignmentInstrctions: string;
+  /**
+   * Hashed learner id for OpenAI safety attribution. Set by the attempt
+   * flow after construction; optional because authoring/preview paths
+   * have no learner.
+   */
+  safetyIdentifier?: string;
 }

--- a/apps/api/src/api/llm/model/file.based.question.evaluate.model.ts
+++ b/apps/api/src/api/llm/model/file.based.question.evaluate.model.ts
@@ -46,4 +46,11 @@ export class FileUploadQuestionEvaluateModel
     this.judgeFeedback = judgeFeedback;
     this.questionId = questionId;
   }
+
+  /**
+   * Hashed learner id for OpenAI safety attribution. Set by the attempt
+   * flow after construction; optional because authoring/preview paths
+   * have no learner.
+   */
+  safetyIdentifier?: string;
 }

--- a/apps/api/src/api/llm/model/image.based.evalutate.model.ts
+++ b/apps/api/src/api/llm/model/image.based.evalutate.model.ts
@@ -62,6 +62,12 @@ export class ImageBasedQuestionEvaluateModel
   }
   previousQuestionsAnswersContext: QuestionAnswerContext[];
   assignmentInstrctions: string;
+  /**
+   * Hashed learner id for OpenAI safety attribution. Set by the attempt
+   * flow after construction; optional because authoring/preview paths
+   * have no learner.
+   */
+  safetyIdentifier?: string;
 }
 
 /**

--- a/apps/api/src/api/llm/model/presentation.question.evaluate.model.ts
+++ b/apps/api/src/api/llm/model/presentation.question.evaluate.model.ts
@@ -39,4 +39,11 @@ export class PresentationQuestionEvaluateModel
     this.questionType = questionType;
     this.responseType = responseType;
   }
+
+  /**
+   * Hashed learner id for OpenAI safety attribution. Set by the attempt
+   * flow after construction; optional because authoring/preview paths
+   * have no learner.
+   */
+  safetyIdentifier?: string;
 }

--- a/apps/api/src/api/llm/model/text.based.question.evaluate.model.ts
+++ b/apps/api/src/api/llm/model/text.based.question.evaluate.model.ts
@@ -38,4 +38,11 @@ export class TextBasedQuestionEvaluateModel
     this.responseType = responseType;
     this.questionId = questionId;
   }
+
+  /**
+   * Hashed learner id for OpenAI safety attribution. Set by the attempt
+   * flow after construction; optional because authoring/preview paths
+   * have no learner.
+   */
+  safetyIdentifier?: string;
 }

--- a/apps/api/src/api/llm/model/url.based.question.evaluate.model.ts
+++ b/apps/api/src/api/llm/model/url.based.question.evaluate.model.ts
@@ -41,4 +41,11 @@ export class UrlBasedQuestionEvaluateModel
     this.scoringCriteria = scoringCriteria;
     this.responseType = responseType;
   }
+
+  /**
+   * Hashed learner id for OpenAI safety attribution. Set by the attempt
+   * flow after construction; optional because authoring/preview paths
+   * have no learner.
+   */
+  safetyIdentifier?: string;
 }

--- a/apps/api/src/api/llm/model/video-presentation.question.evaluate.model.ts
+++ b/apps/api/src/api/llm/model/video-presentation.question.evaluate.model.ts
@@ -47,4 +47,11 @@ export class VideoPresentationQuestionEvaluateModel
     this.responseType = responseType;
     this.videoPresentationConfig = videoPresentationConfig;
   }
+
+  /**
+   * Hashed learner id for OpenAI safety attribution. Set by the attempt
+   * flow after construction; optional because authoring/preview paths
+   * have no learner.
+   */
+  safetyIdentifier?: string;
 }


### PR DESCRIPTION
## Summary

Supersedes the July 20 hotfix (which made moderation flags non-blocking on only 3 of 6 grading services) with a single category-aware moderation policy shared by all six grading services and question authoring.

- **ModerationService** now calls the raw moderations API (`omni-moderation-latest`) and returns a verdict: `allow`, `allow_with_log`, or `block_severe`. The keyword pre-filter (which skipped moderation for most essay-like text while missing the security coursework it was built for) and the lossy `OpenAIModerationChain` are gone. Fail-open on API errors is preserved and narrowed to the API call itself.
- **All six grading services** (text, image, video, file, url, presentation) share the same branch: ordinary flags log `grading.moderation.flagged` and grade normally — a security course answer mentioning rootkits no longer blocks anyone; severe categories (default `sexual/minors`, configurable via `MODERATION_SEVERE_CATEGORIES`) skip the LLM entirely and persist a 0-point result with learner-facing feedback instead of throwing a 400. The file-grading judge loop also short-circuits on blocked results so severe content can't reach the judge model either.
- **Image grading** now moderates the uploaded images themselves (inline data-URLs, storage-fetched, and raw-base64), not just the text portion. Text and image moderation are independent calls so an image-fetch failure can't fail the text check open.
- **Question authoring** (`applyGuardRails`) blocks only on severe categories; ordinary flags are logged instead of 400-ing instructors.
- **Safety identifiers**: every ChatOpenAI call now carries `modelKwargs.safety_identifier` — a SHA-256 hash of the attempt owner's userId — threaded through both the v2 strategy flow (via `GradingContext`) and the legacy v1 handlers, so OpenAI can attribute traffic per end user instead of org-wide. The raw identifier never reaches logs or request options.

## Config

`MODERATION_SEVERE_CATEGORIES` (optional CSV of moderation category names, default `sexual/minors`). If ever set, it must be set on the jobs deployment too — grading runs on worker nodes.

## Testing

Full API suite at HEAD: 140 suites / 1475 tests, 0 failures. New unit coverage: moderation verdict mapping (incl. multi-part aggregation and both fail-open directions), all six services' three-way branches with no-LLM-call assertions on the severe path, judge short-circuit, safety-identifier forwarding in all providers, and hash-threading through both attempt flows.

## Follow-ups (not in this PR)

- Evidence-pipeline (criteria-based) calls don't carry the safety identifier yet; the moderation gate itself covers those paths.
- Chat has no moderation at all today.
- Learner-facing block message is English-only.