### PR TITLE
feat: move assignment reference-file extraction to the mark-jobs worker

### DIFF
--- a/apps/api/src/api/assignment/v2/controllers/assignment.controller.ts
+++ b/apps/api/src/api/assignment/v2/controllers/assignment.controller.ts
@@ -475,8 +475,9 @@ export class AssignmentControllerV2 {
   @Roles(UserRole.AUTHOR)
   @UseGuards(AssignmentAccessControlGuard)
   @ApiOperation({
-    summary:
-      "Complete a multipart upload for an assignment file and extract content",
+    summary: "Complete a multipart upload for an assignment file",
+    description:
+      "File finalized; content extraction runs asynchronously (extractionStatus PENDING until READY/FAILED)",
   })
   @ApiParam({ name: "id", required: true, description: "Assignment ID" })
   @ApiParam({ name: "fileId", required: true, description: "File ID" })
@@ -484,7 +485,7 @@ export class AssignmentControllerV2 {
   @ApiResponse({
     status: 201,
     description:
-      "File record updated to READY (or FAILED extraction) and extracted content persisted",
+      "File record updated to READY with extractionStatus PENDING; extraction runs asynchronously on mark-jobs",
   })
   async completeAssignmentFileUpload(
     @Param("id", ParseIntPipe) id: number,

--- a/apps/api/src/api/assignment/v2/services/assignment-file.service.ts
+++ b/apps/api/src/api/assignment/v2/services/assignment-file.service.ts
@@ -311,23 +311,40 @@ export class AssignmentFileService {
       >
     >[number];
 
+    // Download failures rethrow instead of persisting FAILED: they are
+    // transient infra errors, and the job's remaining BullMQ attempts are
+    // the recovery path. Only extraction itself (deterministic parsing that
+    // a retry cannot fix) falls through to the terminal failure envelope.
+    let buffer: Buffer;
     try {
       const object = await this.s3Service.getObject({
         Bucket: file.storageBucket,
         Key: file.storageKey,
       });
-      const buffer = await this.collectBodyToBuffer(object.Body);
-      const extractionInput = [
-        {
-          filename: file.filename,
-          content: "InCos",
-          fileType: file.mimeType || "application/octet-stream",
-          bucket: file.storageBucket,
-          key: file.storageKey,
-          buffer,
-        },
-      ];
+      buffer = await this.collectBodyToBuffer(object.Body);
+    } catch (downloadError) {
+      const message =
+        downloadError instanceof Error
+          ? downloadError.message
+          : String(downloadError);
+      this.logger.error(
+        `runAssignmentFileExtraction: S3 download failed for fileId=${fileId}, rethrowing for job retry: ${message}`,
+      );
+      throw downloadError;
+    }
 
+    const extractionInput = [
+      {
+        filename: file.filename,
+        content: "InCos",
+        fileType: file.mimeType || "application/octet-stream",
+        bucket: file.storageBucket,
+        key: file.storageKey,
+        buffer,
+      },
+    ];
+
+    try {
       try {
         [extractedFile] =
           await this.fileContentExtractionService.extractContentFromFiles(
@@ -404,15 +421,26 @@ export class AssignmentFileService {
       this.logger.warn(
         `runAssignmentFileExtraction: attempting fallback raw update for fileId=${fileId}`,
       );
-      await this.prisma.$executeRaw`
-        UPDATE "AssignmentFile"
-        SET "extractedText" = NULL,
-            "extractionStatus" = 'FAILED'::"AssignmentFileExtractionStatus",
-            "extractionError" = 'Extraction output rejected by storage layer',
-            "extractedAt" = NULL,
-            "updatedAt" = NOW()
-        WHERE "id" = ${fileId}
-      `;
+      try {
+        await this.prisma.$executeRaw`
+          UPDATE "AssignmentFile"
+          SET "extractedText" = NULL,
+              "extractionStatus" = 'FAILED'::"AssignmentFileExtractionStatus",
+              "extractionError" = 'Extraction output rejected by storage layer',
+              "extractedAt" = NULL,
+              "updatedAt" = NOW()
+          WHERE "id" = ${fileId}
+        `;
+      } catch (fallbackError) {
+        const fallbackMessage =
+          fallbackError instanceof Error
+            ? fallbackError.message
+            : String(fallbackError);
+        this.logger.error(
+          `runAssignmentFileExtraction: fallback raw update ALSO failed for fileId=${fileId}, rethrowing for job retry: ${fallbackMessage}`,
+        );
+        throw fallbackError;
+      }
       this.logger.log(
         `runAssignmentFileExtraction: fallback raw update succeeded for fileId=${fileId}, row marked FAILED`,
       );

--- a/apps/api/src/api/assignment/v2/services/assignment-file.service.ts
+++ b/apps/api/src/api/assignment/v2/services/assignment-file.service.ts
@@ -16,6 +16,8 @@ import { UploadType } from "src/api/files/dto/upload.dto";
 import { FilesService } from "src/api/files/services/files.service";
 import { S3Service } from "src/api/files/services/s3.service";
 import { PrismaService } from "src/database/prisma.service";
+import { JOB_NAMES, JOB_QUEUE_NAMES } from "src/job-queue/job-queue.constants";
+import { JobQueueService } from "src/job-queue/job-queue.service";
 import {
   CompleteAssignmentFileDto,
   InitiateAssignmentFileItemResponseDto,
@@ -52,6 +54,7 @@ export class AssignmentFileService {
     private readonly s3Service: S3Service,
     private readonly fileContentExtractionService: FileContentExtractionService,
     private readonly filesService: FilesService,
+    private readonly jobQueueService: JobQueueService,
   ) {}
 
   async initiateAssignmentFileUploads(
@@ -243,6 +246,65 @@ export class AssignmentFileService {
       );
     }
 
+    // Extraction moved off the request thread onto mark-jobs. Mark the row
+    // ready-to-serve with extraction pending, enqueue, and return immediately.
+    let updated: AssignmentFile;
+    try {
+      updated = await this.prisma.assignmentFile.update({
+        where: { id: fileId },
+        data: {
+          status: AssignmentFileStatus.READY,
+          extractionStatus: AssignmentFileExtractionStatus.PENDING,
+          extractionError: null,
+          extractedText: null,
+          extractedAt: null,
+          uploadId: null,
+        },
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.logger.error(
+        `completeAssignmentFileUpload: mark-pending update failed for fileId=${fileId}: ${message}`,
+      );
+      throw error;
+    }
+
+    try {
+      await this.jobQueueService.enqueue(
+        JOB_QUEUE_NAMES.FILE_EXTRACT,
+        JOB_NAMES.FILE_EXTRACT,
+        { assignmentId, fileId },
+        { jobId: `extract:${fileId}` },
+      );
+      this.logger.log(
+        `completeAssignmentFileUpload: fileId=${fileId} finalized status=READY extraction enqueued`,
+      );
+    } catch (error) {
+      // Leave the row PENDING so a re-enqueue (manual retry / sweeper) can pick
+      // it up; do not fail the author's upload over a transient broker hiccup.
+      const message = error instanceof Error ? error.message : String(error);
+      this.logger.error(
+        `completeAssignmentFileUpload: enqueue failed for fileId=${fileId}, row left PENDING: ${message}`,
+      );
+    }
+
+    return this.toResponse(updated);
+  }
+
+  /**
+   * Heavy extraction half of the reference-file upload, run on the mark-jobs
+   * worker. Loads the row by id (never trusts enqueued fields beyond it),
+   * downloads from S3, extracts, and persists extractedText + terminal
+   * extractionStatus. Idempotent: safe to re-run (overwrites).
+   */
+  async runAssignmentFileExtraction(fileId: number): Promise<void> {
+    const file = await this.prisma.assignmentFile.findUnique({
+      where: { id: fileId },
+    });
+    if (!file) {
+      throw new NotFoundException(`File with ID ${fileId} not found`);
+    }
+
     let extractedFile: Awaited<
       ReturnType<
         typeof this.fileContentExtractionService.extractContentFromFiles
@@ -275,12 +337,8 @@ export class AssignmentFileService {
         if (!(error instanceof OversizedSubmissionError)) {
           throw error;
         }
-        // Author reference material is context, not graded work: an over-cap
-        // PDF should degrade to truncated simple extraction (pre-existing
-        // behavior) rather than fail the upload. The evidence-block cap is a
-        // grading concern that does not apply here.
         this.logger.warn(
-          `completeAssignmentFileUpload: oversized reference file ${file.filename} (blockCount=${error.blockCount} cap=${error.cap}); retrying with structured extraction disabled`,
+          `runAssignmentFileExtraction: oversized reference file ${file.filename} (blockCount=${error.blockCount} cap=${error.cap}); retrying with structured extraction disabled`,
         );
         [extractedFile] =
           await this.fileContentExtractionService.extractContentFromFiles(
@@ -294,7 +352,7 @@ export class AssignmentFileService {
           ? extractionError.message
           : String(extractionError);
       this.logger.error(
-        `completeAssignmentFileUpload: post-complete step failed for fileId=${fileId}: ${message}`,
+        `runAssignmentFileExtraction: extraction failed for fileId=${fileId}: ${message}`,
       );
       extractedFile = {
         filename: file.filename,
@@ -322,77 +380,37 @@ export class AssignmentFileService {
     const safeExtractionError = extractionFailed
       ? this.sanitizeForTextColumn(extractedFile.error ?? null)
       : null;
-    const extractedLength = safeExtractedText?.length ?? 0;
-    const errorLength = safeExtractionError?.length ?? 0;
     this.logger.log(
-      `completeAssignmentFileUpload: fileId=${fileId} extractionFailed=${String(extractionFailed)} extractedLen=${extractedLength} errorLen=${errorLength}`,
+      `runAssignmentFileExtraction: fileId=${fileId} extractionFailed=${String(extractionFailed)} extractedLen=${safeExtractedText?.length ?? 0}`,
     );
 
-    let updated: AssignmentFile;
     try {
-      updated = await this.prisma.assignmentFile.update({
+      await this.prisma.assignmentFile.update({
         where: { id: fileId },
         data: {
-          status: AssignmentFileStatus.READY,
           extractedText: safeExtractedText,
           extractionStatus: extractionFailed
             ? AssignmentFileExtractionStatus.FAILED
             : AssignmentFileExtractionStatus.READY,
           extractionError: safeExtractionError,
           extractedAt: extractionFailed ? null : new Date(),
-          uploadId: null,
         },
       });
-      this.logger.log(
-        `completeAssignmentFileUpload: fileId=${fileId} primary update OK status=READY`,
-      );
     } catch (error) {
-      // Extractor output can be unsafe for Postgres TEXT even after sanitization
-      // (Prisma query engine rejects malformed UTF-8 / truncated \u escapes with
-      // "unexpected end of hex escape"). Fall back to storing a fixed-ASCII
-      // error marker via $executeRaw — that bypasses the query engine's JSON
-      // boundary so it cannot fail on extractor output. Keep the row usable.
       const message = error instanceof Error ? error.message : String(error);
       this.logger.error(
-        `completeAssignmentFileUpload: primary update failed for fileId=${fileId}: ${message}`,
+        `runAssignmentFileExtraction: primary update failed for fileId=${fileId}: ${message}`,
       );
-      try {
-        await this.prisma.$executeRaw`
-          UPDATE "AssignmentFile"
-          SET "status" = 'READY'::"AssignmentFileStatus",
-              "extractedText" = NULL,
-              "extractionStatus" = 'FAILED'::"AssignmentFileExtractionStatus",
-              "extractionError" = 'Extraction output rejected by storage layer',
-              "extractedAt" = NULL,
-              "uploadId" = NULL,
-              "updatedAt" = NOW()
-          WHERE "id" = ${fileId}
-        `;
-        this.logger.log(
-          `completeAssignmentFileUpload: fileId=${fileId} fallback raw update OK status=READY/FAILED`,
-        );
-      } catch (fallbackError) {
-        const fm =
-          fallbackError instanceof Error
-            ? fallbackError.message
-            : String(fallbackError);
-        this.logger.error(
-          `completeAssignmentFileUpload: FALLBACK update ALSO failed for fileId=${fileId}: ${fm}`,
-        );
-        throw fallbackError;
-      }
-      const reloaded = await this.prisma.assignmentFile.findUnique({
-        where: { id: fileId },
-      });
-      if (!reloaded) {
-        throw new NotFoundException(
-          `File with ID ${fileId} not found after fallback update`,
-        );
-      }
-      updated = reloaded;
+      await this.prisma.$executeRaw`
+        UPDATE "AssignmentFile"
+        SET "extractedText" = NULL,
+            "extractionStatus" = 'FAILED'::"AssignmentFileExtractionStatus",
+            "extractionError" = 'Extraction output rejected by storage layer',
+            "extractedAt" = NULL,
+            "updatedAt" = NOW()
+        WHERE "id" = ${fileId}
+      `;
     }
-
-    return this.toResponse(updated);
   }
 
   /**

--- a/apps/api/src/api/assignment/v2/services/assignment-file.service.ts
+++ b/apps/api/src/api/assignment/v2/services/assignment-file.service.ts
@@ -381,7 +381,7 @@ export class AssignmentFileService {
       ? this.sanitizeForTextColumn(extractedFile.error ?? null)
       : null;
     this.logger.log(
-      `runAssignmentFileExtraction: fileId=${fileId} extractionFailed=${String(extractionFailed)} extractedLen=${safeExtractedText?.length ?? 0}`,
+      `runAssignmentFileExtraction: fileId=${fileId} extractionFailed=${String(extractionFailed)} extractedLen=${safeExtractedText?.length ?? 0} errorLen=${safeExtractionError?.length ?? 0}`,
     );
 
     try {
@@ -401,6 +401,9 @@ export class AssignmentFileService {
       this.logger.error(
         `runAssignmentFileExtraction: primary update failed for fileId=${fileId}: ${message}`,
       );
+      this.logger.warn(
+        `runAssignmentFileExtraction: attempting fallback raw update for fileId=${fileId}`,
+      );
       await this.prisma.$executeRaw`
         UPDATE "AssignmentFile"
         SET "extractedText" = NULL,
@@ -410,6 +413,9 @@ export class AssignmentFileService {
             "updatedAt" = NOW()
         WHERE "id" = ${fileId}
       `;
+      this.logger.log(
+        `runAssignmentFileExtraction: fallback raw update succeeded for fileId=${fileId}, row marked FAILED`,
+      );
     }
   }
 

--- a/apps/api/src/api/assignment/v2/services/translation-log-shape.spec.ts
+++ b/apps/api/src/api/assignment/v2/services/translation-log-shape.spec.ts
@@ -89,6 +89,7 @@ describe("Log shape contract: translation-job lifecycle", () => {
       noopService,
       noopService,
       translationService as any,
+      noopService,
       winstonLogger as any,
     );
 

--- a/apps/api/src/api/assignment/v2/tests/unit/services/assignment-file.service.spec.ts
+++ b/apps/api/src/api/assignment/v2/tests/unit/services/assignment-file.service.spec.ts
@@ -12,6 +12,8 @@ import { OversizedSubmissionError } from "src/api/llm/features/grading/errors/ov
 import { FilesService } from "src/api/files/services/files.service";
 import { S3Service } from "src/api/files/services/s3.service";
 import { PrismaService } from "src/database/prisma.service";
+import { JOB_NAMES, JOB_QUEUE_NAMES } from "src/job-queue/job-queue.constants";
+import { JobQueueService } from "src/job-queue/job-queue.service";
 import { AssignmentFileService } from "../../../services/assignment-file.service";
 
 const makeDbFile = (overrides = {}) => ({
@@ -39,6 +41,7 @@ describe("AssignmentFileService", () => {
   let s3: any;
   let extractor: any;
   let filesService: any;
+  let jobQueue: any;
 
   beforeEach(async () => {
     prisma = {
@@ -90,6 +93,8 @@ describe("AssignmentFileService", () => {
       validateUploadSize: jest.fn().mockReturnValue(100 * 1024 * 1024),
     };
 
+    jobQueue = { enqueue: jest.fn().mockResolvedValue(undefined) };
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         AssignmentFileService,
@@ -97,6 +102,7 @@ describe("AssignmentFileService", () => {
         { provide: S3Service, useValue: s3 },
         { provide: FileContentExtractionService, useValue: extractor },
         { provide: FilesService, useValue: filesService },
+        { provide: JobQueueService, useValue: jobQueue },
       ],
     }).compile();
 
@@ -226,14 +232,14 @@ describe("AssignmentFileService", () => {
       ).rejects.toThrow(BadRequestException);
     });
 
-    it("completes MPU, extracts, marks READY, clears uploadId", async () => {
+    it("completes MPU, sets PENDING extractionStatus, enqueues extraction, and does NOT extract inline", async () => {
       prisma.assignmentFile.findUnique.mockResolvedValue(makeDbFile());
       prisma.assignmentFile.update.mockResolvedValue(
         makeDbFile({
           status: AssignmentFileStatus.READY,
-          extractionStatus: AssignmentFileExtractionStatus.READY,
-          extractedText: "extracted content",
-          extractedAt: new Date(),
+          extractionStatus: AssignmentFileExtractionStatus.PENDING,
+          extractedText: null,
+          extractedAt: null,
           uploadId: null,
         }),
       );
@@ -252,18 +258,27 @@ describe("AssignmentFileService", () => {
           },
         }),
       );
-      expect(extractor.extractContentFromFiles).toHaveBeenCalledTimes(1);
+      expect(extractor.extractContentFromFiles).not.toHaveBeenCalled();
       expect(prisma.assignmentFile.update).toHaveBeenCalledWith(
         expect.objectContaining({
           where: { id: 1 },
           data: expect.objectContaining({
             status: AssignmentFileStatus.READY,
-            extractionStatus: AssignmentFileExtractionStatus.READY,
+            extractionStatus: AssignmentFileExtractionStatus.PENDING,
             uploadId: null,
           }),
         }),
       );
+      expect(jobQueue.enqueue).toHaveBeenCalledWith(
+        JOB_QUEUE_NAMES.FILE_EXTRACT,
+        JOB_NAMES.FILE_EXTRACT,
+        { assignmentId: 1, fileId: 1 },
+        expect.objectContaining({ jobId: "extract:1" }),
+      );
       expect(result.status).toBe(AssignmentFileStatus.READY);
+      expect(result.extractionStatus).toBe(
+        AssignmentFileExtractionStatus.PENDING,
+      );
     });
 
     it("marks the row FAILED and aborts S3 when multipart completion fails and no object exists", async () => {
@@ -311,9 +326,9 @@ describe("AssignmentFileService", () => {
       prisma.assignmentFile.update.mockResolvedValue(
         makeDbFile({
           status: AssignmentFileStatus.READY,
-          extractionStatus: AssignmentFileExtractionStatus.READY,
-          extractedText: "extracted content",
-          extractedAt: new Date(),
+          extractionStatus: AssignmentFileExtractionStatus.PENDING,
+          extractedText: null,
+          extractedAt: null,
           uploadId: null,
         }),
       );
@@ -326,61 +341,17 @@ describe("AssignmentFileService", () => {
 
       expect(s3.abortMultipartUpload).not.toHaveBeenCalled();
       expect(result.status).toBe(AssignmentFileStatus.READY);
-    });
-
-    it("persists extraction error and FAILED extractionStatus when extractor returns error", async () => {
-      prisma.assignmentFile.findUnique.mockResolvedValue(makeDbFile());
-      extractor.extractContentFromFiles.mockResolvedValue([
-        {
-          filename: "test.txt",
-          content: "[ERROR extracting test.txt]\n...",
-          error: "parse error",
-          fileType: "text/plain",
-          metadata: { size: 0 },
-        },
-      ]);
-      prisma.assignmentFile.update.mockResolvedValue(
-        makeDbFile({
-          status: AssignmentFileStatus.READY,
-          extractionStatus: AssignmentFileExtractionStatus.FAILED,
-          extractionError: "parse error",
-          extractedText: null,
-          extractedAt: null,
-          uploadId: null,
-        }),
-      );
-
-      const result = await service.completeAssignmentFileUpload(
-        1,
-        1,
-        validDto as any,
-      );
-
-      expect(prisma.assignmentFile.update).toHaveBeenCalledWith(
-        expect.objectContaining({
-          data: expect.objectContaining({
-            status: AssignmentFileStatus.READY,
-            extractionStatus: AssignmentFileExtractionStatus.FAILED,
-            extractionError: "parse error",
-            extractedText: null,
-          }),
-        }),
-      );
       expect(result.extractionStatus).toBe(
-        AssignmentFileExtractionStatus.FAILED,
+        AssignmentFileExtractionStatus.PENDING,
       );
     });
 
-    it("keeps the uploaded file READY when post-complete extraction throws", async () => {
+    it("does not extract inline — complete always returns PENDING and enqueues", async () => {
       prisma.assignmentFile.findUnique.mockResolvedValue(makeDbFile());
-      extractor.extractContentFromFiles.mockRejectedValue(
-        new Error("parser boom"),
-      );
       prisma.assignmentFile.update.mockResolvedValue(
         makeDbFile({
           status: AssignmentFileStatus.READY,
-          extractionStatus: AssignmentFileExtractionStatus.FAILED,
-          extractionError: "Post-upload extraction failed: parser boom",
+          extractionStatus: AssignmentFileExtractionStatus.PENDING,
           extractedText: null,
           extractedAt: null,
           uploadId: null,
@@ -393,30 +364,165 @@ describe("AssignmentFileService", () => {
         validDto as any,
       );
 
+      expect(extractor.extractContentFromFiles).not.toHaveBeenCalled();
+      expect(s3.deleteObject).not.toHaveBeenCalled();
+      expect(result.status).toBe(AssignmentFileStatus.READY);
+      expect(result.extractionStatus).toBe(
+        AssignmentFileExtractionStatus.PENDING,
+      );
+    });
+
+    it("complete survives when enqueue fails — row stays PENDING, upload succeeds", async () => {
+      prisma.assignmentFile.findUnique.mockResolvedValue(makeDbFile());
+      jobQueue.enqueue.mockRejectedValue(new Error("redis down"));
+      prisma.assignmentFile.update.mockResolvedValue(
+        makeDbFile({
+          status: AssignmentFileStatus.READY,
+          extractionStatus: AssignmentFileExtractionStatus.PENDING,
+          uploadId: null,
+        }),
+      );
+
+      const result = await service.completeAssignmentFileUpload(
+        1,
+        1,
+        validDto as any,
+      );
+
+      expect(result.extractionStatus).toBe(
+        AssignmentFileExtractionStatus.PENDING,
+      );
+    });
+
+    it("mark-pending update throws — error propagates (upload not silently swallowed)", async () => {
+      prisma.assignmentFile.findUnique.mockResolvedValue(makeDbFile());
+      prisma.assignmentFile.update.mockRejectedValueOnce(
+        new Error("db connection lost"),
+      );
+
+      await expect(
+        service.completeAssignmentFileUpload(1, 1, validDto as any),
+      ).rejects.toThrow("db connection lost");
+
+      expect(prisma.assignmentFile.update).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("async extraction split", () => {
+    it("complete finalizes S3, sets PENDING, enqueues, and does NOT extract inline", async () => {
+      prisma.assignmentFile.findUnique.mockResolvedValue(makeDbFile());
+      prisma.assignmentFile.update.mockResolvedValue(
+        makeDbFile({
+          status: AssignmentFileStatus.READY,
+          extractionStatus: AssignmentFileExtractionStatus.PENDING,
+          extractedText: null,
+          uploadId: null,
+        }),
+      );
+
+      const res = await service.completeAssignmentFileUpload(1, 1, {
+        uploadId: "upload-abc",
+        parts: [{ partNumber: 1, etag: "e" }],
+      } as never);
+
+      expect(extractor.extractContentFromFiles).not.toHaveBeenCalled();
       expect(prisma.assignmentFile.update).toHaveBeenCalledWith(
         expect.objectContaining({
+          where: { id: 1 },
           data: expect.objectContaining({
             status: AssignmentFileStatus.READY,
-            extractionStatus: AssignmentFileExtractionStatus.FAILED,
-            extractionError: "Post-upload extraction failed: parser boom",
+            extractionStatus: AssignmentFileExtractionStatus.PENDING,
             uploadId: null,
           }),
         }),
       );
-      expect(s3.deleteObject).not.toHaveBeenCalled();
-      expect(result.status).toBe(AssignmentFileStatus.READY);
-      expect(result.extractionStatus).toBe(
-        AssignmentFileExtractionStatus.FAILED,
+      expect(jobQueue.enqueue).toHaveBeenCalledWith(
+        JOB_QUEUE_NAMES.FILE_EXTRACT,
+        JOB_NAMES.FILE_EXTRACT,
+        { assignmentId: 1, fileId: 1 },
+        expect.objectContaining({ jobId: "extract:1" }),
+      );
+      expect(res.extractionStatus).toBe(AssignmentFileExtractionStatus.PENDING);
+    });
+
+    it("complete still succeeds (row PENDING) when enqueue fails", async () => {
+      prisma.assignmentFile.findUnique.mockResolvedValue(makeDbFile());
+      jobQueue.enqueue.mockRejectedValue(new Error("redis down"));
+      prisma.assignmentFile.update.mockResolvedValue(
+        makeDbFile({
+          status: AssignmentFileStatus.READY,
+          extractionStatus: AssignmentFileExtractionStatus.PENDING,
+          uploadId: null,
+        }),
+      );
+
+      const res = await service.completeAssignmentFileUpload(1, 1, {
+        uploadId: "upload-abc",
+        parts: [{ partNumber: 1, etag: "e" }],
+      } as never);
+      expect(res.extractionStatus).toBe(AssignmentFileExtractionStatus.PENDING);
+    });
+
+    it("runAssignmentFileExtraction extracts and persists READY", async () => {
+      prisma.assignmentFile.findUnique.mockResolvedValue(
+        makeDbFile({ status: AssignmentFileStatus.READY }),
+      );
+      extractor.extractContentFromFiles.mockResolvedValue([
+        {
+          filename: "test.txt",
+          content: "extracted text",
+          fileType: "text/plain",
+        },
+      ]);
+      await service.runAssignmentFileExtraction(1);
+
+      expect(extractor.extractContentFromFiles).toHaveBeenCalledTimes(1);
+      expect(prisma.assignmentFile.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: 1 },
+          data: expect.objectContaining({
+            extractedText: "extracted text",
+            extractionStatus: AssignmentFileExtractionStatus.READY,
+          }),
+        }),
       );
     });
 
-    it("retries with structured extraction disabled when an oversized author PDF rejects", async () => {
+    it("runAssignmentFileExtraction persists FAILED when extraction errors", async () => {
       prisma.assignmentFile.findUnique.mockResolvedValue(
-        makeDbFile({ filename: "reference.pdf", mimeType: "application/pdf" }),
+        makeDbFile({ status: AssignmentFileStatus.READY }),
       );
-      // First call (structured default ON) rejects with the typed error; the
-      // service must retry once with structured extraction disabled, which
-      // degrades to truncated simple extraction (pre-existing behavior).
+      extractor.extractContentFromFiles.mockRejectedValue(
+        new Error("parse blew up"),
+      );
+      await service.runAssignmentFileExtraction(1);
+
+      expect(prisma.assignmentFile.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: 1 },
+          data: expect.objectContaining({
+            extractionStatus: AssignmentFileExtractionStatus.FAILED,
+            extractedText: null,
+          }),
+        }),
+      );
+    });
+
+    it("runAssignmentFileExtraction throws NotFound for a missing row", async () => {
+      prisma.assignmentFile.findUnique.mockResolvedValue(null);
+      await expect(service.runAssignmentFileExtraction(999)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it("runAssignmentFileExtraction retries with structured extraction disabled when oversized PDF rejects", async () => {
+      prisma.assignmentFile.findUnique.mockResolvedValue(
+        makeDbFile({
+          status: AssignmentFileStatus.READY,
+          filename: "reference.pdf",
+          mimeType: "application/pdf",
+        }),
+      );
       extractor.extractContentFromFiles
         .mockRejectedValueOnce(
           new OversizedSubmissionError({
@@ -445,11 +551,7 @@ describe("AssignmentFileService", () => {
         }),
       );
 
-      const result = await service.completeAssignmentFileUpload(
-        1,
-        1,
-        validDto as any,
-      );
+      await service.runAssignmentFileExtraction(1);
 
       expect(extractor.extractContentFromFiles).toHaveBeenCalledTimes(2);
       expect(extractor.extractContentFromFiles.mock.calls[1][1]).toEqual({
@@ -458,24 +560,21 @@ describe("AssignmentFileService", () => {
       expect(prisma.assignmentFile.update).toHaveBeenCalledWith(
         expect.objectContaining({
           data: expect.objectContaining({
-            status: AssignmentFileStatus.READY,
             extractionStatus: AssignmentFileExtractionStatus.READY,
             extractedText: "truncated reference text",
           }),
         }),
       );
-      expect(result.status).toBe(AssignmentFileStatus.READY);
-      expect(result.extractionStatus).toBe(
-        AssignmentFileExtractionStatus.READY,
-      );
     });
 
-    it("strips NUL bytes from extracted content before persisting", async () => {
-      prisma.assignmentFile.findUnique.mockResolvedValue(makeDbFile());
+    it("runAssignmentFileExtraction strips NUL bytes from extracted content before persisting", async () => {
+      prisma.assignmentFile.findUnique.mockResolvedValue(
+        makeDbFile({ status: AssignmentFileStatus.READY }),
+      );
       extractor.extractContentFromFiles.mockResolvedValue([
         {
           filename: "test.txt",
-          content: "hel lo world",
+          content: "hel lo world",
           fileType: "text/plain",
           metadata: { size: 13 },
         },
@@ -484,51 +583,41 @@ describe("AssignmentFileService", () => {
         makeDbFile({
           status: AssignmentFileStatus.READY,
           extractionStatus: AssignmentFileExtractionStatus.READY,
-          extractedText: "helloworld",
+          extractedText: "hello world",
           uploadId: null,
         }),
       );
 
-      await service.completeAssignmentFileUpload(1, 1, validDto as any);
+      await service.runAssignmentFileExtraction(1);
 
       expect(prisma.assignmentFile.update).toHaveBeenCalledWith(
         expect.objectContaining({
           data: expect.objectContaining({
-            extractedText: "helloworld",
+            extractedText: "hello world",
           }),
         }),
       );
     });
 
-    it("recovers via raw SQL fallback when the first update throws — never leaves row stuck in UPLOADING", async () => {
-      prisma.assignmentFile.findUnique
-        .mockResolvedValueOnce(makeDbFile())
-        .mockResolvedValueOnce(
-          makeDbFile({
-            status: AssignmentFileStatus.READY,
-            extractionStatus: AssignmentFileExtractionStatus.FAILED,
-            extractionError: "Extraction output rejected by storage layer",
-            extractedText: null,
-            uploadId: null,
-          }),
-        );
+    it("runAssignmentFileExtraction recovers via raw SQL fallback when primary update throws", async () => {
+      prisma.assignmentFile.findUnique.mockResolvedValue(
+        makeDbFile({ status: AssignmentFileStatus.READY }),
+      );
+      extractor.extractContentFromFiles.mockResolvedValue([
+        {
+          filename: "test.txt",
+          content: "some content",
+          fileType: "text/plain",
+        },
+      ]);
       prisma.assignmentFile.update.mockRejectedValueOnce(
         new Error("unexpected end of hex escape at line 1 column 226"),
       );
       prisma.$executeRaw = jest.fn().mockResolvedValue(1);
 
-      const result = await service.completeAssignmentFileUpload(
-        1,
-        1,
-        validDto as any,
-      );
+      await service.runAssignmentFileExtraction(1);
 
-      expect(prisma.assignmentFile.update).toHaveBeenCalledTimes(1);
       expect(prisma.$executeRaw).toHaveBeenCalledTimes(1);
-      expect(result.status).toBe(AssignmentFileStatus.READY);
-      expect(result.extractionStatus).toBe(
-        AssignmentFileExtractionStatus.FAILED,
-      );
     });
   });
 

--- a/apps/api/src/api/assignment/v2/tests/unit/services/assignment-file.service.spec.ts
+++ b/apps/api/src/api/assignment/v2/tests/unit/services/assignment-file.service.spec.ts
@@ -515,6 +515,49 @@ describe("AssignmentFileService", () => {
       );
     });
 
+    it("runAssignmentFileExtraction rethrows on S3 download failure so the job retries", async () => {
+      prisma.assignmentFile.findUnique.mockResolvedValue(
+        makeDbFile({ status: AssignmentFileStatus.READY }),
+      );
+      s3.getObject.mockRejectedValue(new Error("s3 timeout"));
+
+      await expect(service.runAssignmentFileExtraction(1)).rejects.toThrow(
+        "s3 timeout",
+      );
+      expect(extractor.extractContentFromFiles).not.toHaveBeenCalled();
+      expect(prisma.assignmentFile.update).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            extractionStatus: AssignmentFileExtractionStatus.FAILED,
+          }),
+        }),
+      );
+    });
+
+    it("runAssignmentFileExtraction rethrows when the raw fallback update also fails", async () => {
+      prisma.assignmentFile.findUnique.mockResolvedValue(
+        makeDbFile({ status: AssignmentFileStatus.READY }),
+      );
+      extractor.extractContentFromFiles.mockResolvedValue([
+        {
+          filename: "test.txt",
+          content: "extracted text",
+          fileType: "text/plain",
+        },
+      ]);
+      prisma.assignmentFile.update.mockRejectedValue(
+        new Error("bad utf8 rejected"),
+      );
+      prisma.$executeRaw = jest
+        .fn()
+        .mockRejectedValue(new Error("raw update rejected"));
+
+      await expect(service.runAssignmentFileExtraction(1)).rejects.toThrow(
+        "raw update rejected",
+      );
+      expect(prisma.$executeRaw).toHaveBeenCalledTimes(1);
+    });
+
     it("runAssignmentFileExtraction retries with structured extraction disabled when oversized PDF rejects", async () => {
       prisma.assignmentFile.findUnique.mockResolvedValue(
         makeDbFile({

--- a/apps/api/src/job-queue/job-executor.service.spec.ts
+++ b/apps/api/src/job-queue/job-executor.service.spec.ts
@@ -1,3 +1,4 @@
+import { BadRequestException } from "@nestjs/common";
 import { JobExecutorService } from "./job-executor.service";
 import { JOB_NAMES, JOB_QUEUE_NAMES } from "./job-queue.constants";
 
@@ -37,6 +38,7 @@ describe("JobExecutorService translation jobs", () => {
         noopService as never,
         noopService as never,
         translationService as never,
+        noopService as never,
         logger as never,
       ),
       translationService,
@@ -279,5 +281,65 @@ describe("JobExecutorService translation jobs", () => {
         },
       }),
     ).rejects.toThrow(/1 language/);
+  });
+});
+
+describe("JobExecutorService — file-extract", () => {
+  it("dispatches FILE_EXTRACT to AssignmentFileService.runAssignmentFileExtraction", async () => {
+    const assignmentFileService = {
+      runAssignmentFileExtraction: jest.fn().mockResolvedValue(undefined),
+    };
+    const logger = {
+      child: () => ({ info: jest.fn(), warn: jest.fn(), error: jest.fn() }),
+    };
+    const service = new JobExecutorService(
+      {} as never, // assignmentServiceV1
+      {} as never, // assignmentServiceV2
+      {} as never, // assignmentQuestionServiceV2
+      {} as never, // attemptService
+      {} as never, // translationRunner
+      {} as never, // translationService
+      assignmentFileService as never,
+      logger as never,
+    );
+
+    await service.executeJob({
+      queueName: JOB_QUEUE_NAMES.FILE_EXTRACT,
+      jobName: JOB_NAMES.FILE_EXTRACT,
+      payload: { assignmentId: 3, fileId: 7 },
+    });
+
+    expect(
+      assignmentFileService.runAssignmentFileExtraction,
+    ).toHaveBeenCalledWith(7);
+  });
+
+  it("rejects unknown job names on the file-extract queue", async () => {
+    const assignmentFileService = {
+      runAssignmentFileExtraction: jest.fn(),
+    };
+    const logger = {
+      child: () => ({ info: jest.fn(), warn: jest.fn(), error: jest.fn() }),
+    };
+    const service = new JobExecutorService(
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      assignmentFileService as never,
+      logger as never,
+    );
+    await expect(
+      service.executeJob({
+        queueName: JOB_QUEUE_NAMES.FILE_EXTRACT,
+        jobName: JOB_NAMES.ATTEMPT_GRADE,
+        payload: {},
+      }),
+    ).rejects.toThrow(BadRequestException);
+    expect(
+      assignmentFileService.runAssignmentFileExtraction,
+    ).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/job-queue/job-executor.service.ts
+++ b/apps/api/src/job-queue/job-executor.service.ts
@@ -7,6 +7,7 @@ import {
 } from "../api/admin/controllers/translation-maintenance.job-runner";
 import { AssignmentServiceV1 } from "../api/assignment/v1/services/assignment.service";
 import { AssignmentServiceV2 } from "../api/assignment/v2/services/assignment.service";
+import { AssignmentFileService } from "../api/assignment/v2/services/assignment-file.service";
 import { QuestionService as AssignmentQuestionServiceV2 } from "../api/assignment/v2/services/question.service";
 import { TranslationService } from "../api/assignment/v2/services/translation.service";
 import { AttemptServiceV2 } from "../api/attempt/services/attempt.service";
@@ -26,6 +27,7 @@ import {
   AssignmentV2RetryFailedTranslationsJobPayload,
   AttemptAuthorPreviewJobPayload,
   AttemptGradeJobPayload,
+  FileExtractJobPayload,
   TranslateMetaJobPayload,
   TranslateQuestionJobPayload,
   TranslateVariantJobPayload,
@@ -54,6 +56,7 @@ export class JobExecutorService {
     @Inject(TRANSLATION_MAINTENANCE_JOB_RUNNER)
     private readonly translationRunner: TranslationMaintenanceJobRunner,
     private readonly translationService: TranslationService,
+    private readonly assignmentFileService: AssignmentFileService,
     @Inject(WINSTON_MODULE_PROVIDER) parentLogger: Logger,
   ) {
     this.logger = parentLogger.child({ context: JobExecutorService.name });
@@ -84,6 +87,9 @@ export class JobExecutorService {
           request.attemptsMade ?? 0,
           request.maxAttempts ?? 1,
         );
+      }
+      case JOB_QUEUE_NAMES.FILE_EXTRACT: {
+        return this.executeFileExtractJob(request.jobName, request.payload);
       }
       default: {
         throw new BadRequestException(
@@ -389,6 +395,26 @@ export class JobExecutorService {
       default: {
         throw new BadRequestException(
           `Unsupported translation job: ${jobName}`,
+        );
+      }
+    }
+  }
+
+  private async executeFileExtractJob(
+    jobName: JobName,
+    payload: unknown,
+  ): Promise<void> {
+    switch (jobName) {
+      case JOB_NAMES.FILE_EXTRACT: {
+        const jobPayload = payload as FileExtractJobPayload;
+        await this.assignmentFileService.runAssignmentFileExtraction(
+          jobPayload.fileId,
+        );
+        return;
+      }
+      default: {
+        throw new BadRequestException(
+          `Unsupported file-extract job: ${jobName}`,
         );
       }
     }

--- a/apps/api/src/job-queue/job-queue.constants.spec.ts
+++ b/apps/api/src/job-queue/job-queue.constants.spec.ts
@@ -1,0 +1,8 @@
+import { JOB_NAMES, JOB_QUEUE_NAMES } from "./job-queue.constants";
+
+describe("job-queue.constants", () => {
+  it("defines the file-extract queue and job names", () => {
+    expect(JOB_QUEUE_NAMES.FILE_EXTRACT).toBe("mark.file-extract");
+    expect(JOB_NAMES.FILE_EXTRACT).toBe("file.extract");
+  });
+});

--- a/apps/api/src/job-queue/job-queue.constants.ts
+++ b/apps/api/src/job-queue/job-queue.constants.ts
@@ -8,6 +8,7 @@ export const JOB_QUEUE_NAMES = {
   ATTEMPT_HEAVY: "mark.attempt.heavy",
   ADMIN_TRANSLATION: "mark.admin.translation",
   ASSIGNMENT_V2_TRANSLATIONS: "mark.assignment.v2.translations",
+  FILE_EXTRACT: "mark.file-extract",
 } as const;
 
 export const JOB_NAMES = {
@@ -23,6 +24,7 @@ export const JOB_NAMES = {
   TRANSLATE_QUESTION: "assignment-v2.translate-question",
   TRANSLATE_VARIANT: "assignment-v2.translate-variant",
   TRANSLATE_META: "assignment-v2.translate-meta",
+  FILE_EXTRACT: "file.extract",
 } as const;
 
 // BullMQ processes jobs enqueued WITHOUT a priority before ALL prioritized

--- a/apps/api/src/job-queue/job-queue.types.ts
+++ b/apps/api/src/job-queue/job-queue.types.ts
@@ -134,3 +134,8 @@ export interface AdminSweepMissingTranslationsJobPayload {
   jobId: string;
   body: SweepTranslationsJobRequest;
 }
+
+export interface FileExtractJobPayload {
+  assignmentId: number;
+  fileId: number;
+}

--- a/apps/api/src/job-queue/queue-metadata.ts
+++ b/apps/api/src/job-queue/queue-metadata.ts
@@ -21,7 +21,8 @@ export interface QueueMetadata {
 
 // Keyed by the queue's wire name (the value in JOB_QUEUE_NAMES). Concurrency
 // defaults mirror the worker registration: v1/v2 author generation = 2 each,
-// grading (attempt) = 4, translations = 8, admin maintenance = 1.
+// grading (attempt) = 4, translations = 8, admin maintenance = 1, file
+// extraction = 2.
 export const QUEUE_METADATA: Record<string, QueueMetadata> = {
   [JOB_QUEUE_NAMES.ASSIGNMENT_V1]: {
     role: "author",

--- a/apps/api/src/job-queue/queue-metadata.ts
+++ b/apps/api/src/job-queue/queue-metadata.ts
@@ -47,4 +47,8 @@ export const QUEUE_METADATA: Record<string, QueueMetadata> = {
     role: "admin-maintenance",
     defaultConcurrencyPerPod: 1,
   },
+  [JOB_QUEUE_NAMES.FILE_EXTRACT]: {
+    role: "author",
+    defaultConcurrencyPerPod: 2,
+  },
 };

--- a/apps/jobs/src/job-queue.constants.ts
+++ b/apps/jobs/src/job-queue.constants.ts
@@ -8,6 +8,7 @@ export const JOB_QUEUE_NAMES = {
   ATTEMPT_HEAVY: "mark.attempt.heavy",
   ADMIN_TRANSLATION: "mark.admin.translation",
   ASSIGNMENT_V2_TRANSLATIONS: "mark.assignment.v2.translations",
+  FILE_EXTRACT: "mark.file-extract",
 } as const;
 
 export const JOB_NAMES = {
@@ -23,6 +24,7 @@ export const JOB_NAMES = {
   TRANSLATE_QUESTION: "assignment-v2.translate-question",
   TRANSLATE_VARIANT: "assignment-v2.translate-variant",
   TRANSLATE_META: "assignment-v2.translate-meta",
+  FILE_EXTRACT: "file.extract",
 } as const;
 
 // BullMQ processes jobs enqueued WITHOUT a priority before ALL prioritized

--- a/apps/jobs/src/job-worker.service.spec.ts
+++ b/apps/jobs/src/job-worker.service.spec.ts
@@ -31,6 +31,7 @@ type JobWorkerServiceTestAccessor = JobWorkerService & {
   handleAttemptJob: (job: Job) => Promise<void>;
   handleAdminTranslationJob: (job: Job) => Promise<void>;
   handleTranslationJob: (job: Job) => Promise<void>;
+  handleFileExtractJob: (job: Job) => Promise<void>;
   getConnection: () => IORedis;
   heartbeatInterval?: NodeJS.Timeout;
   createWorker: (
@@ -378,7 +379,18 @@ describe("JobWorkerService", () => {
       expect.any(Function),
       { connection: mockConnection, concurrency: 1 },
     );
-    expect(workerInstances).toHaveLength(6);
+    expect(Worker).toHaveBeenNthCalledWith(
+      7,
+      JOB_QUEUE_NAMES.FILE_EXTRACT,
+      expect.any(Function),
+      {
+        connection: mockConnection,
+        concurrency: 2,
+        lockDuration: 300_000,
+        maxStalledCount: 0,
+      },
+    );
+    expect(workerInstances).toHaveLength(7);
     // Most workers wire two listeners (completed + failed) via createWorker.
     // The ATTEMPT and ATTEMPT_HEAVY workers additionally get a third listener
     // attached after createWorker returns: the terminal-failure →
@@ -393,7 +405,7 @@ describe("JobWorkerService", () => {
           : 2;
       expect(worker.on.mock.calls.length).toBe(expectedListenerCount);
     }
-    expect(workerWaitUntilReady).toHaveBeenCalledTimes(6);
+    expect(workerWaitUntilReady).toHaveBeenCalledTimes(7);
   });
 
   // ─── Change 9: configurable GRADING_WORKER_CONCURRENCY ──────────────────────────
@@ -585,7 +597,7 @@ describe("JobWorkerService", () => {
 
     await service.onModuleDestroy();
 
-    expect(workerClose).toHaveBeenCalledTimes(6);
+    expect(workerClose).toHaveBeenCalledTimes(7);
     expect(mockConnection.del).toHaveBeenCalledWith(
       expect.stringMatching(/^mark\.jobs\.worker\.heartbeat:/),
     );
@@ -826,6 +838,35 @@ describe("JobWorkerService", () => {
     });
   });
 
+  it("routes a file-extract job to the executor when JOBS_EXECUTE_LOCALLY=true", async () => {
+    const originalFlag = process.env.JOBS_EXECUTE_LOCALLY;
+    process.env.JOBS_EXECUTE_LOCALLY = "true";
+    try {
+      await (
+        service as unknown as {
+          handleFileExtractJob: (job: unknown) => Promise<void>;
+        }
+      ).handleFileExtractJob({
+        name: JOB_NAMES.FILE_EXTRACT,
+        id: "extract:7",
+        data: encryptJobPayload({ assignmentId: 3, fileId: 7 }),
+      });
+      expect(mockJobExecutorService.executeJob).toHaveBeenCalledWith(
+        expect.objectContaining({
+          queueName: JOB_QUEUE_NAMES.FILE_EXTRACT,
+          jobName: JOB_NAMES.FILE_EXTRACT,
+          payload: { assignmentId: 3, fileId: 7 },
+        }),
+      );
+    } finally {
+      if (originalFlag === undefined) {
+        delete process.env.JOBS_EXECUTE_LOCALLY;
+      } else {
+        process.env.JOBS_EXECUTE_LOCALLY = originalFlag;
+      }
+    }
+  });
+
   it("passes an AbortSignal to fetch so the forward survives past Node's default 5-minute bodyTimeout", async () => {
     // Long-running parent publish jobs run well past the undici default
     // bodyTimeout of 300_000ms. Without an explicit signal the forward
@@ -904,7 +945,8 @@ describe("JobWorkerService", () => {
     | "handleAssignmentV1Job"
     | "handleAssignmentV2Job"
     | "handleAttemptJob"
-    | "handleAdminTranslationJob";
+    | "handleAdminTranslationJob"
+    | "handleFileExtractJob";
   it.each<[HandlerName, string, string]>([
     [
       "handleAssignmentV1Job",
@@ -925,6 +967,11 @@ describe("JobWorkerService", () => {
       "handleAdminTranslationJob",
       "unsupported.admin",
       "Unsupported admin translation job: unsupported.admin",
+    ],
+    [
+      "handleFileExtractJob",
+      "unsupported.file-extract",
+      "Unsupported file-extract job: unsupported.file-extract",
     ],
   ])(
     "rejects unsupported jobs in %s",
@@ -1262,6 +1309,27 @@ describe("JobWorkerService", () => {
             jobName: JOB_NAMES.ADMIN_SWEEP_MISSING_TRANSLATIONS,
             payload,
             bullJobId: "bull-route-4",
+          });
+          expect(fetchMock).not.toHaveBeenCalled();
+        } else {
+          expect(fetchMock).toHaveBeenCalled();
+          expect(mockJobExecutorService.executeJob).not.toHaveBeenCalled();
+        }
+      });
+
+      it("routes file-extract correctly", async () => {
+        const payload = { assignmentId: 3, fileId: 7 };
+        await asTestAccessor(service).handleFileExtractJob({
+          id: "bull-route-5",
+          name: JOB_NAMES.FILE_EXTRACT,
+          data: encryptJobPayload(payload),
+        });
+        if (expected === "local") {
+          expect(mockJobExecutorService.executeJob).toHaveBeenCalledWith({
+            queueName: JOB_QUEUE_NAMES.FILE_EXTRACT,
+            jobName: JOB_NAMES.FILE_EXTRACT,
+            payload,
+            bullJobId: "bull-route-5",
           });
           expect(fetchMock).not.toHaveBeenCalled();
         } else {

--- a/apps/jobs/src/job-worker.service.ts
+++ b/apps/jobs/src/job-worker.service.ts
@@ -198,6 +198,20 @@ export class JobWorkerService implements OnModuleInit, OnModuleDestroy {
       1,
     );
 
+    // Author reference-file extraction. Runs the same pdf-parse/pdfjs+canvas
+    // pipeline as heavy grading, so it shares that memory profile: bounded,
+    // low concurrency. Its own queue (not a job class on mark.attempt.heavy)
+    // so an extraction backlog can never delay learner grading and vice
+    // versa. ~5 min lock covers the worst realistic single-file extraction;
+    // maxStalledCount=0 means a poison file that OOMs a pod fails permanently
+    // rather than being re-delivered to more pods that OOM on the same input.
+    const FILE_EXTRACT_CONCURRENCY = this.resolveConcurrency(
+      "FILE_EXTRACT_CONCURRENCY",
+      2,
+    );
+    const FILE_EXTRACT_LOCK_DURATION_MS = 300_000;
+    const FILE_EXTRACT_NO_STALL_RECOVERY = 0;
+
     // Declarative worker table. A pod consumes the intersection of this
     // table with JOB_WORKER_QUEUES (unset = everything), which is how the
     // fast and heavy deployments share one image but drain different queues.
@@ -260,6 +274,15 @@ export class JobWorkerService implements OnModuleInit, OnModuleDestroy {
         queueName: JOB_QUEUE_NAMES.ADMIN_TRANSLATION,
         processor: async (job) => this.handleAdminTranslationJob(job),
         concurrency: ADMIN_TRANSLATION_CONCURRENCY,
+      },
+      {
+        queueName: JOB_QUEUE_NAMES.FILE_EXTRACT,
+        processor: async (job) => this.handleFileExtractJob(job),
+        concurrency: FILE_EXTRACT_CONCURRENCY,
+        options: {
+          lockDuration: FILE_EXTRACT_LOCK_DURATION_MS,
+          maxStalledCount: FILE_EXTRACT_NO_STALL_RECOVERY,
+        },
       },
     ];
 
@@ -1014,6 +1037,33 @@ export class JobWorkerService implements OnModuleInit, OnModuleDestroy {
       }
       default: {
         throw new Error(`Unsupported admin translation job: ${job.name}`);
+      }
+    }
+  }
+
+  private async handleFileExtractJob(job: Job): Promise<void> {
+    switch (job.name) {
+      case JOB_NAMES.FILE_EXTRACT: {
+        if (this.shouldExecuteLocally()) {
+          this.logger.debug(
+            `Routing locally: queue=${JOB_QUEUE_NAMES.FILE_EXTRACT} jobName=${job.name} jobId=${job.id}`,
+          );
+          await this.jobExecutorService.executeJob({
+            queueName: JOB_QUEUE_NAMES.FILE_EXTRACT,
+            jobName: job.name as JobName,
+            payload: this.getDecryptedJobData(job),
+            bullJobId: job.id,
+          });
+        } else {
+          this.logger.debug(
+            `Forwarding to API: queue=${JOB_QUEUE_NAMES.FILE_EXTRACT} jobName=${job.name} jobId=${job.id}`,
+          );
+          await this.forwardJobToApi(JOB_QUEUE_NAMES.FILE_EXTRACT, job);
+        }
+        return;
+      }
+      default: {
+        throw new Error(`Unsupported file-extract job: ${job.name}`);
       }
     }
   }

--- a/helm-chart/mark-jobs/values.yaml
+++ b/helm-chart/mark-jobs/values.yaml
@@ -54,9 +54,16 @@ env:
   # means ALL queues (single-deployment and local-dev behavior). Deploy
   # overlays use this to split the fast and heavy worker tiers, e.g.
   #   fast:  every queue except mark.attempt.heavy
-  #   heavy: "mark.attempt.heavy"
+  #   heavy: "mark.attempt.heavy,mark.file-extract"
   # An unknown queue name fails the pod at boot (crash loop) by design.
   # JOB_WORKER_QUEUES: ""
+  # BullMQ worker concurrency for mark.file-extract (author reference-file
+  # extraction) when consumed. Default 2: same pdf/canvas memory profile as
+  # heavy grading, bounded rather than deprioritized.
+  # FILE_EXTRACT_CONCURRENCY: "2"
+  # Per-file byte budget for extraction, mirroring mark-api's setting so a
+  # large reference file cannot OOM a worker pod.
+  FILE_PROCESSING_BUDGET_BYTES: "1073741824"
   # BullMQ worker concurrency for mark.attempt.heavy when consumed. Default 1:
   # heavy jobs are the file/image extraction memory hogs, so one at a time
   # per pod unless observation says otherwise.


### PR DESCRIPTION
## Summary

Author reference-file content extraction (pdf-parse / pdfjs+canvas — the CPU/RAM-heavy part of `completeAssignmentFileUpload`) no longer runs on the mark-api request thread. The complete endpoint now finalizes S3, marks the row `status=READY` / `extractionStatus=PENDING`, and enqueues a job on a new `mark.file-extract` BullMQ queue; the extraction half runs on the mark-jobs fleet via `AssignmentFileService.runAssignmentFileExtraction` and persists `extractedText` + terminal `READY`/`FAILED`.

- New queue + job constants (mirrored api/jobs), `FileExtractJobPayload`, `QUEUE_METADATA` entry
- Producer split in `assignment-file.service.ts`; enqueue failure is tolerated (row stays `PENDING`, upload still succeeds)
- `JobExecutorService` dispatches the queue; jobs app registers it through the declarative `workerSpecs` table: `FILE_EXTRACT_CONCURRENCY` (default 2), lockDuration 300s, `maxStalledCount=0` (poison-file OOM fails permanently instead of cascading to more pods)
- Chart defaults: `FILE_PROCESSING_BUDGET_BYTES` on mark-jobs, commented `FILE_EXTRACT_CONCURRENCY`, heavy-tier example updated

This is backend-only: the v2 AssignmentFile pipeline has no frontend caller yet, and its sole server-side consumer (question generation) already reads only `extractionStatus=READY` rows, so the sync→async contract change breaks no consumer.

## Behavior details

- S3 download errors rethrow so the job's retry budget (attempts=3) covers transient infra blips; extraction errors are deterministic and persist `FAILED` terminally. The method is idempotent (fresh row load by id; single overwrite update).
- The worker trusts nothing from the payload beyond ids — bucket/key/mime are re-derived from the row.
- Structured logging on every path, including the raw-update fallback.

## Deploy follow-up (apps-faculty-deploy, separate PR)

- `config/mark-jobs-heavy/values.yaml.gotmpl`: `JOB_WORKER_QUEUES: "mark.attempt.heavy,mark.file-extract"`, plus `FILE_EXTRACT_CONCURRENCY: "2"` and `FILE_PROCESSING_BUDGET_BYTES: "1073741824"`
- Fast tier (`config/mark-jobs`): unchanged — its explicit queue list must NOT gain `mark.file-extract`
- Ordering: deploy this image before (or with) the heavy-tier queue-list change — a pod listing an unknown queue crash-loops at boot by design
- Until the overlay ships, jobs enqueue and wait in Redis (no TTL) and drain when the heavy tier picks the queue up; nothing user-visible in the window
- S3 egress for mark-jobs already exists (grading downloads submissions today); no network-policy change

## Notes for the deferred PENDING-row sweeper

- A permanently failed job sits in the failed set (`removeOnFail: count 100`) under jobId `extract:<fileId>`; a later `add` with the same jobId is silently deduplicated. The sweeper must remove the stale failed job first (or use a nonce jobId) or re-enqueues will silently no-op.
- A stall-killed (OOM) job permanent-fails without transitioning the row, leaving it `PENDING` — indistinguishable from never-enqueued. Fine while headless; add a failed-listener DB mark when the multipart UI lands.

## Testing

- apps/api: `src/job-queue` + assignment v2 file suites — 144 passed (2 pre-existing environment skips)
- apps/jobs: worker + constants-sync + process-safety — 93 passed
- Chart verified with `helm template` (budget key renders; `JOB_WORKER_QUEUES` stays unset by default)