### PR TITLE
Fix false 500 error popups and add report button to error dialogs

### DIFF
--- a/apps/web/app/error.tsx
+++ b/apps/web/app/error.tsx
@@ -46,7 +46,8 @@ export default function Error({
         },
         {
           title: "Report issue",
-          description: "Use the Report button to send details to support.",
+          description:
+            "Use the red 'Report this issue' button above — the error details are attached automatically.",
         },
       ]}
       debugDetails={[]}

--- a/apps/web/app/learner/(components)/Question/PresentationGrader.tsx
+++ b/apps/web/app/learner/(components)/Question/PresentationGrader.tsx
@@ -1,5 +1,5 @@
-import { FFmpeg } from "@ffmpeg/ffmpeg";
 import { fetchFile, toBlobURL } from "@ffmpeg/util";
+import { getFfmpeg } from "@/lib/ffmpeg-client";
 import * as posenet from "@tensorflow-models/posenet";
 import nlp from "compromise";
 import React, { useEffect, useRef, useState } from "react";
@@ -15,7 +15,6 @@ import {
 import { getLiveRecordingFeedback } from "@/lib/talkToBackend";
 import { useLearnerStore, useVideoRecorderStore } from "@/stores/learner";
 
-const ffmpeg = new FFmpeg();
 
 /** ------------------------------------------------------------------
  * HOOK #1: Manage camera stream, recording, and a manual timer
@@ -121,6 +120,7 @@ const useVideoProcessor = () => {
   const [processing, setProcessing] = useState(false);
 
   const extractAudio = async (videoBlob: Blob) => {
+    const ffmpeg = getFfmpeg();
     try {
       await ffmpeg.writeFile("input.webm", await fetchFile(videoBlob));
 
@@ -164,6 +164,7 @@ const useVideoProcessor = () => {
     segments: TranscriptSegment[];
   }> => {
     setProcessing(true);
+    const ffmpeg = getFfmpeg();
     try {
       if (!ffmpeg.loaded) {
         await ffmpeg.load({
@@ -533,6 +534,7 @@ export default function PresentationGrader({
 
   useEffect(() => {
     const loadFFmpeg = async () => {
+      const ffmpeg = getFfmpeg();
       if (!ffmpeg.loaded) {
         await ffmpeg.load({
           coreURL: await toBlobURL(

--- a/apps/web/app/learner/(components)/Question/VideoPresentationEditor.tsx
+++ b/apps/web/app/learner/(components)/Question/VideoPresentationEditor.tsx
@@ -5,8 +5,9 @@ import {
   TranscriptSegment,
 } from "@/config/types";
 import { useLearnerStore } from "@/stores/learner";
-import { FFmpeg } from "@ffmpeg/ffmpeg";
+import type { FFmpeg } from "@ffmpeg/ffmpeg";
 import { fetchFile, toBlobURL } from "@ffmpeg/util";
+import { getFfmpeg } from "@/lib/ffmpeg-client";
 import JSZip from "jszip";
 import React, { useEffect, useRef, useState } from "react";
 import { useDropzone } from "react-dropzone";
@@ -94,7 +95,6 @@ const extractAudio = async (ffmpeg: FFmpeg, videoBlob: Blob): Promise<Blob> => {
   }
 };
 
-const ffmpeg = new FFmpeg();
 
 interface VideoPresentationEditorProps {
   question: QuestionStore;
@@ -144,6 +144,7 @@ const VideoPresentationEditor = ({
 
   useEffect(() => {
     const load = async () => {
+      const ffmpeg = getFfmpeg();
       if (!ffmpeg.loaded) {
         await ffmpeg.load({
           coreURL: await toBlobURL(
@@ -316,6 +317,7 @@ const VideoPresentationEditor = ({
     if (!videoFile) return;
     setProcessingTrim(true);
     setLimitError("");
+    const ffmpeg = getFfmpeg();
     try {
       await ensureFfmpegLoaded(ffmpeg);
 
@@ -350,6 +352,7 @@ const VideoPresentationEditor = ({
   };
 
   const generateTranscript = async (file: File) => {
+    const ffmpeg = getFfmpeg();
     try {
       setProcessingTranscript(true);
       await ensureFfmpegLoaded(ffmpeg);

--- a/apps/web/app/learner/[assignmentId]/questions/LearnerLayout.tsx
+++ b/apps/web/app/learner/[assignmentId]/questions/LearnerLayout.tsx
@@ -148,7 +148,18 @@ async function LearnerLayout(props: Props) {
     return <ClientLearnerLayout assignmentId={assignmentId} role={role} />;
   }
 
-  const listOfAttempts = await getAttempts(assignmentId, cookieHeader);
+  let listOfAttempts;
+  try {
+    listOfAttempts = await getAttempts(assignmentId, cookieHeader, {
+      throwOnAuthError: true,
+    });
+  } catch (error) {
+    // An expired session or revoked access is the learner's situation, not a
+    // server fault — route it to the matching screen instead of a 500 modal.
+    const status = statusFromError(error);
+    log("Attempts fetch unauthorized", `Status ${status}`);
+    return <ErrorScreen status={status} />;
+  }
   if (!listOfAttempts) {
     log("Attempts fetch failed");
     return (
@@ -299,16 +310,23 @@ async function AttemptLoader({
   lang?: string;
   isNewAttempt: boolean;
 }) {
-  const attempt = await getAttempt(
-    Number(assignmentId),
-    Number(attemptId),
-    cookieHeader,
-    lang,
-  );
+  let attempt;
+  try {
+    attempt = await getAttempt(
+      Number(assignmentId),
+      Number(attemptId),
+      cookieHeader,
+      lang,
+      { throwOnAuthError: true },
+    );
+  } catch (error) {
+    return <ErrorScreen status={statusFromError(error)} />;
+  }
   if (!attempt) {
-    // getAttempt swallows the underlying status and returns undefined, so we
-    // can't distinguish a 401 here. Render a contained error instead of throwing
-    // to Next's error boundary (which would show the generic app crash page).
+    // Transient failures were already retried inside getAttempt and auth
+    // failures threw above, so this is a genuine repeated failure. Render a
+    // contained error instead of throwing to Next's error boundary (which
+    // would show the generic app crash page).
     return (
       <ErrorModal error={"Attempt could not be fetched"} statusCode={500} />
     );

--- a/apps/web/components/ErrorPage.tsx
+++ b/apps/web/components/ErrorPage.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMemo } from "react";
+import ReportErrorButton from "@/components/ReportErrorButton";
 import { cn } from "@/lib/strings";
 
 type UserStep = {
@@ -167,6 +168,22 @@ export default function ErrorPage({
                 <p className="text-sm text-gray-500">{context}</p>
               ) : null}
             </div>
+          </div>
+
+          <div className="flex flex-wrap items-center gap-3 rounded-lg border border-red-200 bg-red-50 p-3">
+            <ReportErrorButton
+              error={{
+                statusCode,
+                headline: resolvedHeadline,
+                message: errorMessage,
+                context,
+                stateTimeline,
+              }}
+            />
+            <p className="text-sm text-red-900/80">
+              Something wrong? Send this error to our team — the details are
+              attached automatically.
+            </p>
           </div>
 
           {resolvedSteps.length > 0 ? (

--- a/apps/web/components/ReportBugButton.tsx
+++ b/apps/web/components/ReportBugButton.tsx
@@ -2,20 +2,13 @@
 
 import { FlagIcon } from "@heroicons/react/24/outline";
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { toast } from "sonner";
 import ReportPreviewModal from "@/components/ReportPreviewModal";
-import { getBaseApiPath } from "@/config/constants";
 import type { User } from "@/config/types";
+import {
+  submitBugReport,
+  type BugReportSubmission,
+} from "@/lib/report-client";
 import { getUser } from "@/lib/talkToBackend";
-
-interface ReportSubmission {
-  issueType?: string;
-  description?: string;
-  severity?: string;
-  screenshot?: File | null;
-  userEmail?: string;
-  assignmentId?: number;
-}
 
 /**
  * Floating flag button that lets users report a bug from any main screen,
@@ -49,52 +42,12 @@ export default function ReportBugButton() {
   );
 
   const handleSubmit = useCallback(
-    async (action: string, value?: ReportSubmission) => {
+    async (action: string, value?: BugReportSubmission) => {
       if (action !== "submit" || !value) return;
-
-      try {
-        const formData = new FormData();
-        formData.append("issueType", value.issueType || "technical");
-        formData.append("description", value.description || "");
-        formData.append("severity", value.severity || "info");
-        formData.append("category", "Flag Button Report");
-        formData.append("userRole", user?.role || "learner");
-
-        const resolvedEmail = value.userEmail || user?.userId;
-        if (resolvedEmail) {
-          formData.append("userEmail", resolvedEmail);
-        }
-
-        const assignmentId = value.assignmentId ?? user?.assignmentId;
-        if (assignmentId) {
-          formData.append("assignmentId", String(assignmentId));
-        }
-
-        if (value.screenshot) {
-          formData.append("screenshot", value.screenshot);
-          toast.info("Submitting report with screenshot...");
-        } else {
-          toast.info("Submitting report...");
-        }
-
-        const response = await fetch(`${getBaseApiPath("v1")}/reports`, {
-          method: "POST",
-          credentials: "include",
-          body: formData,
-        });
-
-        if (!response.ok) {
-          const errorBody = (await response.json().catch(() => ({}))) as {
-            message?: string;
-          };
-          throw new Error(errorBody.message || `HTTP error ${response.status}`);
-        }
-
-        toast.success("Bug report submitted. Thank you!");
-      } catch (error) {
-        console.error("ReportBugButton: report submit failed:", error);
-        toast.error("Failed to submit report. Please try again.");
-      }
+      await submitBugReport(value, {
+        category: "Flag Button Report",
+        user,
+      });
     },
     [user],
   );

--- a/apps/web/components/ReportErrorButton.tsx
+++ b/apps/web/components/ReportErrorButton.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { FlagIcon } from "@heroicons/react/24/solid";
+import { useCallback, useMemo, useRef, useState } from "react";
+import ReportPreviewModal from "@/components/ReportPreviewModal";
+import type { User } from "@/config/types";
+import {
+  buildErrorReportPrefills,
+  submitBugReport,
+  type BugReportSubmission,
+  type ErrorReportContext,
+} from "@/lib/report-client";
+import { getUser } from "@/lib/talkToBackend";
+
+/**
+ * The report action shown on every error screen/dialog. Deliberately loud:
+ * error reports used to go through the (removed) chatbot, and anything less
+ * obvious sends users to Slack instead. The form opens with every required
+ * field prefilled from the error, so a report is one click plus "Submit".
+ */
+export default function ReportErrorButton({
+  error,
+  className,
+}: {
+  error: ErrorReportContext;
+  className?: string;
+}) {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [user, setUser] = useState<User | null>(null);
+  const userRequested = useRef(false);
+
+  const openReport = useCallback(() => {
+    // Fetched on first open, not on mount: error screens also render for
+    // signed-out users, where this call can only fail.
+    if (!userRequested.current) {
+      userRequested.current = true;
+      getUser()
+        .then((fetched) => setUser(fetched ?? null))
+        .catch(() => {
+          // Anonymous visitors can still report; the email field stays editable.
+        });
+    }
+    setIsModalOpen(true);
+  }, []);
+
+  const initialData = useMemo(
+    () => ({
+      userEmail: user?.userId,
+      assignmentId: user?.assignmentId,
+      severity: "error",
+      fieldPrefills: buildErrorReportPrefills(error, {
+        pagePath:
+          typeof window !== "undefined"
+            ? window.location.pathname
+            : undefined,
+        userAgent:
+          typeof navigator !== "undefined" ? navigator.userAgent : undefined,
+      }),
+    }),
+    [user, error],
+  );
+
+  const handleSubmit = useCallback(
+    async (action: string, value?: BugReportSubmission) => {
+      if (action !== "submit" || !value) return;
+      await submitBugReport(value, {
+        category: "Error Dialog Report",
+        user,
+      });
+    },
+    [user],
+  );
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={openReport}
+        className={`inline-flex items-center gap-2 rounded-lg bg-red-600 px-5 py-2.5 text-sm font-semibold text-white shadow-md transition hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 ${className || ""}`}
+      >
+        <FlagIcon className="w-4 h-4" aria-hidden />
+        Report this issue
+      </button>
+
+      <ReportPreviewModal
+        isOpen={isModalOpen}
+        onClose={() => setIsModalOpen(false)}
+        reportType="report"
+        initialData={initialData}
+        isAuthor={user?.role === "author"}
+        onSubmit={handleSubmit}
+      />
+    </>
+  );
+}

--- a/apps/web/components/ReportPreviewModal.tsx
+++ b/apps/web/components/ReportPreviewModal.tsx
@@ -111,6 +111,8 @@ interface ReportPreviewModalProps {
     severity?: string;
     screenshot?: File | null;
     userEmail?: string;
+    /** Per-field prefills keyed by description-field key (e.g. "steps"). */
+    fieldPrefills?: Record<string, string>;
   };
   isAuthor?: boolean;
   attemptId?: number;
@@ -375,11 +377,11 @@ const ReportPreviewModal: React.FC<ReportPreviewModalProps> = ({
   }
 
   const initializeDescriptionFields = useCallback(
-    (prefill?: string) => {
+    (prefill?: string, fieldPrefills?: Record<string, string>) => {
       const fields = getDescriptionFields(reportType);
       const initialValues: Record<string, string> = {};
       fields.forEach((field) => {
-        initialValues[field.key] = "";
+        initialValues[field.key] = fieldPrefills?.[field.key] ?? "";
       });
       if (prefill) {
         const contextField = fields.find((field) => field.key === "context");
@@ -393,8 +395,15 @@ const ReportPreviewModal: React.FC<ReportPreviewModalProps> = ({
   );
 
   useEffect(() => {
-    initializeDescriptionFields(initialData?.description);
-  }, [initialData?.description, initializeDescriptionFields]);
+    initializeDescriptionFields(
+      initialData?.description,
+      initialData?.fieldPrefills,
+    );
+  }, [
+    initialData?.description,
+    initialData?.fieldPrefills,
+    initializeDescriptionFields,
+  ]);
 
   const handleFieldChange = (key: string, value: string) => {
     setDescriptionFields((prev) => ({ ...prev, [key]: value }));

--- a/apps/web/components/__tests__/ErrorPage.test.tsx
+++ b/apps/web/components/__tests__/ErrorPage.test.tsx
@@ -3,7 +3,17 @@
  */
 
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import ErrorPage from "../ErrorPage";
+
+jest.mock("@/lib/talkToBackend", () => ({
+  getUser: jest.fn().mockResolvedValue({
+    userId: "learner@example.com",
+    role: "learner",
+    assignmentId: 42,
+    returnUrl: "",
+  }),
+}));
 
 describe("ErrorPage", () => {
   it("renders the headline, message and steps for a status", () => {
@@ -54,5 +64,33 @@ describe("ErrorPage", () => {
     );
     expect(screen.getByText(/recent activity/i)).toBeInTheDocument();
     expect(screen.getByText("Loaded page")).toBeInTheDocument();
+  });
+
+  it("always renders a prominent report button", () => {
+    render(<ErrorPage error="Something broke" statusCode={500} />);
+    expect(
+      screen.getByRole("button", { name: /report this issue/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("opens the report form prefilled from the error", async () => {
+    const user = userEvent.setup();
+    render(
+      <ErrorPage
+        error="Attempts could not be fetched"
+        statusCode={500}
+        stateTimeline={[{ step: "Attempts fetch failed" }]}
+      />,
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: /report this issue/i }),
+    );
+
+    expect(await screen.findByText(/report issue/i)).toBeInTheDocument();
+    // The required "Actual result" field arrives prefilled with the error.
+    expect(
+      screen.getByDisplayValue(/Attempts could not be fetched/),
+    ).toBeInTheDocument();
   });
 });

--- a/apps/web/lib/__tests__/api-retry.test.ts
+++ b/apps/web/lib/__tests__/api-retry.test.ts
@@ -1,0 +1,71 @@
+/**
+ * @jest-environment node
+ */
+
+import { APIError } from "../api-client";
+import {
+  isAuthApiError,
+  isTransientApiError,
+  withTransientRetry,
+} from "../api-retry";
+
+describe("isTransientApiError", () => {
+  it.each([408, 502, 503, 504])("treats APIError %s as transient", (status) => {
+    expect(isTransientApiError(new APIError("x", status, "x"))).toBe(true);
+  });
+
+  it.each([400, 401, 403, 404, 422, 500])(
+    "treats APIError %s as definitive",
+    (status) => {
+      expect(isTransientApiError(new APIError("x", status, "x"))).toBe(false);
+    },
+  );
+
+  it("treats fetch network failures (TypeError) as transient", () => {
+    expect(isTransientApiError(new TypeError("fetch failed"))).toBe(true);
+  });
+
+  it("treats other errors as definitive", () => {
+    expect(isTransientApiError(new Error("boom"))).toBe(false);
+  });
+});
+
+describe("isAuthApiError", () => {
+  it.each([401, 403])("recognises APIError %s", (status) => {
+    expect(isAuthApiError(new APIError("x", status, "x"))).toBe(true);
+  });
+
+  it("rejects other statuses and error shapes", () => {
+    expect(isAuthApiError(new APIError("x", 500, "x"))).toBe(false);
+    expect(isAuthApiError(new Error("Unauthorized"))).toBe(false);
+  });
+});
+
+describe("withTransientRetry", () => {
+  it("returns the first result without retrying on success", async () => {
+    const fn = jest.fn().mockResolvedValue("ok");
+    await expect(withTransientRetry(fn)).resolves.toBe("ok");
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries once when the first attempt fails transiently", async () => {
+    const fn = jest
+      .fn()
+      .mockRejectedValueOnce(new APIError("x", 503, "Service Unavailable"))
+      .mockResolvedValueOnce("recovered");
+    await expect(withTransientRetry(fn)).resolves.toBe("recovered");
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not retry definitive failures", async () => {
+    const fn = jest.fn().mockRejectedValue(new APIError("x", 404, "Not Found"));
+    await expect(withTransientRetry(fn)).rejects.toMatchObject({ status: 404 });
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it("gives up after a single retry", async () => {
+    const fn = jest.fn().mockRejectedValue(new APIError("x", 503, "x"));
+    await expect(withTransientRetry(fn)).rejects.toMatchObject({ status: 503 });
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/web/lib/__tests__/attempt-fetchers.test.ts
+++ b/apps/web/lib/__tests__/attempt-fetchers.test.ts
@@ -1,0 +1,124 @@
+/**
+ * @jest-environment node
+ */
+
+import { APIError } from "../api-client";
+import { getAttempts } from "../author";
+import { getAttempt } from "../learner";
+
+jest.mock("../api-client", () => {
+  const actual = jest.requireActual("../api-client");
+  return {
+    ...actual,
+    apiClient: { get: jest.fn(), post: jest.fn(), patch: jest.fn() },
+  };
+});
+
+// Retry pauses briefly between attempts; keep tests instant.
+jest.mock("../api-retry", () => {
+  const actual = jest.requireActual("../api-retry");
+  return {
+    ...actual,
+    withTransientRetry: async <T,>(fn: () => Promise<T>): Promise<T> => {
+      try {
+        return await fn();
+      } catch (error) {
+        if (!actual.isTransientApiError(error)) throw error;
+        return fn();
+      }
+    },
+  };
+});
+
+const { apiClient }: { apiClient: { get: jest.Mock } } =
+  jest.requireMock("../api-client");
+
+const attemptRow = {
+  id: 7,
+  submitted: false,
+  expiresAt: null,
+  createdAt: "2026-07-01T00:00:00.000Z",
+};
+
+beforeEach(() => {
+  apiClient.get.mockReset();
+  jest.spyOn(console, "error").mockImplementation(() => undefined);
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe("getAttempts", () => {
+  it("recovers when the first request fails transiently", async () => {
+    apiClient.get
+      .mockRejectedValueOnce(new APIError("x", 503, "Service Unavailable"))
+      .mockResolvedValueOnce([attemptRow]);
+
+    const attempts = await getAttempts(1);
+
+    expect(attempts).toHaveLength(1);
+    expect(apiClient.get).toHaveBeenCalledTimes(2);
+  });
+
+  it("logs and returns undefined on persistent failure", async () => {
+    apiClient.get.mockRejectedValue(new APIError("x", 503, "x"));
+
+    await expect(getAttempts(1)).resolves.toBeUndefined();
+    expect(console.error).toHaveBeenCalled();
+  });
+
+  it("suppresses the api-client toast via quiet mode", async () => {
+    apiClient.get.mockResolvedValue([attemptRow]);
+
+    await getAttempts(1);
+
+    expect(apiClient.get).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ quiet: true }),
+    );
+  });
+
+  it("rethrows auth failures when the caller opts in", async () => {
+    apiClient.get.mockRejectedValue(new APIError("x", 401, "Unauthorized"));
+
+    await expect(
+      getAttempts(1, undefined, { throwOnAuthError: true }),
+    ).rejects.toMatchObject({ status: 401 });
+  });
+
+  it("swallows auth failures by default (legacy callers)", async () => {
+    apiClient.get.mockRejectedValue(new APIError("x", 401, "Unauthorized"));
+
+    await expect(getAttempts(1)).resolves.toBeUndefined();
+  });
+});
+
+describe("getAttempt", () => {
+  it("recovers when the first request fails transiently", async () => {
+    apiClient.get
+      .mockRejectedValueOnce(new TypeError("fetch failed"))
+      .mockResolvedValueOnce({ id: 7, questions: [] });
+
+    const attempt = await getAttempt(1, 7);
+
+    expect(attempt).toMatchObject({ id: 7 });
+    expect(apiClient.get).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not retry definitive failures", async () => {
+    apiClient.get.mockRejectedValue(new APIError("x", 404, "Not Found"));
+
+    await expect(getAttempt(1, 7)).resolves.toBeUndefined();
+    expect(apiClient.get).toHaveBeenCalledTimes(1);
+    expect(console.error).toHaveBeenCalled();
+  });
+
+  it("rethrows auth failures when the caller opts in", async () => {
+    apiClient.get.mockRejectedValue(new APIError("x", 403, "Forbidden"));
+
+    await expect(
+      getAttempt(1, 7, undefined, "en", { throwOnAuthError: true }),
+    ).rejects.toMatchObject({ status: 403 });
+  });
+});

--- a/apps/web/lib/__tests__/ffmpeg-client.test.ts
+++ b/apps/web/lib/__tests__/ffmpeg-client.test.ts
@@ -1,0 +1,42 @@
+/**
+ * @jest-environment node
+ */
+
+// In a Node environment `@ffmpeg/ffmpeg` resolves to a stub class whose
+// constructor throws "ffmpeg.wasm does not support nodejs" (see the package's
+// dist/esm/empty.mjs). The mock below mirrors that behavior so these tests
+// can pin the SSR contract without Jest having to transform the package's
+// untranspiled ESM: evaluating ffmpeg-client must construct nothing, and the
+// instance must be created lazily, exactly once.
+
+const constructorSpy = jest.fn();
+
+jest.mock("@ffmpeg/ffmpeg", () => ({
+  FFmpeg: class {
+    constructor() {
+      constructorSpy();
+    }
+  },
+}));
+
+describe("ffmpeg-client (SSR safety)", () => {
+  it("evaluates without constructing FFmpeg", () => {
+    jest.isolateModules(() => {
+      require("../ffmpeg-client");
+    });
+    expect(constructorSpy).not.toHaveBeenCalled();
+  });
+
+  it("constructs lazily and reuses a single instance", () => {
+    let client: typeof import("../ffmpeg-client");
+    jest.isolateModules(() => {
+      client = require("../ffmpeg-client");
+    });
+
+    const first = client.getFfmpeg();
+    const second = client.getFfmpeg();
+
+    expect(constructorSpy).toHaveBeenCalledTimes(1);
+    expect(second).toBe(first);
+  });
+});

--- a/apps/web/lib/__tests__/report-client.test.ts
+++ b/apps/web/lib/__tests__/report-client.test.ts
@@ -1,0 +1,111 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import {
+  buildErrorReportPrefills,
+  submitBugReport,
+} from "../report-client";
+
+jest.mock("sonner", () => ({
+  toast: { info: jest.fn(), success: jest.fn(), error: jest.fn() },
+}));
+
+describe("buildErrorReportPrefills", () => {
+  const error = {
+    statusCode: 500,
+    headline: "Something went wrong on our side",
+    message: "Attempts could not be fetched",
+    stateTimeline: [
+      { step: "Load learner layout", detail: "Assignment 42" },
+      { step: "Attempts fetch failed" },
+    ],
+  };
+
+  it("fills every required report field so the form submits as-is", () => {
+    const prefills = buildErrorReportPrefills(error, {
+      pagePath: "/learner/42/questions",
+    });
+
+    // "steps", "expected" and "actual" are the required fields of the
+    // report form — all must be non-empty.
+    expect(prefills.steps).toContain("/learner/42/questions");
+    expect(prefills.expected).not.toHaveLength(0);
+    expect(prefills.actual).toContain("500");
+    expect(prefills.actual).toContain("Something went wrong on our side");
+    expect(prefills.actual).toContain("Attempts could not be fetched");
+  });
+
+  it("includes the state timeline as context", () => {
+    const prefills = buildErrorReportPrefills(error);
+    expect(prefills.context).toContain("Load learner layout");
+    expect(prefills.context).toContain("Assignment 42");
+  });
+
+  it("omits context when there is no timeline", () => {
+    const prefills = buildErrorReportPrefills({
+      statusCode: 500,
+      headline: "x",
+    });
+    expect(prefills.context).toBeUndefined();
+  });
+
+  it("includes the user agent when provided", () => {
+    const prefills = buildErrorReportPrefills(error, {
+      userAgent: "TestBrowser/1.0",
+    });
+    expect(prefills.environment).toBe("TestBrowser/1.0");
+  });
+});
+
+describe("submitBugReport", () => {
+  const user = {
+    userId: "learner@example.com",
+    role: "learner" as const,
+    assignmentId: 42,
+    returnUrl: "",
+  };
+
+  beforeEach(() => {
+    global.fetch = jest.fn().mockResolvedValue({ ok: true });
+    jest.spyOn(console, "error").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("posts the report fields and resolves true on success", async () => {
+    const ok = await submitBugReport(
+      { description: "it broke", severity: "error" },
+      { category: "Error Dialog Report", user },
+    );
+
+    expect(ok).toBe(true);
+    const [url, init] = (global.fetch as jest.Mock).mock.calls[0];
+    expect(url).toMatch(/\/reports$/);
+    expect(init.credentials).toBe("include");
+    const body = init.body as FormData;
+    expect(body.get("category")).toBe("Error Dialog Report");
+    expect(body.get("severity")).toBe("error");
+    expect(body.get("userRole")).toBe("learner");
+    expect(body.get("userEmail")).toBe("learner@example.com");
+    expect(body.get("assignmentId")).toBe("42");
+  });
+
+  it("resolves false and logs when the endpoint rejects", async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: false,
+      status: 429,
+      json: async () => ({ message: "Too many reports" }),
+    });
+
+    const ok = await submitBugReport(
+      { description: "x" },
+      { category: "Error Dialog Report", user },
+    );
+
+    expect(ok).toBe(false);
+    expect(console.error).toHaveBeenCalled();
+  });
+});

--- a/apps/web/lib/api-retry.ts
+++ b/apps/web/lib/api-retry.ts
@@ -1,0 +1,45 @@
+import { APIError } from "./api-client";
+
+/**
+ * Statuses worth one retry: request timeout and gateway hiccups. A 500 is
+ * excluded — it usually reproduces, and retrying it just doubles the load
+ * that broke it.
+ */
+const TRANSIENT_STATUSES = new Set([408, 502, 503, 504]);
+
+const RETRY_DELAY_MS = 250;
+
+/**
+ * True for failures that are plausibly momentary: a transient HTTP status, or
+ * a network-level failure (fetch rejects with TypeError on connection resets,
+ * DNS blips, and dropped keep-alive sockets).
+ */
+export function isTransientApiError(error: unknown): boolean {
+  if (error instanceof APIError) {
+    return TRANSIENT_STATUSES.has(error.status);
+  }
+  return error instanceof TypeError;
+}
+
+/** True when the failure means the caller's session/permissions are the problem. */
+export function isAuthApiError(error: unknown): boolean {
+  return (
+    error instanceof APIError && (error.status === 401 || error.status === 403)
+  );
+}
+
+/**
+ * Runs `fn`, retrying exactly once (after a short pause) if the first attempt
+ * fails transiently. Definitive failures propagate immediately.
+ */
+export async function withTransientRetry<T>(fn: () => Promise<T>): Promise<T> {
+  try {
+    return await fn();
+  } catch (error) {
+    if (!isTransientApiError(error)) {
+      throw error;
+    }
+    await new Promise((resolve) => setTimeout(resolve, RETRY_DELAY_MS));
+    return fn();
+  }
+}

--- a/apps/web/lib/author.ts
+++ b/apps/web/lib/author.ts
@@ -18,6 +18,7 @@ import type {
 } from "@config/types";
 import type { PublishJobResult } from "@/types/publish-job-result";
 import { apiClient } from "./api-client";
+import { isAuthApiError, withTransientRetry } from "./api-retry";
 import { normalizeAttemptTimestamps } from "@/app/learner/utils/attempts";
 
 function isPublishJobResult(value: unknown): value is PublishJobResult {
@@ -622,17 +623,27 @@ export async function deleteQuestion(
 export async function getAttempts(
   assignmentId: number,
   cookies?: string,
+  options?: { throwOnAuthError?: boolean },
 ): Promise<AssignmentAttempt[] | undefined> {
   const endpointURL = `${getApiRoutes().assignments}/${assignmentId}/attempts`;
 
   try {
-    const attempts = (await apiClient.get(endpointURL, {
-      headers: {
-        ...(cookies ? { Cookie: cookies } : {}),
-      },
-    })) as AssignmentAttempt[];
+    // quiet: a momentary failure must not flash an error toast — it either
+    // recovers on the retry below or the caller renders a real error screen.
+    const attempts = (await withTransientRetry(() =>
+      apiClient.get(endpointURL, {
+        quiet: true,
+        headers: {
+          ...(cookies ? { Cookie: cookies } : {}),
+        },
+      }),
+    )) as AssignmentAttempt[];
     return attempts.map((attempt) => normalizeAttemptTimestamps(attempt));
   } catch (err) {
+    if (options?.throwOnAuthError && isAuthApiError(err)) {
+      throw err;
+    }
+    console.error(`getAttempts failed for assignment ${assignmentId}:`, err);
     return undefined;
   }
 }

--- a/apps/web/lib/ffmpeg-client.ts
+++ b/apps/web/lib/ffmpeg-client.ts
@@ -1,0 +1,19 @@
+import { FFmpeg } from "@ffmpeg/ffmpeg";
+
+let instance: FFmpeg | null = null;
+
+/**
+ * Returns the shared FFmpeg instance, constructing it on first use.
+ *
+ * FFmpeg must never be constructed at module scope: `@ffmpeg/ffmpeg` resolves
+ * to a stub whose constructor throws ("ffmpeg.wasm does not support nodejs")
+ * when evaluated in Node, and module scope runs during the server render of
+ * any page that imports the component — killing the whole render. Only call
+ * this from browser-only code paths (effects and event handlers).
+ */
+export function getFfmpeg(): FFmpeg {
+  if (!instance) {
+    instance = new FFmpeg();
+  }
+  return instance;
+}

--- a/apps/web/lib/learner.ts
+++ b/apps/web/lib/learner.ts
@@ -21,6 +21,7 @@ import type {
 import { toast } from "sonner";
 import { submitReportAuthor } from "@/lib/talkToBackend";
 import { apiClient, APIError } from "./api-client";
+import { isAuthApiError, withTransientRetry } from "./api-retry";
 import { normalizeAttemptTimestamps } from "@/app/learner/utils/attempts";
 
 /**
@@ -154,17 +155,20 @@ export async function getAttempt(
   attemptId: number,
   cookies?: string,
   language = "en",
+  options?: { throwOnAuthError?: boolean },
 ): Promise<AssignmentAttemptWithQuestions | undefined> {
   const endpointURL = `${getApiRoutes().assignments}/${assignmentId}/attempts/${attemptId}?lang=${language}`;
 
   try {
-    const attempt = await apiClient.get<AssignmentAttemptWithQuestions>(
-      endpointURL,
-      {
+    // quiet: a momentary failure must not flash an error toast — it either
+    // recovers on the retry below or the caller renders a real error screen.
+    const attempt = await withTransientRetry(() =>
+      apiClient.get<AssignmentAttemptWithQuestions>(endpointURL, {
+        quiet: true,
         headers: {
           ...(cookies ? { Cookie: cookies } : {}),
         },
-      },
+      }),
     );
     if (!attempt) {
       return undefined;
@@ -178,6 +182,13 @@ export async function getAttempt(
 
     return normalizeAttemptTimestamps(attempt, fallbackAllotedMinutes);
   } catch (err) {
+    if (options?.throwOnAuthError && isAuthApiError(err)) {
+      throw err;
+    }
+    console.error(
+      `getAttempt failed for assignment ${assignmentId}, attempt ${attemptId}:`,
+      err,
+    );
     return undefined;
   }
 }

--- a/apps/web/lib/report-client.ts
+++ b/apps/web/lib/report-client.ts
@@ -1,0 +1,126 @@
+import { toast } from "sonner";
+import { getBaseApiPath } from "@/config/constants";
+import type { User } from "@/config/types";
+
+export interface BugReportSubmission {
+  issueType?: string;
+  description?: string;
+  severity?: string;
+  screenshot?: File | null;
+  userEmail?: string;
+  assignmentId?: number;
+}
+
+/**
+ * Submits a bug report to the reports endpoint (same flow for the floating
+ * flag button and the error-dialog report button, so reports land in GitHub
+ * with the standard template). Returns whether the submission succeeded; all
+ * user feedback (toasts) is handled here.
+ */
+export async function submitBugReport(
+  value: BugReportSubmission,
+  options: { category: string; user?: User | null },
+): Promise<boolean> {
+  const { category, user } = options;
+
+  try {
+    const formData = new FormData();
+    formData.append("issueType", value.issueType || "technical");
+    formData.append("description", value.description || "");
+    formData.append("severity", value.severity || "info");
+    formData.append("category", category);
+    formData.append("userRole", user?.role || "learner");
+
+    const resolvedEmail = value.userEmail || user?.userId;
+    if (resolvedEmail) {
+      formData.append("userEmail", resolvedEmail);
+    }
+
+    const assignmentId = value.assignmentId ?? user?.assignmentId;
+    if (assignmentId) {
+      formData.append("assignmentId", String(assignmentId));
+    }
+
+    if (value.screenshot) {
+      formData.append("screenshot", value.screenshot);
+      toast.info("Submitting report with screenshot...");
+    } else {
+      toast.info("Submitting report...");
+    }
+
+    const response = await fetch(`${getBaseApiPath("v1")}/reports`, {
+      method: "POST",
+      credentials: "include",
+      body: formData,
+    });
+
+    if (!response.ok) {
+      const errorBody = (await response.json().catch(() => ({}))) as {
+        message?: string;
+      };
+      throw new Error(errorBody.message || `HTTP error ${response.status}`);
+    }
+
+    toast.success("Bug report submitted. Thank you!");
+    return true;
+  } catch (error) {
+    console.error("submitBugReport: report submit failed:", error);
+    toast.error("Failed to submit report. Please try again.");
+    return false;
+  }
+}
+
+export interface ErrorReportContext {
+  statusCode: number;
+  headline: string;
+  message?: string;
+  context?: string;
+  stateTimeline?: { step: string; detail?: string; timestamp?: string }[];
+}
+
+/**
+ * Prefills for the report form's fields, built from the error the user is
+ * looking at. Every required field gets a meaningful value so the report is
+ * submittable as-is — the fewer hurdles between "saw an error" and "reported
+ * it", the fewer errors go unreported.
+ */
+export function buildErrorReportPrefills(
+  error: ErrorReportContext,
+  environment?: { pagePath?: string; userAgent?: string },
+): Record<string, string> {
+  const pagePath = environment?.pagePath;
+  const detailLines = [
+    `Status: ${error.statusCode} — ${error.headline}`,
+    error.message && error.message !== error.headline
+      ? `Message: ${error.message}`
+      : null,
+    error.context ? `Context: ${error.context}` : null,
+    pagePath ? `Page: ${pagePath}` : null,
+  ].filter(Boolean);
+
+  const timelineLines = (error.stateTimeline ?? []).map((event) =>
+    [
+      event.timestamp ? `[${event.timestamp}]` : null,
+      event.step,
+      event.detail ? `— ${event.detail}` : null,
+    ]
+      .filter(Boolean)
+      .join(" "),
+  );
+
+  return {
+    steps: [
+      `1. I was using ${pagePath || "the page"} normally.`,
+      "2. The error dialog appeared.",
+      "(Auto-filled — please describe what you were doing if you can.)",
+    ].join("\n"),
+    expected: "The page keeps working without an error dialog.",
+    actual: `An error dialog appeared:\n${detailLines.join("\n")}`,
+    ...(environment?.userAgent ? { environment: environment.userAgent } : {}),
+    ...(timelineLines.length > 0
+      ? {
+          context: `Recent activity before the error:\n${timelineLines.join("\n")}`,
+        }
+      : {}),
+  };
+}


### PR DESCRIPTION
Healthy learners were shown the 500 "Something went wrong on our side" modal with no failed request and nothing in the console. The modal is server-rendered: getAttempts/getAttempt swallowed every failure into undefined, so any transient UI-pod-to-API hiccup (connection reset, timeout, expired session) rendered the fake 500. Two SSR churn drivers made those hiccups frequent: the ssr:false loading wrapper aborting Suspense on every loading render (fixed separately in #606), and @ffmpeg/ffmpeg being constructed at module scope, which throws in Node and killed the server render of every learner questions page.

- Construct FFmpeg lazily in the browser (lib/ffmpeg-client) instead of at module scope in PresentationGrader/VideoPresentationEditor.
- getAttempts/getAttempt: retry once on transient failures, log what was previously swallowed, and optionally rethrow auth errors so LearnerLayout shows SessionExpired/AccessRestricted instead of a fake 500 modal.
- Error screens and dialogs get a prominent "Report this issue" button (the floating flag button is unreachable under the modal backdrop). It opens the standard report form with every required field prefilled from the error, submitting to the existing /v1/reports flow now shared with ReportBugButton via lib/report-client.
