### PR TITLE
fix: auto-link assignment groups from signed launch sessions

### DIFF
--- a/apps/api/src/api/assignment/guards/assignment.access.control.guard.spec.ts
+++ b/apps/api/src/api/assignment/guards/assignment.access.control.guard.spec.ts
@@ -143,15 +143,13 @@ describe("AssignmentAccessControlGuard — launch-derived auto-link", () => {
   });
 
   it("keeps allowing access through an existing group link without writing", async () => {
-    mockPrisma.$transaction = jest
-      .fn()
-      .mockResolvedValue([
-        {
-          assignmentId: 4535,
-          groupId: "autogen-faculty-v1-course-v1-Org-Course-v1",
-        },
-        { id: 4535 },
-      ]);
+    mockPrisma.$transaction = jest.fn().mockResolvedValue([
+      {
+        assignmentId: 4535,
+        groupId: "autogen-faculty-v1-course-v1-Org-Course-v1",
+      },
+      { id: 4535 },
+    ]);
 
     const context = createContext({}, { id: "4535" });
 

--- a/apps/api/src/api/assignment/guards/assignment.access.control.guard.spec.ts
+++ b/apps/api/src/api/assignment/guards/assignment.access.control.guard.spec.ts
@@ -1,0 +1,161 @@
+import { ExecutionContext, ForbiddenException } from "@nestjs/common";
+import { Reflector } from "@nestjs/core";
+import { Prisma } from "@prisma/client";
+
+import {
+  UserRole,
+  type UserSession,
+  type UserSessionRequest,
+} from "../../../auth/interfaces/user.session.interface";
+import { PrismaService } from "../../../database/prisma.service";
+import { AssignmentAccessControlGuard } from "./assignment.access.control.guard";
+
+describe("AssignmentAccessControlGuard — launch-derived auto-link", () => {
+  const mockPrisma = {
+    assignment: {
+      findUnique: jest.fn(),
+    },
+    assignmentGroup: {
+      findFirst: jest.fn(),
+      create: jest.fn(),
+    },
+    $transaction: jest.fn(),
+  } as unknown as PrismaService;
+
+  const childLogger = {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  };
+  const logger = {
+    child: jest.fn().mockReturnValue(childLogger),
+  };
+
+  let guard: AssignmentAccessControlGuard;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    logger.child.mockReturnValue(childLogger);
+    guard = new AssignmentAccessControlGuard(
+      new Reflector(),
+      mockPrisma,
+      logger as never,
+    );
+  });
+
+  const createContext = (
+    session: Partial<UserSession>,
+    params: Record<string, string | undefined> = {},
+  ): ExecutionContext =>
+    ({
+      switchToHttp: () => ({
+        getRequest: () => ({
+          userSession: {
+            userId: "learner-1",
+            role: UserRole.LEARNER,
+            assignmentId: 4535,
+            groupId: "autogen-faculty-v1-course-v1-Org-Course-v1",
+            ...session,
+          },
+          params: params as UserSessionRequest["params"],
+          method: "GET",
+          originalUrl: "/api/v1/assignments/4535",
+        }),
+      }),
+    }) as ExecutionContext;
+
+  const mockNoLink = (assignment: { id: number } | null = { id: 4535 }) => {
+    mockPrisma.$transaction = jest.fn().mockResolvedValue([null, assignment]);
+  };
+
+  it("creates the missing group link and allows access when the signed session targets this assignment", async () => {
+    mockNoLink();
+    (mockPrisma.assignmentGroup.create as jest.Mock).mockResolvedValue({
+      assignmentId: 4535,
+      groupId: "autogen-faculty-v1-course-v1-Org-Course-v1",
+    });
+
+    const context = createContext({}, { id: "4535" });
+
+    await expect(guard.canActivate(context)).resolves.toBe(true);
+
+    expect(mockPrisma.assignmentGroup.create).toHaveBeenCalledWith({
+      data: {
+        assignment: { connect: { id: 4535 } },
+        group: {
+          connectOrCreate: {
+            where: { id: "autogen-faculty-v1-course-v1-Org-Course-v1" },
+            create: { id: "autogen-faculty-v1-course-v1-Org-Course-v1" },
+          },
+        },
+      },
+    });
+  });
+
+  it("still denies access when the session was minted for a different assignment", async () => {
+    mockNoLink({ id: 42 });
+
+    const context = createContext({ assignmentId: 4535 }, { id: "42" });
+
+    await expect(guard.canActivate(context)).rejects.toBeInstanceOf(
+      ForbiddenException,
+    );
+    expect(mockPrisma.assignmentGroup.create).not.toHaveBeenCalled();
+  });
+
+  it("does not auto-link when the session has no group id", async () => {
+    mockNoLink();
+
+    const context = createContext({ groupId: "" }, { id: "4535" });
+
+    await expect(guard.canActivate(context)).rejects.toBeInstanceOf(
+      ForbiddenException,
+    );
+    expect(mockPrisma.assignmentGroup.create).not.toHaveBeenCalled();
+  });
+
+  it("allows access when a concurrent launch already created the link", async () => {
+    mockNoLink();
+    (mockPrisma.assignmentGroup.create as jest.Mock).mockRejectedValue(
+      new Prisma.PrismaClientKnownRequestError("unique conflict", {
+        code: "P2002",
+        clientVersion: "test",
+      }),
+    );
+
+    const context = createContext({}, { id: "4535" });
+
+    await expect(guard.canActivate(context)).resolves.toBe(true);
+  });
+
+  it("rethrows unexpected link-creation failures after logging", async () => {
+    mockNoLink();
+    const databaseError = new Error("connection lost");
+    (mockPrisma.assignmentGroup.create as jest.Mock).mockRejectedValue(
+      databaseError,
+    );
+
+    const context = createContext({}, { id: "4535" });
+
+    await expect(guard.canActivate(context)).rejects.toBe(databaseError);
+    expect(childLogger.error).toHaveBeenCalled();
+  });
+
+  it("keeps allowing access through an existing group link without writing", async () => {
+    mockPrisma.$transaction = jest
+      .fn()
+      .mockResolvedValue([
+        {
+          assignmentId: 4535,
+          groupId: "autogen-faculty-v1-course-v1-Org-Course-v1",
+        },
+        { id: 4535 },
+      ]);
+
+    const context = createContext({}, { id: "4535" });
+
+    await expect(guard.canActivate(context)).resolves.toBe(true);
+    expect(mockPrisma.assignmentGroup.create).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/api/assignment/guards/assignment.access.control.guard.ts
+++ b/apps/api/src/api/assignment/guards/assignment.access.control.guard.ts
@@ -7,8 +7,12 @@ import {
   NotFoundException,
 } from "@nestjs/common";
 import { Reflector } from "@nestjs/core";
+import { Prisma } from "@prisma/client";
 import { WINSTON_MODULE_PROVIDER } from "nest-winston";
-import { UserSessionRequest } from "src/auth/interfaces/user.session.interface";
+import {
+  UserSession,
+  UserSessionRequest,
+} from "src/auth/interfaces/user.session.interface";
 import { Logger } from "winston";
 import { PrismaService } from "../../../database/prisma.service";
 
@@ -69,6 +73,27 @@ export class AssignmentAccessControlGuard implements CanActivate {
     }
 
     if (!assignmentGroup) {
+      // The session JWT is minted by the LTI credentials manager at launch
+      // time, so a signed (assignmentId, groupId) pair is the embedding
+      // course's own declaration that it hosts this assignment. Upstream
+      // provisioning (context-manager, hand-wired Studio embeds) sometimes
+      // skips the admin link call; heal the link here instead of locking
+      // every learner out.
+      const launchDeclaresThisAssignment =
+        userSession.assignmentId === assignmentId &&
+        typeof userSession.groupId === "string" &&
+        userSession.groupId.length > 0;
+
+      if (launchDeclaresThisAssignment) {
+        await this.createLaunchDerivedGroupLink(
+          assignmentId,
+          userSession,
+          method,
+          originalUrl,
+        );
+        return true;
+      }
+
       this.logger.warn(
         "assignment_access_denied: user's group has no link to this assignment",
         {
@@ -84,5 +109,57 @@ export class AssignmentAccessControlGuard implements CanActivate {
     }
 
     return true;
+  }
+
+  private async createLaunchDerivedGroupLink(
+    assignmentId: number,
+    userSession: UserSession,
+    method: string,
+    originalUrl: string,
+  ): Promise<void> {
+    try {
+      await this.prisma.assignmentGroup.create({
+        data: {
+          assignment: { connect: { id: assignmentId } },
+          group: {
+            connectOrCreate: {
+              where: { id: userSession.groupId },
+              create: { id: userSession.groupId },
+            },
+          },
+        },
+      });
+      this.logger.warn(
+        "assignment_group_auto_linked: created missing group link from signed launch session",
+        {
+          assignment_id: assignmentId,
+          group_id: userSession.groupId,
+          user_id: userSession.userId,
+          method,
+          url: originalUrl,
+        },
+      );
+    } catch (error) {
+      if (
+        error instanceof Prisma.PrismaClientKnownRequestError &&
+        error.code === "P2002"
+      ) {
+        // A concurrent launch won the insert race; the link exists.
+        return;
+      }
+      this.logger.error(
+        "assignment_group_auto_link_failed: could not create group link",
+        {
+          assignment_id: assignmentId,
+          group_id: userSession.groupId,
+          user_id: userSession.userId,
+          method,
+          url: originalUrl,
+          error: error instanceof Error ? error.message : String(error),
+          stack: error instanceof Error ? error.stack : undefined,
+        },
+      );
+      throw error;
+    }
   }
 }

--- a/apps/api/src/api/assignment/guards/assignment.access.control.guard.ts
+++ b/apps/api/src/api/assignment/guards/assignment.access.control.guard.ts
@@ -79,6 +79,15 @@ export class AssignmentAccessControlGuard implements CanActivate {
       // provisioning (context-manager, hand-wired Studio embeds) sometimes
       // skips the admin link call; heal the link here instead of locking
       // every learner out.
+      //
+      // This makes AssignmentGroup rows a materialization of course embeds,
+      // not an independent authorization root: deleting a row does not revoke
+      // access while still-valid launch sessions for the pair exist — the
+      // next request re-creates it. Revoking a course's access means removing
+      // the embed so no new sessions are minted; a hard block while the embed
+      // remains would need an explicit revocation marker checked before the
+      // heal, since row state alone cannot distinguish "never linked" from
+      // "unlinked".
       const launchDeclaresThisAssignment =
         userSession.assignmentId === assignmentId &&
         typeof userSession.groupId === "string" &&
@@ -144,7 +153,10 @@ export class AssignmentAccessControlGuard implements CanActivate {
         error instanceof Prisma.PrismaClientKnownRequestError &&
         error.code === "P2002"
       ) {
-        // A concurrent launch won the insert race; the link exists.
+        // Lost a unique race to a concurrent launch. Either the link row or
+        // the Group row (via connectOrCreate) was just created by the other
+        // request; if only the Group row landed, the next request completes
+        // the link. Allow this one either way.
         return;
       }
       this.logger.error(


### PR DESCRIPTION
## Problem

Assignments provisioned outside AWB (e.g. by the context-manager service) are created with only a `CONTEXT-MANAGER` group link and nothing ever links the courses that embed them. Every learner and author launch then fails `AssignmentAccessControlGuard` with `denial_reason=no_group_link` and gets the access-restricted screen — assignment 4535 locked out all learners this way on 2026-07-28 and needed a manual `AssignmentGroup` insert. ~20 more published context-manager-only assignments will break identically the moment a course launches them.

## Fix

The launch session JWT is minted by the LTI credentials manager from the embedding course's own consumer, so a signed `(assignmentId, groupId)` pair is that course's declaration that it hosts the assignment. When the requested assignment matches the session's `assignmentId` and no group link exists, the guard now creates the link and allows the request instead of 403ing:

- `connectOrCreate` on `Group`, so never-before-seen group ids (e.g. platform-clone `_Coursera_Coursera` variants) work too
- concurrent-launch insert races (P2002) are treated as success
- any other create failure logs with stack and rethrows
- every auto-link logs `assignment_group_auto_linked` (assignment/group/user ids) for observability
- everything else still denies exactly as before: mismatched session assignment, empty session groupId, unknown assignment

The chat guard is deliberately unchanged — it checks client-sent `body.assignmentId`, not a signed claim, so auto-linking there would be an authz hole.

## Testing

New spec for the guard (written red-first): auto-link happy path, mismatched-session deny, empty-groupId deny, P2002 race allow, unexpected-failure rethrow+log, existing-link no-write. `tsc --noEmit` and eslint clean.