### PR TITLE
Fix number-input scroll drift in AI question generation modal

### DIFF
--- a/apps/web/components/FileUploadModal.tsx
+++ b/apps/web/components/FileUploadModal.tsx
@@ -671,6 +671,7 @@ const FileUploadModal = ({ onClose, questionId }: FileUploadModalProps) => {
                   placeholder="0"
                   value={toDisplayValue(selectedQuestionTypes.multipleSelect)}
                   onFocus={(e) => e.currentTarget.select()}
+                  onWheel={(e) => e.currentTarget.blur()}
                   onChange={(e) =>
                     setSelectedQuestionTypes((prev) => ({
                       ...prev,
@@ -692,6 +693,7 @@ const FileUploadModal = ({ onClose, questionId }: FileUploadModalProps) => {
                   placeholder="0"
                   value={toDisplayValue(selectedQuestionTypes.textResponse)}
                   onFocus={(e) => e.currentTarget.select()}
+                  onWheel={(e) => e.currentTarget.blur()}
                   onChange={(e) =>
                     setSelectedQuestionTypes((prev) => ({
                       ...prev,
@@ -713,6 +715,7 @@ const FileUploadModal = ({ onClose, questionId }: FileUploadModalProps) => {
                   placeholder="0"
                   value={toDisplayValue(selectedQuestionTypes.trueFalse)}
                   onFocus={(e) => e.currentTarget.select()}
+                  onWheel={(e) => e.currentTarget.blur()}
                   onChange={(e) =>
                     setSelectedQuestionTypes((prev) => ({
                       ...prev,
@@ -734,6 +737,7 @@ const FileUploadModal = ({ onClose, questionId }: FileUploadModalProps) => {
                   placeholder="0"
                   value={toDisplayValue(selectedQuestionTypes.url)}
                   onFocus={(e) => e.currentTarget.select()}
+                  onWheel={(e) => e.currentTarget.blur()}
                   onChange={(e) =>
                     setSelectedQuestionTypes((prev) => ({
                       ...prev,
@@ -765,6 +769,7 @@ const FileUploadModal = ({ onClose, questionId }: FileUploadModalProps) => {
                   placeholder="0"
                   value={toDisplayValue(selectedQuestionTypes.upload)}
                   onFocus={(e) => e.currentTarget.select()}
+                  onWheel={(e) => e.currentTarget.blur()}
                   onChange={(e) =>
                     setSelectedQuestionTypes((prev) => ({
                       ...prev,
@@ -796,6 +801,7 @@ const FileUploadModal = ({ onClose, questionId }: FileUploadModalProps) => {
                   placeholder="0"
                   value={toDisplayValue(selectedQuestionTypes.linkFile)}
                   onFocus={(e) => e.currentTarget.select()}
+                  onWheel={(e) => e.currentTarget.blur()}
                   onChange={(e) =>
                     setSelectedQuestionTypes((prev) => ({
                       ...prev,


### PR DESCRIPTION
Mouse-wheel over a focused count field silently changed its value (e.g. 2 became 9). Add the onWheel blur guard to the six inputs that were missing it, matching the Multiple Choice inputs.

<!-- This is helper text. It won't appear in the rendered output, but it will be visible when editing the Markdown file. -->

## **PR Description**

### **Overview:**

<!-- Select all that applies -->

#### **Type of Issue:**

- [ ] **Feature (`feat`)**: New functionality or feature added.
- [x] **Bug Fix (`bug`)**: Issue or bug resolved.
- [ ] **Chore (`chore`)**: Maintenance, refactoring, or non-functional changes.
- [ ] **Documentation Update (`doc`)**: Documentation improvements or additions.

#### **Change Type:**

- [ ] **Major:** Significant changes that introduce new features, large refactoring, or breaking changes. Requires thorough review and testing.
- [x] **Minor:** Small to medium changes, such as adding new functionality that is backward-compatible or minor refactoring. Moderate review needed.
- [ ] **Patch:** Bug fixes, small tweaks, or documentation updates. Light review is sufficient.

## Test Coverage
- [ ] Unit tests updated
- [ ] Manual verification done

Evidence:
<!-- commands, screenshots, GIFs if UI -->

## Impact / Risk
<!-- subsystems touched, breaking potential -->

## Rollback
<!-- git revert <sha> if needed or config toggle -->

## Reviewer Focus
<!-- specific files or logic to inspect -->