### PR TITLE
Fix quantitative question generator producing answers the review pass…

### DIFF
--- a/apps/api/src/api/llm/features/question-generation/services/question-generation.service.spec.ts
+++ b/apps/api/src/api/llm/features/question-generation/services/question-generation.service.spec.ts
@@ -465,6 +465,61 @@ describe("QuestionGenerationService", () => {
     },
   );
 
+  it("instructs the quantitative prompt to put the number in the stem and forbid numeric answer choices", async () => {
+    // Regression guard for the generator<->review contradiction: the review
+    // pass removes questions whose answer is a bare number, so the quantitative
+    // generator must produce conceptual-interpretation answers with the
+    // statistic stated in the stem — otherwise every quantitative question is
+    // rejected and falls back to a generic template.
+    promptProcessor.processPromptForFeature
+      .mockResolvedValueOnce(buildGenerationResponse(1))
+      .mockResolvedValueOnce(
+        buildReviewResponse([
+          {
+            question: "Which practice keeps code reviews focused 0?",
+            type: MCSubtype.QUANTITATIVE,
+            page: 0,
+          },
+        ]),
+      );
+
+    await service.generateAssignmentQuestions(
+      1,
+      AssignmentTypeEnum.QUIZ,
+      {
+        multipleChoice: 0,
+        multipleSelect: 0,
+        textResponse: 0,
+        trueFalse: 0,
+        url: 0,
+        upload: 0,
+        linkFile: 0,
+        multipleChoiceSubtypes: {
+          [MCSubtype.SHORT]: 0,
+          [MCSubtype.QUANTITATIVE]: 1,
+          [MCSubtype.LONG]: 0,
+          [MCSubtype.SCENARIO]: 0,
+        },
+      },
+      "IBM product content",
+    );
+
+    const generationPrompt = promptProcessor.processPromptForFeature.mock
+      .calls[0][0] as PromptTemplate;
+    const formattedPrompt = await generationPrompt.format({});
+
+    expect(formattedPrompt).toContain(
+      "STATE the relevant statistic INSIDE the question stem",
+    );
+    expect(formattedPrompt).toContain(
+      "NEVER make a bare number, percentage, figure, or measure an answer choice.",
+    );
+    // The old contradictory instruction must be gone.
+    expect(formattedPrompt).not.toContain(
+      "The answer is a specific number or measure from the content",
+    );
+  });
+
   // ────────────────────────────────────────────────────────────────────────
   // New coverage: review edge cases and parallel shortfall
   // ────────────────────────────────────────────────────────────────────────

--- a/apps/api/src/api/llm/features/question-generation/services/question-generation.service.ts
+++ b/apps/api/src/api/llm/features/question-generation/services/question-generation.service.ts
@@ -879,8 +879,12 @@ FORMAT INSTRUCTIONS:
 
   QUANTITATIVE QUESTION RULES:
   - The question MUST require the learner to interpret or apply a statistic from the content — not recall it. Frame it as what a number indicates or why it matters.
-  - The answer is a specific number or measure from the content, but the question tests comprehension of its meaning.
-  - DO NOT start with "What percentage" or "How many".
+  - STATE the relevant statistic INSIDE the question stem (give the learner the number), then ask what it demonstrates, implies, or enables. The learner reasons about the number's meaning; they must never have to retrieve the number itself.
+  - CRITICAL: The correct answer and every wrong answer must be a short CONCEPTUAL interpretation of the statistic — a business or technical implication. NEVER make a bare number, percentage, figure, or measure an answer choice.
+  - Do NOT ask what value a metric has, how much something changed, or what result a specific company achieved — those force a numeric answer and will be rejected. The number is already in the stem; the answer is what that number means.
+  - Do NOT start with, or embed mid-sentence, "What percentage", "How many", "How much", "What number", or "How often".
+  - GOOD: "Instana cut the bank's mean incident-response time by 45%. What does this improvement indicate?" → answers are short implications (e.g., "Faster operational recovery at scale").
+  - BAD (never do this): "What reduction in incident-response time did the bank achieve?" → forces a numeric answer.
 
   QUANTITATIVE ANSWER LENGTH: at MOST 5-8 words for both the correct answer and each wrong answer.
 


### PR DESCRIPTION
… rejects

The generator prompt told the model to make the answer a bare number, but the review pass drops number-answer questions, so all quantitative questions were killed and fell back to templates. Move the statistic into the stem and require conceptual-interpretation answer choices.

<!-- This is helper text. It won't appear in the rendered output, but it will be visible when editing the Markdown file. -->

## **PR Description**

### **Overview:**

<!-- Select all that applies -->

#### **Type of Issue:**

- [ ] **Feature (`feat`)**: New functionality or feature added.
- [x] **Bug Fix (`bug`)**: Issue or bug resolved.
- [ ] **Chore (`chore`)**: Maintenance, refactoring, or non-functional changes.
- [ ] **Documentation Update (`doc`)**: Documentation improvements or additions.

#### **Change Type:**

- [ ] **Major:** Significant changes that introduce new features, large refactoring, or breaking changes. Requires thorough review and testing.
- [x] **Minor:** Small to medium changes, such as adding new functionality that is backward-compatible or minor refactoring. Moderate review needed.
- [ ] **Patch:** Bug fixes, small tweaks, or documentation updates. Light review is sufficient.

## Test Coverage
- [ ] Unit tests updated
- [ ] Manual verification done

Evidence:
<!-- commands, screenshots, GIFs if UI -->

## Impact / Risk
<!-- subsystems touched, breaking potential -->

## Rollback
<!-- git revert <sha> if needed or config toggle -->

## Reviewer Focus
<!-- specific files or logic to inspect -->