### PR TITLE
fix: grading progress delivery, GitHub URL grading, and autosave hardening

### DIFF
--- a/apps/api/.env.template
+++ b/apps/api/.env.template
@@ -53,3 +53,6 @@ GRADING_CONCURRENCY=10
 
 # ────── Translation Settings ──────
 ENABLE_TRANSLATION=false # true | false
+
+# Optional server-side token for grading's GitHub API calls (see github-grading-token.ts) — never a learner token
+GITHUB_GRADING_API_TOKEN= # enter your secret here

--- a/apps/api/src/api/assignment/attempt/attempt.service.spec.ts
+++ b/apps/api/src/api/assignment/attempt/attempt.service.spec.ts
@@ -7,11 +7,14 @@ import {
 import { Test, TestingModule } from "@nestjs/testing";
 import { LtiSyncStatus } from "@prisma/client";
 import { WINSTON_MODULE_PROVIDER } from "nest-winston";
+import { GithubRateLimitedError } from "src/api/llm/features/grading/errors/github-rate-limited.error";
+import { UserRole } from "../../../auth/interfaces/user.session.interface";
 import { PrismaService } from "../../../database/prisma.service";
 import { LlmFacadeService } from "../../llm/llm-facade.service";
 import { QuestionService } from "../question/question.service";
 import { AssignmentServiceV1 } from "../v1/services/assignment.service";
 import { AttemptServiceV1 } from "./attempt.service";
+import { AttemptHelper } from "./helper/attempts.helper";
 import { LtiGradeSyncService } from "../../attempt/services/lti-grade-sync.service";
 import { GradingKillSwitchService } from "../../ai-feature-flags/grading-kill-switch.service";
 
@@ -33,6 +36,7 @@ describe("AttemptServiceV1 - Auto-Grade Expired Attempts", () => {
     },
     question: {
       findMany: jest.fn(),
+      findUnique: jest.fn(),
     },
     questionResponse: {
       findMany: jest.fn(),
@@ -666,6 +670,76 @@ describe("AttemptServiceV1 - Auto-Grade Expired Attempts", () => {
       await expect(service.getAssignmentAttempt(555, "en")).rejects.toThrow(
         NotFoundException,
       );
+    });
+  });
+
+  describe("getAssignmentContext - v1 URL context enrichment", () => {
+    const callGetAssignmentContext = () =>
+      (
+        service as unknown as {
+          getAssignmentContext: (
+            assignmentId: number,
+            questionId: number,
+            assignmentAttemptId: number,
+            role: UserRole,
+          ) => Promise<{
+            assignmentInstructions: string;
+            questionAnswerContext: { question: string; answer: string }[];
+          }>;
+        }
+      ).getAssignmentContext(42, 10, 555, UserRole.LEARNER);
+
+    beforeEach(() => {
+      mockPrismaService.assignment.findUnique.mockResolvedValue({
+        instructions: "do the assignment",
+      });
+      mockPrismaService.question.findUnique.mockResolvedValue({
+        gradingContextQuestionIds: [30],
+      });
+      mockPrismaService.question.findMany.mockResolvedValue([
+        { id: 30, question: "Link your repo", type: "URL" },
+      ]);
+      mockPrismaService.questionResponse.findMany.mockResolvedValue([
+        {
+          questionId: 30,
+          learnerResponse: "https://github.com/octocat/hello-world",
+        },
+      ]);
+    });
+
+    it("degrades to the raw response (no fetched content) when the context URL fetch is rate-limited, instead of failing the caller", async () => {
+      const fetchSpy = jest
+        .spyOn(AttemptHelper, "fetchPlainTextFromUrl")
+        .mockRejectedValue(
+          new GithubRateLimitedError({
+            owner: "octocat",
+            repo: "hello-world",
+            requestUrl: "https://api.github.com/repos/octocat/hello-world",
+          }),
+        );
+
+      const context = await callGetAssignmentContext();
+
+      expect(context.questionAnswerContext).toEqual([
+        {
+          question: "Link your repo",
+          answer: "https://github.com/octocat/hello-world",
+        },
+      ]);
+
+      fetchSpy.mockRestore();
+    });
+
+    it("still includes the fetched content when the URL fetch succeeds", async () => {
+      const fetchSpy = jest
+        .spyOn(AttemptHelper, "fetchPlainTextFromUrl")
+        .mockResolvedValue({ body: "# Readme", isFunctional: true });
+
+      const context = await callGetAssignmentContext();
+
+      expect(context.questionAnswerContext[0].answer).toContain("# Readme");
+
+      fetchSpy.mockRestore();
     });
   });
 });

--- a/apps/api/src/api/assignment/attempt/attempt.service.ts
+++ b/apps/api/src/api/assignment/attempt/attempt.service.ts
@@ -3623,12 +3623,16 @@ export class AttemptServiceV1 implements OnModuleDestroy {
             groupedResponses[contextQuestion.id]?.learnerResponse || "";
 
           if (contextQuestion.type === "URL" && learnerResponse) {
-            const urlContent =
-              await AttemptHelper.fetchPlainTextFromUrl(learnerResponse);
-            learnerResponse = JSON.stringify({
-              url: learnerResponse,
-              ...urlContent,
-            });
+            try {
+              const urlContent =
+                await AttemptHelper.fetchPlainTextFromUrl(learnerResponse);
+              learnerResponse = JSON.stringify({
+                url: learnerResponse,
+                ...urlContent,
+              });
+            } catch {
+              // Ignore URL fetch failures while building learner context.
+            }
           }
 
           return {

--- a/apps/api/src/api/assignment/attempt/helper/attempts.helper.fetch.spec.ts
+++ b/apps/api/src/api/assignment/attempt/helper/attempts.helper.fetch.spec.ts
@@ -1,0 +1,45 @@
+import { GithubRateLimitedError } from "../../../llm/features/grading/errors/github-rate-limited.error";
+import * as githubContentFetch from "../../../attempt/common/utils/github-content-fetch.util";
+import { AttemptHelper } from "./attempts.helper";
+
+jest.mock("../../../attempt/common/utils/github-content-fetch.util");
+
+const mockedFetch =
+  githubContentFetch.fetchUrlContentForGrading as jest.MockedFunction<
+    typeof githubContentFetch.fetchUrlContentForGrading
+  >;
+
+describe("AttemptHelper.fetchPlainTextFromUrl", () => {
+  beforeEach(() => {
+    mockedFetch.mockReset();
+  });
+
+  it("delegates to the shared fetchUrlContentForGrading helper", async () => {
+    mockedFetch.mockResolvedValue({ body: "content", isFunctional: true });
+
+    const result = await AttemptHelper.fetchPlainTextFromUrl(
+      "https://github.com/octocat/hello-world",
+    );
+
+    expect(mockedFetch).toHaveBeenCalledWith(
+      "https://github.com/octocat/hello-world",
+    );
+    expect(result).toEqual({ body: "content", isFunctional: true });
+  });
+
+  it("propagates GithubRateLimitedError rather than swallowing it", async () => {
+    mockedFetch.mockRejectedValue(
+      new GithubRateLimitedError({
+        owner: "octocat",
+        repo: "hello-world",
+        requestUrl: "https://api.github.com/repos/octocat/hello-world",
+      }),
+    );
+
+    await expect(
+      AttemptHelper.fetchPlainTextFromUrl(
+        "https://github.com/octocat/hello-world",
+      ),
+    ).rejects.toThrow(GithubRateLimitedError);
+  });
+});

--- a/apps/api/src/api/assignment/attempt/helper/attempts.helper.ts
+++ b/apps/api/src/api/assignment/attempt/helper/attempts.helper.ts
@@ -2,10 +2,9 @@
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
-import { BadRequestException, Logger } from "@nestjs/common";
+import { BadRequestException } from "@nestjs/common";
 import { QuestionType } from "@prisma/client";
-import * as cheerio from "cheerio";
-import { safeGet } from "../../../attempt/common/utils/ssrf-safe-http";
+import { fetchUrlContentForGrading } from "../../../attempt/common/utils/github-content-fetch.util";
 import { ChoiceBasedQuestionResponseModel } from "../../../llm/model/choice.based.question.response.model";
 import { FileBasedQuestionResponseModel } from "../../../llm/model/file.based.question.response.model";
 import { TextBasedQuestionResponseModel } from "../../../llm/model/text.based.question.response.model";
@@ -22,8 +21,6 @@ import {
   GeneralFeedbackDto,
   TrueFalseBasedFeedbackDto,
 } from "../dto/question-response/create.question.response.attempt.response.dto";
-
-const logger = new Logger("AttemptHelper");
 
 export const AttemptHelper = {
   assignFeedbackToResponse(
@@ -228,167 +225,6 @@ export const AttemptHelper = {
   async fetchPlainTextFromUrl(
     url: string,
   ): Promise<{ body: string; isFunctional: boolean }> {
-    const MAX_CONTENT_SIZE = 100_000;
-    try {
-      if (url.includes("github.com")) {
-        if (url.includes("/blob/")) {
-          const rawUrl = convertGitHubUrlToRaw(url);
-          if (!rawUrl) {
-            return { body: "", isFunctional: false };
-          }
-
-          const rawContentResponse = await safeGet<string>(rawUrl);
-          if (rawContentResponse.status === 200) {
-            let body = rawContentResponse.data;
-            if (body.length > MAX_CONTENT_SIZE) {
-              body = body.slice(0, MAX_CONTENT_SIZE);
-            }
-            return { body, isFunctional: true };
-          }
-        } else {
-          try {
-            const repoMatch = url.match(
-              /^https:\/\/github\.com\/([^/]+)\/([^/]+)\/?$/,
-            );
-            if (repoMatch) {
-              const [, user, repo] = repoMatch;
-
-              const readmeUrl = `https://raw.githubusercontent.com/${user}/${repo}/main/README.md`;
-              try {
-                const readmeResponse = await safeGet<string>(readmeUrl);
-                if (readmeResponse.status === 200) {
-                  let body = readmeResponse.data;
-                  if (body.length > MAX_CONTENT_SIZE) {
-                    body = body.slice(0, MAX_CONTENT_SIZE);
-                  }
-                  return { body, isFunctional: true };
-                }
-              } catch {
-                try {
-                  const masterReadmeUrl = `https://raw.githubusercontent.com/${user}/${repo}/master/README.md`;
-                  const masterReadmeResponse =
-                    await safeGet<string>(masterReadmeUrl);
-                  if (masterReadmeResponse.status === 200) {
-                    let body = masterReadmeResponse.data;
-                    if (body.length > MAX_CONTENT_SIZE) {
-                      body = body.slice(0, MAX_CONTENT_SIZE);
-                    }
-                    return { body, isFunctional: true };
-                  }
-                } catch {
-                  const apiUrl = `https://api.github.com/repos/${user}/${repo}`;
-                  try {
-                    const apiResponse = await safeGet<{
-                      full_name?: string;
-                      description?: string;
-                      stargazers_count?: number;
-                      forks_count?: number;
-                      language?: string;
-                      updated_at?: string;
-                    }>(apiUrl);
-                    if (apiResponse.status === 200) {
-                      const repoInfo = apiResponse.data;
-                      const body = `Repository: ${
-                        repoInfo.full_name
-                      }\nDescription: ${
-                        repoInfo.description || "No description"
-                      }\nStars: ${repoInfo.stargazers_count}\nForks: ${
-                        repoInfo.forks_count
-                      }\nLanguage: ${
-                        repoInfo.language || "Not specified"
-                      }\nLast Updated: ${repoInfo.updated_at}`;
-                      return { body, isFunctional: true };
-                    }
-                  } catch {
-                    logger.warn(
-                      `Failed to fetch README or repository info for ${user}/${repo}. URL may be non-functional or rate-limited.`,
-                    );
-                  }
-                }
-              }
-            }
-          } catch {
-            logger.warn(
-              `Failed to fetch repository info for ${url}. URL may be non-functional or rate-limited.`,
-            );
-          }
-
-          try {
-            const response = await safeGet<string>(url);
-            const $ = cheerio.load(response.data);
-
-            $(
-              "script, style, noscript, iframe, noembed, embed, object",
-            ).remove();
-
-            let content = "";
-            const readmeElement = $("article.markdown-body");
-            if (readmeElement.length > 0) {
-              content = readmeElement.text().trim();
-            } else {
-              const aboutSection = $(".Box-body");
-              if (aboutSection.length > 0) {
-                content += aboutSection.text().trim() + "\n\n";
-              }
-
-              const fileList = $(
-                "div.js-details-container div.js-navigation-container tr.js-navigation-item",
-              );
-              if (fileList.length > 0) {
-                content += "Repository Files:\n";
-                fileList.each((_, element) => {
-                  const fileName = $(element)
-                    .find(".js-navigation-open")
-                    .text()
-                    .trim();
-                  if (fileName) {
-                    content += `- ${fileName}\n`;
-                  }
-                });
-              }
-            }
-
-            if (content) {
-              return {
-                body: content.replaceAll(/\s+/g, " ").trim(),
-                isFunctional: true,
-              };
-            }
-          } catch {
-            logger.warn(
-              `Failed to fetch content from ${url}. URL may be non-functional or rate-limited.`,
-            );
-          }
-        }
-
-        return { body: "", isFunctional: false };
-      } else {
-        const response = await safeGet<string>(url);
-        const $ = cheerio.load(response.data);
-
-        $("script, style, noscript, iframe, noembed, embed, object").remove();
-
-        const plainText = $("body")
-          .text()
-          .trim()
-          // eslint-disable-next-line unicorn/prefer-string-replace-all
-          .replace(/\s+/g, " ");
-
-        return { body: plainText, isFunctional: true };
-      }
-    } catch {
-      return { body: "", isFunctional: false };
-    }
+    return fetchUrlContentForGrading(url);
   },
 };
-function convertGitHubUrlToRaw(url: string): string | null {
-  const match = url.match(
-    /^https:\/\/github\.com\/([^/]+)\/([^/]+)\/blob\/(.+)$/,
-  );
-  if (!match) {
-    // eslint-disable-next-line unicorn/no-null
-    return null;
-  }
-  const [, user, repo, path] = match;
-  return `https://raw.githubusercontent.com/${user}/${repo}/${path}`;
-}

--- a/apps/api/src/api/attempt/common/strategies/__tests__/url-grading.strategy.spec.ts
+++ b/apps/api/src/api/attempt/common/strategies/__tests__/url-grading.strategy.spec.ts
@@ -4,12 +4,21 @@ import { BadRequestException } from "@nestjs/common";
 import { Test, TestingModule } from "@nestjs/testing";
 import { CreateQuestionResponseAttemptRequestDto } from "src/api/assignment/attempt/dto/question-response/create.question.response.attempt.request.dto";
 import { QuestionDto } from "src/api/assignment/dto/update.questions.request.dto";
+import { GithubRateLimitedError } from "src/api/llm/features/grading/errors/github-rate-limited.error";
 import { LlmFacadeService } from "src/api/llm/llm-facade.service";
 import { Logger } from "winston";
+import * as githubContentFetch from "src/api/attempt/common/utils/github-content-fetch.util";
 import { GradingAuditService } from "../../../services/question-response/grading-audit.service";
 import { GRADING_AUDIT_SERVICE } from "../../../attempt.constants";
 import { LocalizationService } from "../../utils/localization.service";
 import { UrlGradingStrategy } from "../url-grading.strategy";
+
+jest.mock("src/api/attempt/common/utils/github-content-fetch.util");
+
+const mockedFetch =
+  githubContentFetch.fetchUrlContentForGrading as jest.MockedFunction<
+    typeof githubContentFetch.fetchUrlContentForGrading
+  >;
 
 describe("UrlGradingStrategy - Type Safety Tests", () => {
   let strategy: UrlGradingStrategy;
@@ -266,6 +275,79 @@ describe("UrlGradingStrategy - Type Safety Tests", () => {
 
       const result = await strategy.extractLearnerResponse(requestDto);
       expect(result).toBe("https://example.com");
+    });
+  });
+
+  describe("UrlGradingStrategy - GitHub fetch behavior", () => {
+    const mockQuestion: QuestionDto = {
+      id: 1,
+      question: "Submit your project URL",
+      type: "URL" as any,
+      totalPoints: 10,
+    } as QuestionDto;
+
+    const context = {
+      language: "en",
+      assignmentId: 42,
+      questionAnswerContext: [],
+      assignmentInstructions: "",
+    } as any;
+
+    beforeEach(() => {
+      mockedFetch.mockReset();
+    });
+
+    it("delegates to the shared fetchUrlContentForGrading helper", async () => {
+      mockedFetch.mockResolvedValue({ body: "# Readme", isFunctional: true });
+      llmFacadeService.gradeUrlBasedQuestion.mockResolvedValue({
+        points: 8,
+        feedback: "Good work",
+        gradingRationale: "Looks complete",
+      } as any);
+
+      await strategy.gradeResponse(
+        mockQuestion,
+        "https://github.com/octocat/hello-world",
+        context,
+      );
+
+      expect(mockedFetch).toHaveBeenCalledWith(
+        "https://github.com/octocat/hello-world",
+        expect.objectContaining({ assignmentId: 42, questionId: 1 }),
+      );
+    });
+
+    it("returns a 0-point fallback response when the fetch reports isFunctional:false", async () => {
+      mockedFetch.mockResolvedValue({ body: "", isFunctional: false });
+
+      const result = await strategy.gradeResponse(
+        mockQuestion,
+        "https://github.com/octocat/private-or-broken",
+        context,
+      );
+
+      expect(result.totalPoints).toBe(0);
+      expect(JSON.stringify(result)).toMatch(/unable to fetch/i);
+      expect(llmFacadeService.gradeUrlBasedQuestion).not.toHaveBeenCalled();
+    });
+
+    it("propagates GithubRateLimitedError instead of grading a silent 0", async () => {
+      mockedFetch.mockRejectedValue(
+        new GithubRateLimitedError({
+          owner: "octocat",
+          repo: "hello-world",
+          requestUrl: "https://api.github.com/repos/octocat/hello-world",
+        }),
+      );
+
+      await expect(
+        strategy.gradeResponse(
+          mockQuestion,
+          "https://github.com/octocat/hello-world",
+          context,
+        ),
+      ).rejects.toThrow(GithubRateLimitedError);
+      expect(llmFacadeService.gradeUrlBasedQuestion).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/api/src/api/attempt/common/strategies/url-grading.strategy.ts
+++ b/apps/api/src/api/attempt/common/strategies/url-grading.strategy.ts
@@ -8,13 +8,16 @@ import {
   Injectable,
   Optional,
 } from "@nestjs/common";
-import * as cheerio from "cheerio";
 import { WINSTON_MODULE_PROVIDER } from "nest-winston";
 import { CreateQuestionResponseAttemptRequestDto } from "src/api/assignment/attempt/dto/question-response/create.question.response.attempt.request.dto";
 import { CreateQuestionResponseAttemptResponseDto } from "src/api/assignment/attempt/dto/question-response/create.question.response.attempt.response.dto";
 import { AttemptHelper } from "src/api/assignment/attempt/helper/attempts.helper";
 import { QuestionDto } from "src/api/assignment/dto/update.questions.request.dto";
-import { safeGet } from "src/api/attempt/common/utils/ssrf-safe-http";
+import {
+  fetchUrlContentForGrading,
+  GithubFetchResult,
+} from "src/api/attempt/common/utils/github-content-fetch.util";
+import { GithubRateLimitedError } from "src/api/llm/features/grading/errors/github-rate-limited.error";
 import { hashSafetyIdentifier } from "src/api/llm/core/utils/safety-identifier.util";
 import { LlmFacadeService } from "src/api/llm/llm-facade.service";
 import { UrlBasedQuestionEvaluateModel } from "src/api/llm/model/url.based.question.evaluate.model";
@@ -141,22 +144,32 @@ export class UrlGradingStrategy extends AbstractGradingStrategy<string> {
       return responseDto;
     }
 
-    let urlFetchResponse: { body: string; isFunctional: boolean };
+    let urlFetchResponse: GithubFetchResult;
 
     try {
-      urlFetchResponse = await this.fetchUrlContent(learnerResponse);
-    } catch {
-      try {
-        urlFetchResponse =
-          await AttemptHelper.fetchPlainTextFromUrl(learnerResponse);
-      } catch {
-        return this.createFallbackResponse(
-          question,
-          learnerResponse,
-          context,
-          "url_fetch_completely_failed",
+      urlFetchResponse = await fetchUrlContentForGrading(learnerResponse, {
+        assignmentId: context.assignmentId,
+        questionId: question.id,
+      });
+    } catch (error) {
+      if (error instanceof GithubRateLimitedError) {
+        this.logger?.warn(
+          "GitHub rate limit hit while fetching a learner URL for grading; propagating as retryable",
+          {
+            url: learnerResponse,
+            assignmentId: context.assignmentId,
+            questionId: question.id,
+            resetAt: error.resetAt,
+          },
         );
+        throw error;
       }
+      return this.createFallbackResponse(
+        question,
+        learnerResponse,
+        context,
+        "url_fetch_completely_failed",
+      );
     }
 
     if (!urlFetchResponse.isFunctional) {
@@ -308,169 +321,6 @@ export class UrlGradingStrategy extends AbstractGradingStrategy<string> {
       return true;
     } catch {
       return false;
-    }
-  }
-
-  /**
-   * Convert GitHub blob URL to raw content URL
-   */
-  private convertGitHubUrlToRaw(url: string): string | null {
-    const match = url.match(
-      /^https:\/\/github\.com\/([^/]+)\/([^/]+)\/blob\/(.+)$/,
-    );
-    if (!match) {
-      return;
-    }
-    const [, user, repo, path] = match;
-    return `https://raw.githubusercontent.com/${user}/${repo}/${path}`;
-  }
-
-  /**
-   * Fetch content from a URL
-   */
-  private async fetchUrlContent(
-    url: string,
-  ): Promise<{ body: string; isFunctional: boolean }> {
-    const MAX_CONTENT_SIZE = 100_000;
-    try {
-      if (url.includes("github.com")) {
-        if (url.includes("/blob/")) {
-          const rawUrl = this.convertGitHubUrlToRaw(url);
-          if (!rawUrl) {
-            return { body: "", isFunctional: false };
-          }
-
-          const rawContentResponse = await safeGet<string>(rawUrl);
-          if (rawContentResponse.status === 200) {
-            let body = rawContentResponse.data;
-            if (body.length > MAX_CONTENT_SIZE) {
-              body = body.slice(0, MAX_CONTENT_SIZE);
-            }
-            return { body, isFunctional: true };
-          }
-        } else {
-          const repoMatch = url.match(
-            /^https:\/\/github\.com\/([^/]+)\/([^/]+)\/?$/,
-          );
-          if (repoMatch) {
-            const [, user, repo] = repoMatch;
-
-            const readmeUrl = `https://raw.githubusercontent.com/${user}/${repo}/main/README.md`;
-            try {
-              const readmeResponse = await safeGet<string>(readmeUrl);
-              if (readmeResponse.status === 200) {
-                let body = readmeResponse.data;
-                if (body.length > MAX_CONTENT_SIZE) {
-                  body = body.slice(0, MAX_CONTENT_SIZE);
-                }
-                return { body, isFunctional: true };
-              }
-            } catch {
-              try {
-                const masterReadmeUrl = `https://raw.githubusercontent.com/${user}/${repo}/master/README.md`;
-                const masterReadmeResponse =
-                  await safeGet<string>(masterReadmeUrl);
-                if (masterReadmeResponse.status === 200) {
-                  let body = masterReadmeResponse.data;
-                  if (body.length > MAX_CONTENT_SIZE) {
-                    body = body.slice(0, MAX_CONTENT_SIZE);
-                  }
-                  return { body, isFunctional: true };
-                }
-              } catch {
-                const apiUrl = `https://api.github.com/repos/${user}/${repo}`;
-                try {
-                  const apiResponse = await safeGet<{
-                    full_name?: string;
-                    description?: string;
-                    stargazers_count?: number;
-                    forks_count?: number;
-                    language?: string;
-                    updated_at?: string;
-                  }>(apiUrl);
-                  if (apiResponse.status === 200) {
-                    const repoInfo = apiResponse.data;
-                    const body = `Repository: ${
-                      repoInfo.full_name
-                    }\nDescription: ${
-                      repoInfo.description || "No description"
-                    }\nStars: ${repoInfo.stargazers_count}\nForks: ${
-                      repoInfo.forks_count
-                    }\nLanguage: ${
-                      repoInfo.language || "Not specified"
-                    }\nLast Updated: ${repoInfo.updated_at}`;
-                    return { body, isFunctional: true };
-                  }
-                } catch {
-                  return { body: "", isFunctional: false };
-                }
-              }
-            }
-          }
-
-          try {
-            const response = await safeGet<string>(url);
-            const $ = cheerio.load(response.data);
-
-            $(
-              "script, style, noscript, iframe, noembed, embed, object",
-            ).remove();
-
-            let content = "";
-            const readmeElement = $("article.markdown-body");
-            if (readmeElement.length > 0) {
-              content = readmeElement.text().trim();
-            } else {
-              const aboutSection = $(".Box-body");
-              if (aboutSection.length > 0) {
-                content += aboutSection.text().trim() + "\n\n";
-              }
-
-              const fileList = $(
-                "div.js-details-container div.js-navigation-container tr.js-navigation-item",
-              );
-              if (fileList.length > 0) {
-                content += "Repository Files:\n";
-                fileList.each((index, element) => {
-                  const fileName = $(element)
-                    .find(".js-navigation-open")
-                    .text()
-                    .trim();
-                  if (fileName) {
-                    content += `- ${fileName}\n`;
-                  }
-                });
-              }
-            }
-
-            if (content) {
-              return {
-                body: content.replaceAll(/\s+/g, " ").trim(),
-                isFunctional: true,
-              };
-            }
-          } catch (error) {
-            this.logger?.error("Error fetching GitHub content", {
-              url,
-              error: error instanceof Error ? error.message : String(error),
-              stack: error instanceof Error ? error.stack : undefined,
-            });
-          }
-        }
-
-        return { body: "", isFunctional: false };
-      } else {
-        const response = await safeGet<string>(url);
-        const $ = cheerio.load(response.data);
-
-        $("script, style, noscript, iframe, noembed, embed, object").remove();
-
-        const plainText = $("body").text().trim().replaceAll(/\s+/g, " ");
-
-        return { body: plainText, isFunctional: true };
-      }
-    } catch {
-      return { body: "", isFunctional: false };
     }
   }
 }

--- a/apps/api/src/api/attempt/common/utils/github-content-fetch.util.spec.ts
+++ b/apps/api/src/api/attempt/common/utils/github-content-fetch.util.spec.ts
@@ -1,0 +1,99 @@
+import { GithubRateLimitedError } from "src/api/llm/features/grading/errors/github-rate-limited.error";
+import { safeGet } from "./ssrf-safe-http";
+import { githubApiGet } from "./github-content-fetch.util";
+
+jest.mock("./ssrf-safe-http", () => ({
+  safeGet: jest.fn(),
+}));
+
+const mockedSafeGet = safeGet as jest.MockedFunction<typeof safeGet>;
+
+function axiosError(status: number, headers: Record<string, string> = {}) {
+  return {
+    isAxiosError: true,
+    message: `Request failed with status code ${status}`,
+    response: { status, headers, data: {} },
+  };
+}
+
+describe("githubApiGet", () => {
+  const ORIGINAL_TOKEN = process.env.GITHUB_GRADING_API_TOKEN;
+
+  afterEach(() => {
+    if (ORIGINAL_TOKEN === undefined) {
+      delete process.env.GITHUB_GRADING_API_TOKEN;
+    } else {
+      process.env.GITHUB_GRADING_API_TOKEN = ORIGINAL_TOKEN;
+    }
+  });
+
+  it("attaches an Authorization header when a token is configured", async () => {
+    process.env.GITHUB_GRADING_API_TOKEN = "test-token-value";
+    mockedSafeGet.mockResolvedValue({
+      data: { default_branch: "develop" },
+      status: 200,
+    } as any);
+
+    await githubApiGet(
+      "https://api.github.com/repos/octocat/hello-world",
+      "octocat",
+      "hello-world",
+    );
+
+    expect(mockedSafeGet).toHaveBeenCalledWith(
+      "https://api.github.com/repos/octocat/hello-world",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: "Bearer test-token-value",
+        }),
+      }),
+    );
+  });
+
+  it("omits the Authorization header when no token is configured", async () => {
+    delete process.env.GITHUB_GRADING_API_TOKEN;
+    mockedSafeGet.mockResolvedValue({
+      data: { default_branch: "main" },
+      status: 200,
+    } as any);
+
+    await githubApiGet(
+      "https://api.github.com/repos/octocat/hello-world",
+      "octocat",
+      "hello-world",
+    );
+
+    const [, config] = mockedSafeGet.mock.calls[0];
+    expect(config?.headers).not.toHaveProperty("Authorization");
+  });
+
+  it("throws GithubRateLimitedError on a 403 rate-limit response", async () => {
+    mockedSafeGet.mockRejectedValue(
+      axiosError(403, {
+        "x-ratelimit-remaining": "0",
+        "x-ratelimit-reset": "1800000000",
+      }),
+    );
+
+    await expect(
+      githubApiGet(
+        "https://api.github.com/repos/octocat/hello-world",
+        "octocat",
+        "hello-world",
+      ),
+    ).rejects.toThrow(GithubRateLimitedError);
+  });
+
+  it("rethrows the original error for a non-rate-limit failure (e.g. 404)", async () => {
+    const notFound = axiosError(404);
+    mockedSafeGet.mockRejectedValue(notFound);
+
+    await expect(
+      githubApiGet(
+        "https://api.github.com/repos/octocat/does-not-exist",
+        "octocat",
+        "does-not-exist",
+      ),
+    ).rejects.toBe(notFound);
+  });
+});

--- a/apps/api/src/api/attempt/common/utils/github-content-fetch.util.spec.ts
+++ b/apps/api/src/api/attempt/common/utils/github-content-fetch.util.spec.ts
@@ -419,6 +419,36 @@ describe("fetchUrlContentForGrading", () => {
 
       expect(result).toEqual({ body: "", isFunctional: false });
     });
+
+    it("propagates GithubRateLimitedError when the metadata-fallback call itself is rate-limited after README misses", async () => {
+      // Default-branch resolution succeeds (not rate-limited) on the first
+      // call; the README for that branch misses; the metadata-fallback call
+      // reuses the exact same api.github.com endpoint and is rate-limited on
+      // its own second, independent attempt. This exercises the
+      // `fetchRepoMetadataSummary` catch's GithubRateLimitedError rethrow,
+      // which is a different path than the default-branch-resolution
+      // rate-limit case covered above.
+      let metadataEndpointCallCount = 0;
+      mockedSafeGet.mockImplementation(async (url: string) => {
+        if (url === "https://api.github.com/repos/octocat/hello-world") {
+          metadataEndpointCallCount++;
+          if (metadataEndpointCallCount === 1) {
+            return { data: { default_branch: "develop" }, status: 200 } as any;
+          }
+          throw axiosError(403, { "x-ratelimit-remaining": "0" });
+        }
+        // README lookup on the resolved "develop" branch misses.
+        throw axiosError(404);
+      });
+
+      await expect(
+        fetchUrlContentForGrading("https://github.com/octocat/hello-world"),
+      ).rejects.toThrow(GithubRateLimitedError);
+
+      // First call resolves the default branch; second is the metadata
+      // fallback attempt that hits the rate limit.
+      expect(metadataEndpointCallCount).toBe(2);
+    });
   });
 
   describe("non-repo-root github.com URLs (e.g. an issue page)", () => {
@@ -459,6 +489,90 @@ describe("fetchUrlContentForGrading", () => {
       );
 
       expect(result).toEqual({ body: "", isFunctional: false });
+    });
+  });
+
+  describe("entry/outcome logging", () => {
+    function messagesContaining(
+      spy: jest.SpyInstance,
+      substrings: string[],
+    ): boolean {
+      return spy.mock.calls.some((call) =>
+        substrings.every((substring) => String(call[0]).includes(substring)),
+      );
+    }
+
+    it("logs entry and outcome lines carrying the url, assignmentId, and questionId from logContext", async () => {
+      const debugSpy = jest
+        .spyOn(Logger.prototype, "debug")
+        .mockImplementation(() => undefined);
+      mockedSafeGet.mockResolvedValue({
+        data: "console.log(1)",
+        status: 200,
+      } as any);
+
+      const url = "https://github.com/octocat/hello-world/blob/main/index.js";
+
+      await fetchUrlContentForGrading(url, {
+        assignmentId: 4242,
+        questionId: 77,
+      });
+
+      // Entry log, before dispatch even runs.
+      expect(
+        messagesContaining(debugSpy, [
+          "Fetching URL content for grading",
+          url,
+          "assignmentId=4242",
+          "questionId=77",
+        ]),
+      ).toBe(true);
+
+      // Outcome log, after a successful fetch.
+      expect(
+        messagesContaining(debugSpy, [
+          "succeeded",
+          url,
+          "assignmentId=4242",
+          "questionId=77",
+        ]),
+      ).toBe(true);
+
+      debugSpy.mockRestore();
+    });
+
+    it("never logs the fetched content body, even though it appears in the result", async () => {
+      const debugSpy = jest
+        .spyOn(Logger.prototype, "debug")
+        .mockImplementation(() => undefined);
+      const warnSpy = jest
+        .spyOn(Logger.prototype, "warn")
+        .mockImplementation(() => undefined);
+
+      const sentinelBody = "SENTINEL_CONTENT_9f27ac_never_log_me";
+      mockedSafeGet.mockResolvedValue({
+        data: sentinelBody,
+        status: 200,
+      } as any);
+
+      const result = await fetchUrlContentForGrading(
+        "https://github.com/octocat/hello-world/blob/main/index.js",
+        { assignmentId: 1, questionId: 2 },
+      );
+
+      // Sanity check: the sentinel really did flow through into the result.
+      expect(result.body).toBe(sentinelBody);
+
+      const allLoggedMessages = [
+        ...debugSpy.mock.calls,
+        ...warnSpy.mock.calls,
+      ].map((call) => String(call[0]));
+      expect(
+        allLoggedMessages.some((message) => message.includes(sentinelBody)),
+      ).toBe(false);
+
+      debugSpy.mockRestore();
+      warnSpy.mockRestore();
     });
   });
 });

--- a/apps/api/src/api/attempt/common/utils/github-content-fetch.util.spec.ts
+++ b/apps/api/src/api/attempt/common/utils/github-content-fetch.util.spec.ts
@@ -1,6 +1,9 @@
 import { GithubRateLimitedError } from "src/api/llm/features/grading/errors/github-rate-limited.error";
 import { safeGet } from "./ssrf-safe-http";
-import { githubApiGet } from "./github-content-fetch.util";
+import {
+  githubApiGet,
+  resolveGithubDefaultBranch,
+} from "./github-content-fetch.util";
 
 jest.mock("./ssrf-safe-http", () => ({
   safeGet: jest.fn(),
@@ -119,5 +122,54 @@ describe("githubApiGet", () => {
       ),
     ).rejects.toThrow("githubApiGet requires an api.github.com URL");
     expect(mockedSafeGet).not.toHaveBeenCalled();
+  });
+});
+
+describe("resolveGithubDefaultBranch", () => {
+  it("returns the repo's actual default_branch on success", async () => {
+    mockedSafeGet.mockResolvedValue({
+      data: { default_branch: "develop" },
+      status: 200,
+    } as any);
+
+    const branch = await resolveGithubDefaultBranch("octocat", "hello-world");
+
+    expect(branch).toBe("develop");
+    expect(mockedSafeGet).toHaveBeenCalledWith(
+      "https://api.github.com/repos/octocat/hello-world",
+      expect.anything(),
+    );
+  });
+
+  it("returns undefined (does not throw) on a non-rate-limit failure", async () => {
+    mockedSafeGet.mockRejectedValue(axiosError(404));
+
+    await expect(
+      resolveGithubDefaultBranch("octocat", "does-not-exist"),
+    ).resolves.toBeUndefined();
+  });
+
+  it("rethrows GithubRateLimitedError instead of swallowing it", async () => {
+    mockedSafeGet.mockRejectedValue(
+      axiosError(403, { "x-ratelimit-remaining": "0" }),
+    );
+
+    await expect(
+      resolveGithubDefaultBranch("octocat", "hello-world"),
+    ).rejects.toThrow(GithubRateLimitedError);
+  });
+
+  it("URL-encodes owner/repo before building the request", async () => {
+    mockedSafeGet.mockResolvedValue({
+      data: { default_branch: "main" },
+      status: 200,
+    } as any);
+
+    await resolveGithubDefaultBranch("owner name", "repo#1");
+
+    expect(mockedSafeGet).toHaveBeenCalledWith(
+      "https://api.github.com/repos/owner%20name/repo%231",
+      expect.anything(),
+    );
   });
 });

--- a/apps/api/src/api/attempt/common/utils/github-content-fetch.util.spec.ts
+++ b/apps/api/src/api/attempt/common/utils/github-content-fetch.util.spec.ts
@@ -1,6 +1,8 @@
 import { GithubRateLimitedError } from "src/api/llm/features/grading/errors/github-rate-limited.error";
 import { safeGet } from "./ssrf-safe-http";
 import {
+  convertGitHubUrlToRaw,
+  fetchReadmeForBranch,
   githubApiGet,
   resolveGithubDefaultBranch,
 } from "./github-content-fetch.util";
@@ -171,5 +173,59 @@ describe("resolveGithubDefaultBranch", () => {
       "https://api.github.com/repos/owner%20name/repo%231",
       expect.anything(),
     );
+  });
+});
+
+describe("fetchReadmeForBranch", () => {
+  it("returns the README body for the given branch", async () => {
+    mockedSafeGet.mockResolvedValue({ data: "# Hello", status: 200 } as any);
+
+    const body = await fetchReadmeForBranch(
+      "octocat",
+      "hello-world",
+      "develop",
+    );
+
+    expect(body).toBe("# Hello");
+    expect(mockedSafeGet).toHaveBeenCalledWith(
+      "https://raw.githubusercontent.com/octocat/hello-world/develop/README.md",
+    );
+  });
+
+  it("returns undefined on a 404 without throwing", async () => {
+    mockedSafeGet.mockRejectedValue(axiosError(404));
+
+    await expect(
+      fetchReadmeForBranch("octocat", "hello-world", "develop"),
+    ).resolves.toBeUndefined();
+  });
+
+  it("truncates content over 100000 characters", async () => {
+    mockedSafeGet.mockResolvedValue({
+      data: "x".repeat(150_000),
+      status: 200,
+    } as any);
+
+    const body = await fetchReadmeForBranch("octocat", "hello-world", "main");
+
+    expect(body).toHaveLength(100_000);
+  });
+});
+
+describe("convertGitHubUrlToRaw", () => {
+  it("converts a blob URL to its raw-content equivalent", () => {
+    expect(
+      convertGitHubUrlToRaw(
+        "https://github.com/octocat/hello-world/blob/main/src/index.js",
+      ),
+    ).toBe(
+      "https://raw.githubusercontent.com/octocat/hello-world/main/src/index.js",
+    );
+  });
+
+  it("returns null for a non-blob URL", () => {
+    expect(
+      convertGitHubUrlToRaw("https://github.com/octocat/hello-world"),
+    ).toBeNull();
   });
 });

--- a/apps/api/src/api/attempt/common/utils/github-content-fetch.util.spec.ts
+++ b/apps/api/src/api/attempt/common/utils/github-content-fetch.util.spec.ts
@@ -4,6 +4,7 @@ import { safeGet } from "./ssrf-safe-http";
 import {
   convertGitHubUrlToRaw,
   fetchReadmeForBranch,
+  fetchUrlContentForGrading,
   githubApiGet,
   resolveGithubDefaultBranch,
 } from "./github-content-fetch.util";
@@ -243,5 +244,221 @@ describe("convertGitHubUrlToRaw", () => {
     expect(
       convertGitHubUrlToRaw("https://github.com/octocat/hello-world"),
     ).toBeNull();
+  });
+});
+
+describe("fetchUrlContentForGrading", () => {
+  describe("blob URLs", () => {
+    it("fetches raw content for a blob URL", async () => {
+      mockedSafeGet.mockResolvedValue({
+        data: "console.log(1)",
+        status: 200,
+      } as any);
+
+      const result = await fetchUrlContentForGrading(
+        "https://github.com/octocat/hello-world/blob/main/index.js",
+      );
+
+      expect(result).toEqual({ body: "console.log(1)", isFunctional: true });
+    });
+
+    it("returns isFunctional:false when the blob fetch fails, without throwing", async () => {
+      mockedSafeGet.mockRejectedValue(axiosError(404));
+
+      const result = await fetchUrlContentForGrading(
+        "https://github.com/octocat/hello-world/blob/main/missing.js",
+      );
+
+      expect(result).toEqual({ body: "", isFunctional: false });
+    });
+  });
+
+  describe("repo-root URLs — the reported bug", () => {
+    it("resolves a non-main/master default branch and fetches its README", async () => {
+      mockedSafeGet.mockImplementation(async (url: string) => {
+        if (url === "https://api.github.com/repos/octocat/hello-world") {
+          return { data: { default_branch: "develop" }, status: 200 } as any;
+        }
+        if (
+          url ===
+          "https://raw.githubusercontent.com/octocat/hello-world/develop/README.md"
+        ) {
+          return { data: "# Develop branch readme", status: 200 } as any;
+        }
+        throw axiosError(404);
+      });
+
+      const result = await fetchUrlContentForGrading(
+        "https://github.com/octocat/hello-world",
+      );
+
+      expect(result).toEqual({
+        body: "# Develop branch readme",
+        isFunctional: true,
+      });
+      // Must not have guessed main/master when the real branch resolved.
+      expect(mockedSafeGet).not.toHaveBeenCalledWith(
+        expect.stringContaining("/main/README.md"),
+      );
+    });
+
+    it("falls back to main/master guesses when branch resolution fails for a non-rate-limit reason", async () => {
+      mockedSafeGet.mockImplementation(async (url: string) => {
+        if (url === "https://api.github.com/repos/octocat/hello-world") {
+          throw axiosError(500);
+        }
+        if (
+          url ===
+          "https://raw.githubusercontent.com/octocat/hello-world/main/README.md"
+        ) {
+          throw axiosError(404);
+        }
+        if (
+          url ===
+          "https://raw.githubusercontent.com/octocat/hello-world/master/README.md"
+        ) {
+          return { data: "# Master readme", status: 200 } as any;
+        }
+        throw axiosError(404);
+      });
+
+      const result = await fetchUrlContentForGrading(
+        "https://github.com/octocat/hello-world",
+      );
+
+      expect(result).toEqual({ body: "# Master readme", isFunctional: true });
+    });
+
+    it("throws GithubRateLimitedError instead of silently grading 0 when rate-limited and no README guess lands", async () => {
+      mockedSafeGet.mockImplementation(async (url: string) => {
+        if (url === "https://api.github.com/repos/octocat/hello-world") {
+          throw axiosError(403, { "x-ratelimit-remaining": "0" });
+        }
+        // main/master guesses also miss (private repo, or genuinely no readme)
+        throw axiosError(404);
+      });
+
+      await expect(
+        fetchUrlContentForGrading("https://github.com/octocat/hello-world"),
+      ).rejects.toThrow(GithubRateLimitedError);
+    });
+
+    it("skips the metadata fallback call once rate-limiting is already known", async () => {
+      let metadataCallCount = 0;
+      mockedSafeGet.mockImplementation(async (url: string) => {
+        if (url === "https://api.github.com/repos/octocat/hello-world") {
+          metadataCallCount++;
+          throw axiosError(403, { "x-ratelimit-remaining": "0" });
+        }
+        throw axiosError(404);
+      });
+
+      await expect(
+        fetchUrlContentForGrading("https://github.com/octocat/hello-world"),
+      ).rejects.toThrow(GithubRateLimitedError);
+      // One call for default-branch resolution; the metadata-fallback call
+      // (the same endpoint) must NOT fire a second time once we already
+      // know the surface is exhausted.
+      expect(metadataCallCount).toBe(1);
+    });
+
+    it("falls through to the metadata summary, then the DOM scrape, when README lookups miss for a non-rate-limit reason", async () => {
+      mockedSafeGet.mockImplementation(async (url: string) => {
+        if (url === "https://api.github.com/repos/octocat/hello-world") {
+          return {
+            data: {
+              full_name: "octocat/hello-world",
+              description: "A test repo",
+              stargazers_count: 5,
+              forks_count: 1,
+              language: "JavaScript",
+              updated_at: "2026-01-01T00:00:00Z",
+            },
+            status: 200,
+          } as any;
+        }
+        throw axiosError(404); // README misses on the resolved branch
+      });
+
+      const result = await fetchUrlContentForGrading(
+        "https://github.com/octocat/hello-world",
+      );
+
+      expect(result.isFunctional).toBe(true);
+      expect(result.body).toContain("octocat/hello-world");
+      expect(result.body).toContain("JavaScript");
+    });
+
+    it("scrapes the repo page as a true last resort when every API path fails without rate-limiting", async () => {
+      mockedSafeGet.mockImplementation(async (url: string) => {
+        if (url === "https://github.com/octocat/hello-world") {
+          return {
+            data: '<html><body><article class="markdown-body">Scraped readme text</article></body></html>',
+            status: 200,
+          } as any;
+        }
+        throw axiosError(404);
+      });
+
+      const result = await fetchUrlContentForGrading(
+        "https://github.com/octocat/hello-world",
+      );
+
+      expect(result).toEqual({
+        body: "Scraped readme text",
+        isFunctional: true,
+      });
+    });
+
+    it("returns isFunctional:false when every path — including the scrape — fails, and it is not a rate limit", async () => {
+      mockedSafeGet.mockRejectedValue(axiosError(404));
+
+      const result = await fetchUrlContentForGrading(
+        "https://github.com/octocat/hello-world",
+      );
+
+      expect(result).toEqual({ body: "", isFunctional: false });
+    });
+  });
+
+  describe("non-repo-root github.com URLs (e.g. an issue page)", () => {
+    it("scrapes directly without attempting branch/README resolution", async () => {
+      mockedSafeGet.mockResolvedValue({
+        data: '<html><body><div class="Box-body">Issue content</div></body></html>',
+        status: 200,
+      } as any);
+
+      const result = await fetchUrlContentForGrading(
+        "https://github.com/octocat/hello-world/issues/5",
+      );
+
+      expect(result.isFunctional).toBe(true);
+      expect(result.body).toContain("Issue content");
+    });
+  });
+
+  describe("non-GitHub URLs", () => {
+    it("scrapes the page body as plain text", async () => {
+      mockedSafeGet.mockResolvedValue({
+        data: "<html><body>Hello <b>world</b></body></html>",
+        status: 200,
+      } as any);
+
+      const result = await fetchUrlContentForGrading(
+        "https://example.com/portfolio",
+      );
+
+      expect(result).toEqual({ body: "Hello world", isFunctional: true });
+    });
+
+    it("returns isFunctional:false (does not throw) when the fetch fails", async () => {
+      mockedSafeGet.mockRejectedValue(axiosError(500));
+
+      const result = await fetchUrlContentForGrading(
+        "https://example.com/unreachable",
+      );
+
+      expect(result).toEqual({ body: "", isFunctional: false });
+    });
   });
 });

--- a/apps/api/src/api/attempt/common/utils/github-content-fetch.util.spec.ts
+++ b/apps/api/src/api/attempt/common/utils/github-content-fetch.util.spec.ts
@@ -1,3 +1,4 @@
+import { Logger } from "@nestjs/common";
 import { GithubRateLimitedError } from "src/api/llm/features/grading/errors/github-rate-limited.error";
 import { safeGet } from "./ssrf-safe-http";
 import {
@@ -209,6 +210,21 @@ describe("fetchReadmeForBranch", () => {
     const body = await fetchReadmeForBranch("octocat", "hello-world", "main");
 
     expect(body).toHaveLength(100_000);
+  });
+
+  it("logs a debug entry with owner/repo/branch context on a miss", async () => {
+    const debugSpy = jest
+      .spyOn(Logger.prototype, "debug")
+      .mockImplementation(() => undefined);
+    mockedSafeGet.mockRejectedValue(axiosError(404));
+
+    await fetchReadmeForBranch("octocat", "hello-world", "develop");
+
+    expect(debugSpy).toHaveBeenCalledWith(
+      expect.stringContaining("octocat/hello-world@develop"),
+    );
+
+    debugSpy.mockRestore();
   });
 });
 

--- a/apps/api/src/api/attempt/common/utils/github-content-fetch.util.spec.ts
+++ b/apps/api/src/api/attempt/common/utils/github-content-fetch.util.spec.ts
@@ -2,6 +2,7 @@ import { Logger } from "@nestjs/common";
 import { GithubRateLimitedError } from "src/api/llm/features/grading/errors/github-rate-limited.error";
 import { safeGet } from "./ssrf-safe-http";
 import {
+  clearGithubDefaultBranchCache,
   convertGitHubUrlToRaw,
   fetchReadmeForBranch,
   fetchUrlContentForGrading,
@@ -14,6 +15,13 @@ jest.mock("./ssrf-safe-http", () => ({
 }));
 
 const mockedSafeGet = safeGet as jest.MockedFunction<typeof safeGet>;
+
+// The default-branch cache is module-level state shared across every test in
+// this file (many reuse "octocat/hello-world"); clear it after each case so
+// a resolution cached by one test can't change another's expected call count.
+afterEach(() => {
+  clearGithubDefaultBranchCache();
+});
 
 function axiosError(status: number, headers: Record<string, string> = {}) {
   return {
@@ -178,6 +186,94 @@ describe("resolveGithubDefaultBranch", () => {
   });
 });
 
+describe("resolveGithubDefaultBranch caching", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("makes one API call for two fetches of the same owner/repo", async () => {
+    mockedSafeGet.mockResolvedValue({
+      data: { default_branch: "develop" },
+      status: 200,
+    } as any);
+
+    const first = await resolveGithubDefaultBranch("octocat", "hello-world");
+    const second = await resolveGithubDefaultBranch("octocat", "hello-world");
+
+    expect(first).toBe("develop");
+    expect(second).toBe("develop");
+    expect(mockedSafeGet).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not serve a cached entry past its TTL", async () => {
+    let now = 1_700_000_000_000;
+    jest.spyOn(Date, "now").mockImplementation(() => now);
+    mockedSafeGet.mockResolvedValue({
+      data: { default_branch: "develop" },
+      status: 200,
+    } as any);
+
+    await resolveGithubDefaultBranch("octocat", "hello-world");
+    expect(mockedSafeGet).toHaveBeenCalledTimes(1);
+
+    // Still within the 5-minute TTL: served from cache, no second call.
+    now += 4 * 60 * 1000;
+    await resolveGithubDefaultBranch("octocat", "hello-world");
+    expect(mockedSafeGet).toHaveBeenCalledTimes(1);
+
+    // Past the TTL: must re-fetch.
+    now += 2 * 60 * 1000;
+    await resolveGithubDefaultBranch("octocat", "hello-world");
+    expect(mockedSafeGet).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not cache a rate-limited lookup — the next call retries", async () => {
+    mockedSafeGet.mockRejectedValue(
+      axiosError(403, { "x-ratelimit-remaining": "0" }),
+    );
+
+    await expect(
+      resolveGithubDefaultBranch("octocat", "hello-world"),
+    ).rejects.toThrow(GithubRateLimitedError);
+    await expect(
+      resolveGithubDefaultBranch("octocat", "hello-world"),
+    ).rejects.toThrow(GithubRateLimitedError);
+
+    expect(mockedSafeGet).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not cache a non-rate-limit failure — the next call retries", async () => {
+    mockedSafeGet.mockRejectedValue(axiosError(500));
+
+    await resolveGithubDefaultBranch("octocat", "hello-world");
+    await resolveGithubDefaultBranch("octocat", "hello-world");
+
+    expect(mockedSafeGet).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps separate cache entries per owner/repo", async () => {
+    mockedSafeGet.mockImplementation(async (url: string) => {
+      if (url === "https://api.github.com/repos/octocat/hello-world") {
+        return { data: { default_branch: "develop" }, status: 200 } as any;
+      }
+      if (url === "https://api.github.com/repos/other/repo") {
+        return { data: { default_branch: "trunk" }, status: 200 } as any;
+      }
+      throw axiosError(404);
+    });
+
+    expect(await resolveGithubDefaultBranch("octocat", "hello-world")).toBe(
+      "develop",
+    );
+    expect(await resolveGithubDefaultBranch("other", "repo")).toBe("trunk");
+    expect(await resolveGithubDefaultBranch("octocat", "hello-world")).toBe(
+      "develop",
+    );
+
+    expect(mockedSafeGet).toHaveBeenCalledTimes(2);
+  });
+});
+
 describe("fetchReadmeForBranch", () => {
   it("returns the README body for the given branch", async () => {
     mockedSafeGet.mockResolvedValue({ data: "# Hello", status: 200 } as any);
@@ -200,6 +296,24 @@ describe("fetchReadmeForBranch", () => {
     await expect(
       fetchReadmeForBranch("octocat", "hello-world", "develop"),
     ).resolves.toBeUndefined();
+  });
+
+  it("encodes each segment of a slash-containing branch name without escaping the slash itself", async () => {
+    mockedSafeGet.mockResolvedValue({
+      data: "# Release readme",
+      status: 200,
+    } as any);
+
+    const body = await fetchReadmeForBranch(
+      "octocat",
+      "hello-world",
+      "release/2.0",
+    );
+
+    expect(body).toBe("# Release readme");
+    expect(mockedSafeGet).toHaveBeenCalledWith(
+      "https://raw.githubusercontent.com/octocat/hello-world/release/2.0/README.md",
+    );
   });
 
   it("truncates content over 100000 characters", async () => {
@@ -332,15 +446,30 @@ describe("fetchUrlContentForGrading", () => {
     it("throws GithubRateLimitedError instead of silently grading 0 when rate-limited and no README guess lands", async () => {
       mockedSafeGet.mockImplementation(async (url: string) => {
         if (url === "https://api.github.com/repos/octocat/hello-world") {
-          throw axiosError(403, { "x-ratelimit-remaining": "0" });
+          throw axiosError(403, {
+            "x-ratelimit-remaining": "0",
+            "x-ratelimit-reset": "1800000000",
+            "retry-after": "45",
+          });
         }
         // main/master guesses also miss (private repo, or genuinely no readme)
         throw axiosError(404);
       });
 
-      await expect(
-        fetchUrlContentForGrading("https://github.com/octocat/hello-world"),
-      ).rejects.toThrow(GithubRateLimitedError);
+      const rejection = await fetchUrlContentForGrading(
+        "https://github.com/octocat/hello-world",
+      ).then(
+        () => {
+          throw new Error("expected fetchUrlContentForGrading to reject");
+        },
+        (error: unknown) => error,
+      );
+
+      expect(rejection).toBeInstanceOf(GithubRateLimitedError);
+      // The primary rate-limit path must carry the real timing fields from
+      // the response headers, not a fresh error constructed with none.
+      expect((rejection as GithubRateLimitedError).resetAt).toBe(1_800_000_000);
+      expect((rejection as GithubRateLimitedError).retryAfterSeconds).toBe(45);
     });
 
     it("skips the metadata fallback call once rate-limiting is already known", async () => {

--- a/apps/api/src/api/attempt/common/utils/github-content-fetch.util.spec.ts
+++ b/apps/api/src/api/attempt/common/utils/github-content-fetch.util.spec.ts
@@ -96,4 +96,28 @@ describe("githubApiGet", () => {
       ),
     ).rejects.toBe(notFound);
   });
+
+  it("throws for a non-api.github.com host and never reaches safeGet", async () => {
+    await expect(
+      githubApiGet(
+        "https://evil.example.com/repos/octocat/hello-world",
+        "octocat",
+        "hello-world",
+      ),
+    ).rejects.toThrow("githubApiGet requires an api.github.com URL");
+    expect(mockedSafeGet).not.toHaveBeenCalled();
+  });
+
+  it("never attaches the token off-host when the host guard rejects the URL", async () => {
+    process.env.GITHUB_GRADING_API_TOKEN = "test-token-value";
+
+    await expect(
+      githubApiGet(
+        "https://evil.example.com/repos/octocat/hello-world",
+        "octocat",
+        "hello-world",
+      ),
+    ).rejects.toThrow("githubApiGet requires an api.github.com URL");
+    expect(mockedSafeGet).not.toHaveBeenCalled();
+  });
 });

--- a/apps/api/src/api/attempt/common/utils/github-content-fetch.util.ts
+++ b/apps/api/src/api/attempt/common/utils/github-content-fetch.util.ts
@@ -1,0 +1,75 @@
+import { Logger } from "@nestjs/common";
+import { GithubRateLimitedError } from "src/api/llm/features/grading/errors/github-rate-limited.error";
+import { getGithubGradingApiToken } from "src/config/github-grading-token";
+import {
+  isGithubRateLimitResponse,
+  parseGithubRateLimitInfo,
+} from "./github-rate-limit-detection.util";
+import { safeGet } from "./ssrf-safe-http";
+
+/**
+ * Single, deduplicated implementation of the "learner submitted a GitHub (or
+ * arbitrary) URL, fetch something gradeable out of it" fetch pipeline.
+ * Before this file existed, this exact logic (main/master-only README
+ * guessing, an unauthenticated final api.github.com call, and an HTML-
+ * scrape fallback) was hand-copied into three call sites:
+ *   - UrlGradingStrategy.fetchUrlContent
+ *   - AttemptHelper.fetchPlainTextFromUrl
+ *   - QuestionResponseService.fetchUrlContent
+ * All three now delegate here so branch-resolution and rate-limit fixes
+ * land once.
+ */
+
+const logger = new Logger("GithubContentFetch");
+
+const GITHUB_API_VERSION = "2022-11-28";
+
+/**
+ * GET against api.github.com with the optional server token attached, and
+ * the rate-limit response translated into a typed, retryable error. This
+ * still goes through `safeGet`, so the SSRF guard (scheme allow-list +
+ * per-connection DNS re-check) applies exactly as it does for the raw
+ * README/blob fetches below.
+ */
+export async function githubApiGet<T>(
+  requestUrl: string,
+  owner: string,
+  repo: string,
+): Promise<T> {
+  const token = getGithubGradingApiToken();
+  try {
+    const response = await safeGet<T>(requestUrl, {
+      headers: {
+        Accept: "application/vnd.github+json",
+        "X-GitHub-Api-Version": GITHUB_API_VERSION,
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      },
+    });
+    return response.data;
+  } catch (error) {
+    const response = (
+      error as {
+        response?: { status?: number; headers?: Record<string, unknown> };
+      }
+    )?.response;
+    if (
+      typeof response?.status === "number" &&
+      isGithubRateLimitResponse(response.status, response.headers)
+    ) {
+      const { resetAt, retryAfterSeconds } = parseGithubRateLimitInfo(
+        response.headers,
+      );
+      logger.warn(
+        `GitHub API rate limit hit for ${owner}/${repo} (authenticated=${token ? "true" : "false"}, resetAt=${resetAt ?? "unknown"})`,
+      );
+      throw new GithubRateLimitedError({
+        owner,
+        repo,
+        requestUrl,
+        resetAt,
+        retryAfterSeconds,
+      });
+    }
+    throw error;
+  }
+}

--- a/apps/api/src/api/attempt/common/utils/github-content-fetch.util.ts
+++ b/apps/api/src/api/attempt/common/utils/github-content-fetch.util.ts
@@ -36,6 +36,21 @@ export async function githubApiGet<T>(
   owner: string,
   repo: string,
 ): Promise<T> {
+  // Defense in depth: this helper exists specifically to attach the server's
+  // GitHub token, so a caller-constructed URL that resolves anywhere other
+  // than api.github.com must never reach safeGet. This is a programmer-error
+  // guard (every call site builds requestUrl from a literal
+  // "https://api.github.com/..." template), not a learner-facing error.
+  let host: string;
+  try {
+    host = new URL(requestUrl).hostname;
+  } catch {
+    throw new Error("githubApiGet requires an api.github.com URL");
+  }
+  if (host !== "api.github.com") {
+    throw new Error("githubApiGet requires an api.github.com URL");
+  }
+
   const token = getGithubGradingApiToken();
   try {
     const response = await safeGet<T>(requestUrl, {

--- a/apps/api/src/api/attempt/common/utils/github-content-fetch.util.ts
+++ b/apps/api/src/api/attempt/common/utils/github-content-fetch.util.ts
@@ -95,8 +95,77 @@ interface GithubRepoDescriptor {
 }
 
 /**
+ * A grading run that asks the same URL-context question for K learners (or
+ * a single assignment with K questions sharing one repo-root URL) previously
+ * cost K identical `GET /repos/{owner}/{repo}` calls. Memoize the resolved
+ * branch per owner/repo for a short window so repeated lookups within the
+ * same grading burst reuse one API call instead of amplifying rate-limit
+ * pressure. Only successful resolutions are cached — a rate-limited or
+ * otherwise-failed lookup must be retried on the next call, never served
+ * stale-failed from here.
+ */
+const DEFAULT_BRANCH_CACHE_TTL_MS = 5 * 60 * 1000;
+const DEFAULT_BRANCH_CACHE_MAX_ENTRIES = 500;
+
+interface DefaultBranchCacheEntry {
+  branch: string;
+  expiresAt: number;
+}
+
+const defaultBranchCache = new Map<string, DefaultBranchCacheEntry>();
+
+function defaultBranchCacheKey(owner: string, repo: string): string {
+  return `${owner}/${repo}`;
+}
+
+function getCachedDefaultBranch(
+  owner: string,
+  repo: string,
+): string | undefined {
+  const key = defaultBranchCacheKey(owner, repo);
+  const entry = defaultBranchCache.get(key);
+  if (!entry) {
+    return undefined;
+  }
+  if (entry.expiresAt <= Date.now()) {
+    defaultBranchCache.delete(key);
+    return undefined;
+  }
+  return entry.branch;
+}
+
+function setCachedDefaultBranch(
+  owner: string,
+  repo: string,
+  branch: string,
+): void {
+  const key = defaultBranchCacheKey(owner, repo);
+  if (
+    !defaultBranchCache.has(key) &&
+    defaultBranchCache.size >= DEFAULT_BRANCH_CACHE_MAX_ENTRIES
+  ) {
+    // Bound memory with simple FIFO eviction: Map iteration order is
+    // insertion order, so the first key is the oldest entry.
+    const oldestKey = defaultBranchCache.keys().next().value;
+    if (oldestKey !== undefined) {
+      defaultBranchCache.delete(oldestKey);
+    }
+  }
+  defaultBranchCache.set(key, {
+    branch,
+    expiresAt: Date.now() + DEFAULT_BRANCH_CACHE_TTL_MS,
+  });
+}
+
+/** Test-only escape hatch: clears the module-level default-branch cache so specs don't leak state across cases. Not called from production code paths. */
+export function clearGithubDefaultBranchCache(): void {
+  defaultBranchCache.clear();
+}
+
+/**
  * Resolves a GitHub repository's actual default branch via
- * `GET /repos/{owner}/{repo}`. Returns undefined (never throws, other than
+ * `GET /repos/{owner}/{repo}`, memoized per owner/repo (see cache doc
+ * comment above). Returns undefined (never throws, other than
  * GithubRateLimitedError) when the lookup fails for any other reason —
  * network hiccup, private/nonexistent repo, unexpected response shape — so
  * callers can fall back to guessing main/master exactly like before this
@@ -106,6 +175,11 @@ export async function resolveGithubDefaultBranch(
   owner: string,
   repo: string,
 ): Promise<string | undefined> {
+  const cached = getCachedDefaultBranch(owner, repo);
+  if (cached !== undefined) {
+    return cached;
+  }
+
   const requestUrl = `https://api.github.com/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}`;
   try {
     const data = await githubApiGet<GithubRepoDescriptor>(
@@ -113,6 +187,9 @@ export async function resolveGithubDefaultBranch(
       owner,
       repo,
     );
+    if (data.default_branch) {
+      setCachedDefaultBranch(owner, repo, data.default_branch);
+    }
     return data.default_branch;
   } catch (error) {
     if (error instanceof GithubRateLimitedError) {
@@ -160,7 +237,15 @@ export async function fetchReadmeForBranch(
   repo: string,
   branch: string,
 ): Promise<string | undefined> {
-  const readmeUrl = `https://raw.githubusercontent.com/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/${encodeURIComponent(branch)}/README.md`;
+  // Encode each path segment separately: a branch name like "release/2.0"
+  // contains a literal slash that's part of the path, not a character to
+  // percent-encode — encoding the whole string turns it into "release%2F2.0"
+  // and raw.githubusercontent.com 404s on the mangled path.
+  const encodedBranch = branch
+    .split("/")
+    .map((segment) => encodeURIComponent(segment))
+    .join("/");
+  const readmeUrl = `https://raw.githubusercontent.com/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/${encodedBranch}/README.md`;
   try {
     const response = await safeGet<string>(readmeUrl);
     return response.status === 200 ? truncate(response.data) : undefined;
@@ -289,7 +374,7 @@ async function fetchGithubRepoRootContent(
   owner: string,
   repo: string,
 ): Promise<GithubFetchResult> {
-  let apiRateLimited = false;
+  let rateLimitError: GithubRateLimitedError | undefined;
   let defaultBranch: string | undefined;
 
   try {
@@ -298,7 +383,7 @@ async function fetchGithubRepoRootContent(
     if (!(error instanceof GithubRateLimitedError)) {
       throw error;
     }
-    apiRateLimited = true;
+    rateLimitError = error;
   }
 
   const candidateBranches = defaultBranch
@@ -312,15 +397,14 @@ async function fetchGithubRepoRootContent(
     }
   }
 
-  if (apiRateLimited) {
+  if (rateLimitError) {
     // Already know the api.github.com surface is exhausted — skip straight
     // to the retryable failure instead of burning another call on the
-    // metadata fallback below.
-    throw new GithubRateLimitedError({
-      owner,
-      repo,
-      requestUrl: `https://api.github.com/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}`,
-    });
+    // metadata fallback below. Rethrow the error caught above rather than
+    // constructing a new one, so resetAt/retryAfterSeconds (populated from
+    // the actual response headers) survive to the caller instead of coming
+    // back undefined.
+    throw rateLimitError;
   }
 
   try {

--- a/apps/api/src/api/attempt/common/utils/github-content-fetch.util.ts
+++ b/apps/api/src/api/attempt/common/utils/github-content-fetch.util.ts
@@ -88,3 +88,40 @@ export async function githubApiGet<T>(
     throw error;
   }
 }
+
+interface GithubRepoDescriptor {
+  default_branch?: string;
+}
+
+/**
+ * Resolves a GitHub repository's actual default branch via
+ * `GET /repos/{owner}/{repo}`. Returns undefined (never throws, other than
+ * GithubRateLimitedError) when the lookup fails for any other reason —
+ * network hiccup, private/nonexistent repo, unexpected response shape — so
+ * callers can fall back to guessing main/master exactly like before this
+ * function existed.
+ */
+export async function resolveGithubDefaultBranch(
+  owner: string,
+  repo: string,
+): Promise<string | undefined> {
+  const requestUrl = `https://api.github.com/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}`;
+  try {
+    const data = await githubApiGet<GithubRepoDescriptor>(
+      requestUrl,
+      owner,
+      repo,
+    );
+    return data.default_branch;
+  } catch (error) {
+    if (error instanceof GithubRateLimitedError) {
+      throw error;
+    }
+    logger.warn(
+      `Could not resolve default branch for ${owner}/${repo}; falling back to main/master guesses: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+    return undefined;
+  }
+}

--- a/apps/api/src/api/attempt/common/utils/github-content-fetch.util.ts
+++ b/apps/api/src/api/attempt/common/utils/github-content-fetch.util.ts
@@ -163,7 +163,13 @@ export async function fetchReadmeForBranch(
   try {
     const response = await safeGet<string>(readmeUrl);
     return response.status === 200 ? truncate(response.data) : undefined;
-  } catch {
+  } catch (error) {
+    // swallow: caller tries the next branch candidate
+    logger.debug(
+      `No README for ${owner}/${repo}@${branch}: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
     return undefined;
   }
 }

--- a/apps/api/src/api/attempt/common/utils/github-content-fetch.util.ts
+++ b/apps/api/src/api/attempt/common/utils/github-content-fetch.util.ts
@@ -125,3 +125,45 @@ export async function resolveGithubDefaultBranch(
     return undefined;
   }
 }
+
+const MAX_CONTENT_SIZE = 100_000;
+
+function truncate(body: string): string {
+  return body.length > MAX_CONTENT_SIZE
+    ? body.slice(0, MAX_CONTENT_SIZE)
+    : body;
+}
+
+/** Converts a GitHub blob URL to its raw-content equivalent, or null if the URL isn't a blob URL. */
+export function convertGitHubUrlToRaw(url: string): string | null {
+  const match = url.match(
+    /^https:\/\/github\.com\/([^/]+)\/([^/]+)\/blob\/(.+)$/,
+  );
+  if (!match) {
+    return null;
+  }
+  const [, owner, repo, path] = match;
+  return `https://raw.githubusercontent.com/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/${path}`;
+}
+
+/**
+ * Fetches README.md from a specific branch's raw content. Never throws for
+ * an ordinary miss (404, network hiccup) — returns undefined so callers can
+ * try the next candidate branch. raw.githubusercontent.com is a separate
+ * surface from api.github.com and is not subject to the same rate limit, so
+ * this is safe to try even when the default-branch API call was itself
+ * rate-limited.
+ */
+export async function fetchReadmeForBranch(
+  owner: string,
+  repo: string,
+  branch: string,
+): Promise<string | undefined> {
+  const readmeUrl = `https://raw.githubusercontent.com/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/${encodeURIComponent(branch)}/README.md`;
+  try {
+    const response = await safeGet<string>(readmeUrl);
+    return response.status === 200 ? truncate(response.data) : undefined;
+  } catch {
+    return undefined;
+  }
+}

--- a/apps/api/src/api/attempt/common/utils/github-content-fetch.util.ts
+++ b/apps/api/src/api/attempt/common/utils/github-content-fetch.util.ts
@@ -1,4 +1,5 @@
 import { Logger } from "@nestjs/common";
+import * as cheerio from "cheerio";
 import { GithubRateLimitedError } from "src/api/llm/features/grading/errors/github-rate-limited.error";
 import { getGithubGradingApiToken } from "src/config/github-grading-token";
 import {
@@ -171,5 +172,308 @@ export async function fetchReadmeForBranch(
       }`,
     );
     return undefined;
+  }
+}
+
+export interface GithubFetchResult {
+  body: string;
+  isFunctional: boolean;
+}
+
+export interface GithubFetchLogContext {
+  assignmentId?: number;
+  questionId?: number;
+}
+
+interface GithubRepoMetadata {
+  full_name?: string;
+  description?: string;
+  stargazers_count?: number;
+  forks_count?: number;
+  language?: string;
+  updated_at?: string;
+}
+
+function formatRepoMetadataSummary(metadata: GithubRepoMetadata): string {
+  return `Repository: ${metadata.full_name}\nDescription: ${
+    metadata.description || "No description"
+  }\nStars: ${metadata.stargazers_count}\nForks: ${
+    metadata.forks_count
+  }\nLanguage: ${metadata.language || "Not specified"}\nLast Updated: ${
+    metadata.updated_at
+  }`;
+}
+
+async function fetchRepoMetadataSummary(
+  owner: string,
+  repo: string,
+): Promise<string | undefined> {
+  const requestUrl = `https://api.github.com/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}`;
+  const metadata = await githubApiGet<GithubRepoMetadata>(
+    requestUrl,
+    owner,
+    repo,
+  );
+  return formatRepoMetadataSummary(metadata);
+}
+
+function stripNoiseNodes($: ReturnType<typeof cheerio.load>): void {
+  $("script, style, noscript, iframe, noembed, embed, object").remove();
+}
+
+/** DOM-scrape fallback for a GitHub page (repo root or otherwise). Last resort, unchanged selectors from the pre-existing implementation. */
+async function scrapeGithubPage(url: string): Promise<string | undefined> {
+  try {
+    const response = await safeGet<string>(url);
+    const $ = cheerio.load(response.data);
+    stripNoiseNodes($);
+
+    let content = "";
+    const readmeElement = $("article.markdown-body");
+    if (readmeElement.length > 0) {
+      content = readmeElement.text().trim();
+    } else {
+      const aboutSection = $(".Box-body");
+      if (aboutSection.length > 0) {
+        content += `${aboutSection.text().trim()}\n\n`;
+      }
+
+      const fileList = $(
+        "div.js-details-container div.js-navigation-container tr.js-navigation-item",
+      );
+      if (fileList.length > 0) {
+        content += "Repository Files:\n";
+        fileList.each((_index, element) => {
+          const fileName = $(element).find(".js-navigation-open").text().trim();
+          if (fileName) {
+            content += `- ${fileName}\n`;
+          }
+        });
+      }
+    }
+
+    return content ? content.replaceAll(/\s+/g, " ").trim() : undefined;
+  } catch (error) {
+    logger.warn(
+      `GitHub HTML-scrape fallback failed for ${url}: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+    return undefined;
+  }
+}
+
+async function fetchGithubBlobContent(
+  rawUrl: string,
+): Promise<GithubFetchResult> {
+  try {
+    const response = await safeGet<string>(rawUrl);
+    if (response.status === 200) {
+      return { body: truncate(response.data), isFunctional: true };
+    }
+    return { body: "", isFunctional: false };
+  } catch (error) {
+    logger.warn(
+      `Failed to fetch GitHub blob raw content from ${rawUrl}: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+    return { body: "", isFunctional: false };
+  }
+}
+
+const REPO_ROOT_RE = /^https:\/\/github\.com\/([^/]+)\/([^/]+)\/?$/;
+
+async function fetchGithubRepoRootContent(
+  url: string,
+  owner: string,
+  repo: string,
+): Promise<GithubFetchResult> {
+  let apiRateLimited = false;
+  let defaultBranch: string | undefined;
+
+  try {
+    defaultBranch = await resolveGithubDefaultBranch(owner, repo);
+  } catch (error) {
+    if (!(error instanceof GithubRateLimitedError)) {
+      throw error;
+    }
+    apiRateLimited = true;
+  }
+
+  const candidateBranches = defaultBranch
+    ? [defaultBranch]
+    : ["main", "master"];
+
+  for (const branch of candidateBranches) {
+    const body = await fetchReadmeForBranch(owner, repo, branch);
+    if (body) {
+      return { body, isFunctional: true };
+    }
+  }
+
+  if (apiRateLimited) {
+    // Already know the api.github.com surface is exhausted — skip straight
+    // to the retryable failure instead of burning another call on the
+    // metadata fallback below.
+    throw new GithubRateLimitedError({
+      owner,
+      repo,
+      requestUrl: `https://api.github.com/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}`,
+    });
+  }
+
+  try {
+    const summary = await fetchRepoMetadataSummary(owner, repo);
+    if (summary) {
+      return { body: summary, isFunctional: true };
+    }
+  } catch (error) {
+    if (error instanceof GithubRateLimitedError) {
+      throw error;
+    }
+    logger.warn(
+      `GitHub repository metadata fallback failed for ${owner}/${repo}: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  }
+
+  const scraped = await scrapeGithubPage(url);
+  return scraped
+    ? { body: scraped, isFunctional: true }
+    : { body: "", isFunctional: false };
+}
+
+async function scrapeGenericUrl(url: string): Promise<GithubFetchResult> {
+  try {
+    const response = await safeGet<string>(url);
+    const $ = cheerio.load(response.data);
+    stripNoiseNodes($);
+    const plainText = $("body").text().trim().replaceAll(/\s+/g, " ");
+    return { body: plainText, isFunctional: true };
+  } catch (error) {
+    logger.warn(
+      `Failed to fetch non-GitHub URL for grading: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+    return { body: "", isFunctional: false };
+  }
+}
+
+/**
+ * Routes a learner-submitted URL to the right fetch strategy: GitHub blob
+ * URLs are converted to their raw form; GitHub repo-root URLs resolve the
+ * real default branch before guessing main/master, with an authenticated
+ * metadata fallback and a DOM-scrape last resort; any other GitHub page is
+ * scraped directly; any non-GitHub URL is scraped as plain text. Pure
+ * routing/fetch logic — entry/outcome logging lives in the exported
+ * `fetchUrlContentForGrading` wrapper below.
+ */
+async function dispatchUrlContentFetch(
+  url: string,
+): Promise<GithubFetchResult> {
+  if (!url.includes("github.com")) {
+    return scrapeGenericUrl(url);
+  }
+
+  if (url.includes("/blob/")) {
+    const rawUrl = convertGitHubUrlToRaw(url);
+    if (!rawUrl) {
+      return { body: "", isFunctional: false };
+    }
+    return fetchGithubBlobContent(rawUrl);
+  }
+
+  const repoMatch = url.match(REPO_ROOT_RE);
+  if (repoMatch) {
+    const [, owner, repo] = repoMatch;
+    return fetchGithubRepoRootContent(url, owner, repo);
+  }
+
+  // A github.com URL that's neither a blob nor a bare repo root (an issue,
+  // PR, or directory listing) — scrape it directly, unchanged from the
+  // pre-existing behavior.
+  const scraped = await scrapeGithubPage(url);
+  return scraped
+    ? { body: scraped, isFunctional: true }
+    : { body: "", isFunctional: false };
+}
+
+const GITHUB_OWNER_REPO_RE = /^https:\/\/github\.com\/([^/]+)\/([^/]+)/;
+
+/** Best-effort owner/repo extraction for log context only — never gates fetch behavior. */
+function extractOwnerRepoForLogging(url: string): {
+  owner?: string;
+  repo?: string;
+} {
+  const match = url.match(GITHUB_OWNER_REPO_RE);
+  return match ? { owner: match[1], repo: match[2] } : {};
+}
+
+function buildLogContextSuffix(
+  url: string,
+  logContext: GithubFetchLogContext,
+): string {
+  const { owner, repo } = extractOwnerRepoForLogging(url);
+  const parts = [
+    `url=${url}`,
+    owner ? `owner=${owner}` : undefined,
+    repo ? `repo=${repo}` : undefined,
+    `assignmentId=${logContext.assignmentId ?? "unknown"}`,
+    `questionId=${logContext.questionId ?? "unknown"}`,
+  ].filter(Boolean);
+  return parts.join(", ");
+}
+
+/**
+ * Fetches gradeable content from a learner-submitted URL. This is the single
+ * entry point for the three call sites that used to hand-roll this pipeline
+ * independently — see the module doc comment at the top of this file.
+ *
+ * Owns entry/outcome structured logging for the whole pipeline (url, best-
+ * effort owner/repo, assignmentId/questionId as supplied by the caller).
+ * Never logs tokens or fetched content bodies. The individual fetch/scrape
+ * helpers above additionally log their own narrower misses (rate limits,
+ * branch-resolution failures, per-branch README misses) — this wrapper adds
+ * the top-level entry and final outcome the caller needs for correlating a
+ * grading failure back to an assignment/question.
+ *
+ * Throws GithubRateLimitedError when the api.github.com surface is
+ * exhausted and no README guess landed — callers must NOT swallow this into
+ * a 0-point "invalid URL" response; it is a retryable system failure, not a
+ * problem with the learner's submission (see the error class doc comment).
+ */
+export async function fetchUrlContentForGrading(
+  url: string,
+  logContext?: GithubFetchLogContext,
+): Promise<GithubFetchResult> {
+  const resolvedLogContext = logContext ?? {};
+  const logSuffix = buildLogContextSuffix(url, resolvedLogContext);
+
+  logger.debug(`Fetching URL content for grading (${logSuffix})`);
+
+  try {
+    const result = await dispatchUrlContentFetch(url);
+    if (result.isFunctional) {
+      logger.debug(`URL content fetch succeeded (${logSuffix})`);
+    } else {
+      logger.warn(
+        `URL content fetch returned no functional content (${logSuffix})`,
+      );
+    }
+    return result;
+  } catch (error) {
+    // Re-thrown deliberately: GithubRateLimitedError (the only expected
+    // throw here) must propagate to the caller as a retryable failure, not
+    // be swallowed into a graded-0 outcome. This is the outcome log for that
+    // path.
+    logger.warn(
+      `URL content fetch failed with a retryable error (${logSuffix}): ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+    throw error;
   }
 }

--- a/apps/api/src/api/attempt/common/utils/github-rate-limit-detection.util.spec.ts
+++ b/apps/api/src/api/attempt/common/utils/github-rate-limit-detection.util.spec.ts
@@ -20,6 +20,15 @@ describe("isGithubRateLimitResponse", () => {
     expect(isGithubRateLimitResponse(403, { "retry-after": "30" })).toBe(true);
   });
 
+  it("is true for a secondary/abuse-detection 429 carrying retry-after with no ratelimit-remaining", () => {
+    expect(isGithubRateLimitResponse(429, { "retry-after": "30" })).toBe(true);
+  });
+
+  it("is false for a plain 429 with no rate-limit headers at all", () => {
+    expect(isGithubRateLimitResponse(429, {})).toBe(false);
+    expect(isGithubRateLimitResponse(429, undefined)).toBe(false);
+  });
+
   it("is case-insensitive on header keys", () => {
     expect(
       isGithubRateLimitResponse(403, { "X-RateLimit-Remaining": "0" }),

--- a/apps/api/src/api/attempt/common/utils/github-rate-limit-detection.util.spec.ts
+++ b/apps/api/src/api/attempt/common/utils/github-rate-limit-detection.util.spec.ts
@@ -1,0 +1,64 @@
+import {
+  isGithubRateLimitResponse,
+  parseGithubRateLimitInfo,
+} from "./github-rate-limit-detection.util";
+
+describe("isGithubRateLimitResponse", () => {
+  it("is true for a 403 with x-ratelimit-remaining: 0", () => {
+    expect(
+      isGithubRateLimitResponse(403, { "x-ratelimit-remaining": "0" }),
+    ).toBe(true);
+  });
+
+  it("is true for a 429 with x-ratelimit-remaining: 0", () => {
+    expect(
+      isGithubRateLimitResponse(429, { "x-ratelimit-remaining": "0" }),
+    ).toBe(true);
+  });
+
+  it("is true for a secondary/abuse-detection 403 carrying retry-after with no ratelimit-remaining", () => {
+    expect(isGithubRateLimitResponse(403, { "retry-after": "30" })).toBe(true);
+  });
+
+  it("is case-insensitive on header keys", () => {
+    expect(
+      isGithubRateLimitResponse(403, { "X-RateLimit-Remaining": "0" }),
+    ).toBe(true);
+  });
+
+  it("is false for an ordinary 403 with no rate-limit headers (e.g. private repo)", () => {
+    expect(isGithubRateLimitResponse(403, {})).toBe(false);
+    expect(isGithubRateLimitResponse(403, undefined)).toBe(false);
+  });
+
+  it("is false for a 404", () => {
+    expect(
+      isGithubRateLimitResponse(404, { "x-ratelimit-remaining": "0" }),
+    ).toBe(false);
+  });
+
+  it("is false for a 200", () => {
+    expect(isGithubRateLimitResponse(200, {})).toBe(false);
+  });
+});
+
+describe("parseGithubRateLimitInfo", () => {
+  it("extracts resetAt and retryAfterSeconds", () => {
+    const info = parseGithubRateLimitInfo({
+      "x-ratelimit-reset": "1800000000",
+      "retry-after": "30",
+    });
+    expect(info.resetAt).toBe(1_800_000_000);
+    expect(info.retryAfterSeconds).toBe(30);
+  });
+
+  it("returns undefined fields when headers are missing or malformed", () => {
+    expect(parseGithubRateLimitInfo(undefined)).toEqual({
+      resetAt: undefined,
+      retryAfterSeconds: undefined,
+    });
+    expect(
+      parseGithubRateLimitInfo({ "x-ratelimit-reset": "not-a-number" }),
+    ).toEqual({ resetAt: undefined, retryAfterSeconds: undefined });
+  });
+});

--- a/apps/api/src/api/attempt/common/utils/github-rate-limit-detection.util.ts
+++ b/apps/api/src/api/attempt/common/utils/github-rate-limit-detection.util.ts
@@ -1,0 +1,62 @@
+/**
+ * Pure helpers for detecting a GitHub API rate-limit response and pulling
+ * the retry-timing hints out of its headers. Kept separate from the fetch
+ * orchestration so the detection logic is unit-testable without mocking any
+ * HTTP call.
+ */
+
+export interface GithubRateLimitInfo {
+  resetAt?: number;
+  retryAfterSeconds?: number;
+}
+
+function normalizeHeaders(
+  headers: Record<string, unknown> | undefined,
+): Record<string, string> {
+  const normalized: Record<string, string> = {};
+  if (!headers) return normalized;
+  for (const [key, value] of Object.entries(headers)) {
+    if (typeof value === "string") {
+      normalized[key.toLowerCase()] = value;
+    }
+  }
+  return normalized;
+}
+
+function parseIntHeader(raw: string | undefined): number | undefined {
+  if (!raw) return undefined;
+  const value = Number.parseInt(raw, 10);
+  return Number.isFinite(value) ? value : undefined;
+}
+
+/**
+ * True when a response looks like a GitHub primary or secondary rate-limit
+ * rejection: a 403 (or 429, which GitHub has been rolling out for some
+ * rate-limited endpoints) with `x-ratelimit-remaining: 0`, or a 403 carrying
+ * a `retry-after` header (the secondary/abuse-detection limit, which does
+ * not always report ratelimit-remaining).
+ */
+export function isGithubRateLimitResponse(
+  status: number,
+  headers: Record<string, unknown> | undefined,
+): boolean {
+  if (status !== 403 && status !== 429) {
+    return false;
+  }
+  const normalized = normalizeHeaders(headers);
+  if (normalized["x-ratelimit-remaining"] === "0") {
+    return true;
+  }
+  return status === 403 && "retry-after" in normalized;
+}
+
+/** Extracts retry-timing hints from a rate-limited response's headers. */
+export function parseGithubRateLimitInfo(
+  headers: Record<string, unknown> | undefined,
+): GithubRateLimitInfo {
+  const normalized = normalizeHeaders(headers);
+  return {
+    resetAt: parseIntHeader(normalized["x-ratelimit-reset"]),
+    retryAfterSeconds: parseIntHeader(normalized["retry-after"]),
+  };
+}

--- a/apps/api/src/api/attempt/common/utils/github-rate-limit-detection.util.ts
+++ b/apps/api/src/api/attempt/common/utils/github-rate-limit-detection.util.ts
@@ -31,10 +31,10 @@ function parseIntHeader(raw: string | undefined): number | undefined {
 
 /**
  * True when a response looks like a GitHub primary or secondary rate-limit
- * rejection: a 403 (or 429, which GitHub has been rolling out for some
- * rate-limited endpoints) with `x-ratelimit-remaining: 0`, or a 403 carrying
- * a `retry-after` header (the secondary/abuse-detection limit, which does
- * not always report ratelimit-remaining).
+ * rejection: a 403 or 429 with `x-ratelimit-remaining: 0`, or a 403 or 429
+ * carrying a `retry-after` header (the secondary/abuse-detection limit,
+ * which does not always report ratelimit-remaining; GitHub documents this
+ * limit as returning either status).
  */
 export function isGithubRateLimitResponse(
   status: number,
@@ -47,7 +47,7 @@ export function isGithubRateLimitResponse(
   if (normalized["x-ratelimit-remaining"] === "0") {
     return true;
   }
-  return status === 403 && "retry-after" in normalized;
+  return "retry-after" in normalized;
 }
 
 /** Extracts retry-timing hints from a rate-limited response's headers. */

--- a/apps/api/src/api/attempt/services/attempt-submission.service.spec.ts
+++ b/apps/api/src/api/attempt/services/attempt-submission.service.spec.ts
@@ -2,6 +2,7 @@ import { HttpService } from "@nestjs/axios";
 import {
   BadRequestException,
   InternalServerErrorException,
+  ServiceUnavailableException,
 } from "@nestjs/common";
 import { Test, TestingModule } from "@nestjs/testing";
 import { Question } from "@prisma/client";
@@ -10,6 +11,7 @@ import {
   UserSession,
 } from "../../../auth/interfaces/user.session.interface";
 import { PrismaService } from "../../../database/prisma.service";
+import { GithubRateLimitedError } from "../../llm/features/grading/errors/github-rate-limited.error";
 import { OversizedSubmissionError } from "../../llm/features/grading/errors/oversized-submission.error";
 import { UnsupportedImageFormatError } from "../../llm/features/grading/errors/unsupported-image-format.error";
 import { CreateQuestionResponseAttemptResponseDto } from "../../assignment/attempt/dto/question-response/create.question.response.attempt.response.dto";
@@ -726,6 +728,29 @@ describe("AttemptSubmissionService - Grading Validation", () => {
           "en",
         ),
       ).rejects.toBe(boom);
+    });
+
+    it("maps a GithubRateLimitedError into a ServiceUnavailableException (retryable 503)", async () => {
+      const rateLimited = new GithubRateLimitedError({
+        owner: "octocat",
+        repo: "hello-world",
+        requestUrl: "https://api.github.com/repos/octocat/hello-world",
+      });
+      mockQuestionResponseService.createQuestionResponse.mockRejectedValue(
+        rateLimited,
+      );
+
+      const rejection = await service
+        .autoSaveQuestionResponse(71, 99, 101, requestDto, learnerSession, "en")
+        .then(
+          () => {
+            throw new Error("expected autoSaveQuestionResponse to reject");
+          },
+          (error: unknown) => error,
+        );
+
+      expect(rejection).toBeInstanceOf(ServiceUnavailableException);
+      expect(mockPrisma.questionResponse.deleteMany).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/api/src/api/attempt/services/attempt-submission.service.spec.ts
+++ b/apps/api/src/api/attempt/services/attempt-submission.service.spec.ts
@@ -1958,6 +1958,7 @@ describe("AttemptSubmissionService - Grading Validation", () => {
           request,
         );
 
+        expect(callOrder).toContain("lti");
         expect(callOrder.indexOf("markGradingComplete")).toBeGreaterThan(
           callOrder.indexOf("lti"),
         );

--- a/apps/api/src/api/attempt/services/attempt-submission.service.spec.ts
+++ b/apps/api/src/api/attempt/services/attempt-submission.service.spec.ts
@@ -90,6 +90,9 @@ describe("AttemptSubmissionService - Grading Validation", () => {
   const mockQuestionResponseService = {
     submitQuestions: jest.fn(),
     createQuestionResponse: jest.fn(),
+    gradeQuestionsForLearner: jest.fn(),
+    commitAttemptWithResponses: jest.fn(),
+    markGradingComplete: jest.fn(),
   };
 
   const mockTranslationService = {
@@ -1816,6 +1819,149 @@ describe("AttemptSubmissionService - Grading Validation", () => {
         mockTranslationService.preTranslateQuestions,
       ).not.toHaveBeenCalled();
       expect(mockLtiGradeSyncService.createAndSync).not.toHaveBeenCalled();
+    });
+
+    describe("grading progress ordering", () => {
+      type LearnerAttemptRunner = {
+        updateLearnerAttempt: (
+          attemptId: number,
+          assignmentId: number,
+          updateDto: unknown,
+          authCookie: string,
+          gradingCallbackRequired: boolean,
+          request: unknown,
+        ) => Promise<unknown>;
+      };
+
+      const callOrder: string[] = [];
+
+      beforeEach(() => {
+        callOrder.length = 0;
+
+        mockPrisma.assignmentAttempt.findUnique.mockResolvedValue({
+          id: 555,
+          userId: "learner@example.com",
+          submitted: false,
+          expiresAt: new Date(Date.now() + 60_000),
+          questionOrder: [101],
+          questionVariants: [],
+        });
+        mockPrisma.assignmentAttempt.findMany.mockResolvedValue([]);
+        mockPrisma.assignment.findUnique.mockResolvedValue({
+          id: 2580,
+          questionOrder: [101],
+          questions: [{ id: 101, totalPoints: 10 }],
+          requireAllQuestions: false,
+          showAssignmentScore: true,
+          showQuestions: true,
+          showSubmissionFeedback: true,
+          currentVersion: { correctAnswerVisibility: "ALWAYS" },
+        });
+        mockValidationService.isAttemptExpired.mockReturnValue(false);
+        mockTranslationService.preTranslateQuestions.mockResolvedValue(
+          new Map(),
+        );
+
+        mockQuestionResponseService.gradeQuestionsForLearner.mockImplementation(
+          async () => {
+            callOrder.push("grade");
+            return [
+              {
+                questionId: 101,
+                learnerResponse: "an answer",
+                responseDto: makeResponse({
+                  id: 9001,
+                  questionId: 101,
+                  points: 8,
+                  totalPoints: 10,
+                }),
+              },
+            ];
+          },
+        );
+        mockQuestionResponseService.commitAttemptWithResponses.mockImplementation(
+          async () => {
+            callOrder.push("commit");
+            return { id: 555, submitted: true, grade: 0.8 };
+          },
+        );
+        mockQuestionResponseService.markGradingComplete.mockImplementation(
+          async () => {
+            callOrder.push("markGradingComplete");
+          },
+        );
+
+        mockGradingService.calculateGradeForLearner.mockReturnValue({
+          grade: 0.8,
+          totalPointsEarned: 8,
+        });
+        mockGradingService.constructFeedbacksForQuestions.mockReturnValue([]);
+      });
+
+      const updateDto = {
+        responsesForQuestions: [{ id: 101 }],
+        language: "en",
+      } as never;
+      const request = {
+        userSession: { userId: "learner@example.com", role: "Learner" },
+      } as never;
+
+      it("marks grading complete only after the responses and grade commit", async () => {
+        await (service as unknown as LearnerAttemptRunner).updateLearnerAttempt(
+          555,
+          2580,
+          updateDto,
+          "cookie",
+          false,
+          request,
+        );
+
+        expect(callOrder).toEqual(["grade", "commit", "markGradingComplete"]);
+      });
+
+      it("never marks grading complete when the commit fails", async () => {
+        mockQuestionResponseService.commitAttemptWithResponses.mockImplementation(
+          async () => {
+            callOrder.push("commit");
+            throw new Error("Attempt 555 was concurrently submitted.");
+          },
+        );
+
+        await expect(
+          (service as unknown as LearnerAttemptRunner).updateLearnerAttempt(
+            555,
+            2580,
+            updateDto,
+            "cookie",
+            false,
+            request,
+          ),
+        ).rejects.toThrow("concurrently submitted");
+
+        expect(
+          mockQuestionResponseService.markGradingComplete,
+        ).not.toHaveBeenCalled();
+      });
+
+      it("marks grading complete after the LTI callback, not before it", async () => {
+        mockLtiGradeSyncService.createAndSync.mockImplementation(async () => {
+          callOrder.push("lti");
+          return undefined;
+        });
+
+        await (service as unknown as LearnerAttemptRunner).updateLearnerAttempt(
+          555,
+          2580,
+          updateDto,
+          "cookie",
+          true,
+          request,
+        );
+
+        expect(callOrder.indexOf("markGradingComplete")).toBeGreaterThan(
+          callOrder.indexOf("lti"),
+        );
+      });
     });
   });
 });

--- a/apps/api/src/api/attempt/services/attempt-submission.service.ts
+++ b/apps/api/src/api/attempt/services/attempt-submission.service.ts
@@ -7,6 +7,7 @@ import {
   InternalServerErrorException,
   Logger,
   NotFoundException,
+  ServiceUnavailableException,
   UnprocessableEntityException,
 } from "@nestjs/common";
 import {
@@ -51,6 +52,7 @@ import {
   UserSessionRequest,
 } from "../../../auth/interfaces/user.session.interface";
 import { PrismaService } from "../../../database/prisma.service";
+import { GithubRateLimitedError } from "../../llm/features/grading/errors/github-rate-limited.error";
 import { LearnerFacingGradingError } from "../../llm/features/grading/errors/learner-facing-grading.error";
 import {
   AssignmentAttemptWithRelations,
@@ -126,6 +128,14 @@ export class AttemptSubmissionService {
       // filter.
       if (error instanceof LearnerFacingGradingError) {
         throw new BadRequestException(error.learnerMessage);
+      }
+      // A rate-limited GitHub fetch is a temporary system fault, not a
+      // problem with the learner's submission — surface it as a retryable
+      // 503 instead of letting it fall through to a generic 500.
+      if (error instanceof GithubRateLimitedError) {
+        throw new ServiceUnavailableException(
+          "Temporarily unable to fetch the submitted URL's content. Please try again shortly.",
+        );
       }
       throw error;
     }

--- a/apps/api/src/api/attempt/services/attempt-submission.service.ts
+++ b/apps/api/src/api/attempt/services/attempt-submission.service.ts
@@ -1335,6 +1335,13 @@ export class AttemptSubmissionService {
           updateDto,
         );
 
+      // Only now is the grade readable, so only now may the progress row say
+      // COMPLETED. Everything above — grade computation, the external LTI
+      // callback, the commit transaction itself — used to run after the row
+      // had already been flipped, which let a client see "done" and then read
+      // an unsubmitted, ungraded attempt.
+      await this.questionResponseService.markGradingComplete(attemptId);
+
       await this.pruneAutoSavedResponses(
         attemptId,
         successfulQuestionResponses,

--- a/apps/api/src/api/attempt/services/grading-progress.service.spec.ts
+++ b/apps/api/src/api/attempt/services/grading-progress.service.spec.ts
@@ -1,0 +1,113 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { GradingStatus } from "@prisma/client";
+import { AdminEmailService } from "../../../auth/services/admin-email.service";
+import { PrismaService } from "../../../database/prisma.service";
+import { GradingProgressService } from "./grading-progress.service";
+
+describe("GradingProgressService.markComplete", () => {
+  let service: GradingProgressService;
+
+  const mockPrisma = {
+    gradingProgress: {
+      update: jest.fn(),
+      findUnique: jest.fn(),
+      upsert: jest.fn(),
+    },
+  };
+
+  const mockEmailService = {
+    sendGradingCompletionEmail: jest.fn().mockResolvedValue(true),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        GradingProgressService,
+        { provide: PrismaService, useValue: mockPrisma },
+        { provide: AdminEmailService, useValue: mockEmailService },
+      ],
+    }).compile();
+
+    service = module.get<GradingProgressService>(GradingProgressService);
+    jest.clearAllMocks();
+    mockPrisma.gradingProgress.update.mockResolvedValue({});
+  });
+
+  it("writes COMPLETED before reading the attempt for the notification", async () => {
+    const callOrder: string[] = [];
+
+    mockPrisma.gradingProgress.update.mockImplementation(async () => {
+      callOrder.push("update");
+      return {};
+    });
+    mockPrisma.gradingProgress.findUnique.mockImplementation(async () => {
+      callOrder.push("read");
+      return {
+        attemptId: 77,
+        notifyOnComplete: false,
+        notificationEmail: null,
+        attempt: { assignmentId: 12, grade: 0.75, submitted: true },
+      };
+    });
+
+    await service.markComplete(77);
+
+    expect(callOrder).toEqual(["update", "read"]);
+    expect(mockPrisma.gradingProgress.update).toHaveBeenCalledWith({
+      where: { attemptId: 77 },
+      data: expect.objectContaining({
+        status: GradingStatus.COMPLETED,
+        progress: 100,
+      }),
+    });
+  });
+
+  it("emails the committed grade rather than a missing one", async () => {
+    mockPrisma.gradingProgress.findUnique.mockResolvedValue({
+      attemptId: 77,
+      notifyOnComplete: true,
+      notificationEmail: "learner@example.com",
+      attempt: { assignmentId: 12, grade: 0.75, submitted: true },
+    });
+
+    await service.markComplete(77);
+
+    expect(mockEmailService.sendGradingCompletionEmail).toHaveBeenCalledWith(
+      "learner@example.com",
+      12,
+      77,
+      75,
+    );
+  });
+
+  it("warns when it is reached before the attempt has been committed", async () => {
+    const warn = jest
+      .spyOn(
+        Reflect.get(service, "logger") as {
+          warn: (message: string) => void;
+        },
+        "warn",
+      )
+      .mockImplementation(() => undefined);
+
+    mockPrisma.gradingProgress.findUnique.mockResolvedValue({
+      attemptId: 77,
+      notifyOnComplete: false,
+      notificationEmail: null,
+      attempt: { assignmentId: 12, grade: null, submitted: false },
+    });
+
+    await service.markComplete(77);
+
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("grading.progress.completed.before.commit"),
+    );
+  });
+
+  it("does not touch the database for author preview attempts", async () => {
+    await service.markComplete(-1);
+
+    expect(mockPrisma.gradingProgress.update).not.toHaveBeenCalled();
+    expect(mockPrisma.gradingProgress.findUnique).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/api/attempt/services/grading-progress.service.spec.ts
+++ b/apps/api/src/api/attempt/services/grading-progress.service.spec.ts
@@ -80,6 +80,24 @@ describe("GradingProgressService.markComplete", () => {
     );
   });
 
+  it("emails a genuine 0% grade rather than treating it as missing", async () => {
+    mockPrisma.gradingProgress.findUnique.mockResolvedValue({
+      attemptId: 77,
+      notifyOnComplete: true,
+      notificationEmail: "learner@example.com",
+      attempt: { assignmentId: 12, grade: 0, submitted: true },
+    });
+
+    await service.markComplete(77);
+
+    expect(mockEmailService.sendGradingCompletionEmail).toHaveBeenCalledWith(
+      "learner@example.com",
+      12,
+      77,
+      0,
+    );
+  });
+
   it("warns when it is reached before the attempt has been committed", async () => {
     const warn = jest
       .spyOn(

--- a/apps/api/src/api/attempt/services/grading-progress.service.ts
+++ b/apps/api/src/api/attempt/services/grading-progress.service.ts
@@ -239,13 +239,6 @@ export class GradingProgressService {
   async markComplete(attemptId: number): Promise<void> {
     try {
       if (attemptId > 0) {
-        const gradingProgress = await this.prisma.gradingProgress.findUnique({
-          where: { attemptId },
-          include: {
-            attempt: true,
-          },
-        });
-
         await this.prisma.gradingProgress.update({
           where: { attemptId },
           data: {
@@ -255,6 +248,29 @@ export class GradingProgressService {
             completedAt: new Date(),
           },
         });
+
+        // Read the attempt AFTER the status write, not before. Callers reach
+        // this method only once the grade and question responses are
+        // committed, so this read sees the durable grade; reading first
+        // captured the pre-commit row and mailed learners a completion notice
+        // with no score in it.
+        const gradingProgress = await this.prisma.gradingProgress.findUnique({
+          where: { attemptId },
+          include: {
+            attempt: true,
+          },
+        });
+
+        if (gradingProgress && !gradingProgress.attempt.submitted) {
+          // Tripwire, not an abort. COMPLETED is the learner's "your grade is
+          // ready" signal and must never precede the commit; if a future
+          // caller reintroduces that ordering this is how we find out.
+          // Throwing here would strand the row at PROCESSING, which is worse
+          // for the learner than a momentarily early COMPLETED.
+          this.logger.warn(
+            `grading.progress.completed.before.commit attemptId=${attemptId}`,
+          );
+        }
 
         if (
           gradingProgress?.notifyOnComplete &&

--- a/apps/api/src/api/attempt/services/grading-progress.service.ts
+++ b/apps/api/src/api/attempt/services/grading-progress.service.ts
@@ -282,9 +282,10 @@ export class GradingProgressService {
 
           try {
             const assignmentId = gradingProgress.attempt.assignmentId;
-            const grade = gradingProgress.attempt.grade
-              ? gradingProgress.attempt.grade * 100
-              : undefined;
+            const grade =
+              gradingProgress.attempt.grade === null
+                ? undefined
+                : gradingProgress.attempt.grade * 100;
 
             await this.emailService.sendGradingCompletionEmail(
               gradingProgress.notificationEmail,

--- a/apps/api/src/api/attempt/services/question-response/question-response.service.spec.ts
+++ b/apps/api/src/api/attempt/services/question-response/question-response.service.spec.ts
@@ -10,6 +10,7 @@ import { WINSTON_MODULE_PROVIDER } from "nest-winston";
 import { UserRole } from "../../../../auth/interfaces/user.session.interface";
 import { PrismaService } from "../../../../database/prisma.service";
 import { QuestionService } from "../../../assignment/question/question.service";
+import { GithubRateLimitedError } from "../../../llm/features/grading/errors/github-rate-limited.error";
 import { OversizedSubmissionError } from "../../../llm/features/grading/errors/oversized-submission.error";
 import { UnsupportedImageFormatError } from "../../../llm/features/grading/errors/unsupported-image-format.error";
 import { LocalizationService } from "../../common/utils/localization.service";
@@ -774,5 +775,47 @@ describe("QuestionResponseService — gradeQuestionNoSave error handling", () =>
     await expect(callGradeQuestionNoSave()).rejects.toThrow(
       "Failed to process question response: model exploded",
     );
+  });
+
+  it("rethrows GithubRateLimitedError unchanged (same instance)", async () => {
+    const rateLimited = new GithubRateLimitedError({
+      owner: "octocat",
+      repo: "hello-world",
+      requestUrl: "https://api.github.com/repos/octocat/hello-world",
+    });
+    mockStrategy.gradeResponse.mockRejectedValue(rateLimited);
+
+    await expect(callGradeQuestionNoSave()).rejects.toBe(rateLimited);
+  });
+
+  it("surfaces GithubRateLimitedError out of the public createQuestionResponse entry point with its class intact", async () => {
+    const rateLimited = new GithubRateLimitedError({
+      owner: "octocat",
+      repo: "hello-world",
+      requestUrl: "https://api.github.com/repos/octocat/hello-world",
+    });
+    mockStrategy.gradeResponse.mockRejectedValue(rateLimited);
+
+    // Author path avoids the DB lookups the learner path needs — the point
+    // here is the error's class survives the createQuestionResponse ->
+    // gradeQuestionNoSave boundary, not the question-loading mechanics.
+    const rejection = await service
+      .createQuestionResponse(
+        10, // assignmentAttemptId
+        { ...requestDto, id: question.id },
+        UserRole.AUTHOR,
+        5, // assignmentId
+        "en",
+        [question], // authorQuestions
+      )
+      .then(
+        () => {
+          throw new Error("expected createQuestionResponse to reject");
+        },
+        (error: unknown) => error,
+      );
+
+    expect(rejection).toBe(rateLimited);
+    expect(rejection).toBeInstanceOf(GithubRateLimitedError);
   });
 });

--- a/apps/api/src/api/attempt/services/question-response/question-response.service.spec.ts
+++ b/apps/api/src/api/attempt/services/question-response/question-response.service.spec.ts
@@ -316,7 +316,71 @@ describe("QuestionResponseService — gradeQuestionsForLearner", () => {
       1,
       "Grading question 1 of 1...",
     );
+    // Grading no longer flips the progress row; the caller does that after
+    // the responses and grade commit.
+    expect(mockProgressService.markComplete).not.toHaveBeenCalled();
+  });
+
+  it("exposes markGradingComplete so the caller can flip the row post-commit", async () => {
+    await service.markGradingComplete(20);
+
     expect(mockProgressService.markComplete).toHaveBeenCalledWith(20);
+  });
+
+  it("marks the legacy submitQuestions path complete only after its write phase", async () => {
+    const callOrder: string[] = [];
+
+    const questionDto = {
+      id: 3,
+      question: "Explain entropy",
+      type: QuestionType.TEXT,
+      gradingContextQuestionIds: [],
+      totalPoints: 10,
+      responseType: "TEXT",
+    };
+
+    spyPrivate("getLearnerQuestion", async () => ({
+      question: questionDto,
+      assignmentContext: {
+        assignmentInstructions: "",
+        questionAnswerContext: [],
+      },
+    }));
+    spyPrivate("buildAndSortDependencies", () => ({
+      sorted: [3],
+      adj: new Map(),
+      inDegree: new Map([[3, 0]]),
+    }));
+    spyPrivate("getAssignmentContext", async () => ({
+      assignmentInstructions: "",
+      questionAnswerContext: [],
+    }));
+    spyPrivate("gradeQuestionNoSave", async () => ({
+      learnerResponse: "disorder increases",
+      responseDto: {
+        questionId: 3,
+        question: "Explain entropy",
+        points: 10,
+        totalPoints: 10,
+        feedback: [],
+      },
+    }));
+    spyPrivate("saveResponseToDatabase", async () => {
+      callOrder.push("write");
+    });
+    mockProgressService.markComplete.mockImplementation(async () => {
+      callOrder.push("markComplete");
+    });
+
+    await service.submitQuestions(
+      [{ id: 3, language: "en" }] as any[],
+      30,
+      UserRole.LEARNER,
+      5,
+      "en",
+    );
+
+    expect(callOrder).toEqual(["write", "markComplete"]);
   });
 
   it("stores context responses in-memory so subsequent questions can reference them without a DB call", async () => {

--- a/apps/api/src/api/attempt/services/question-response/question-response.service.ts
+++ b/apps/api/src/api/attempt/services/question-response/question-response.service.ts
@@ -519,8 +519,14 @@ export class QuestionResponseService {
    * learner their grade is readable, so it must not become visible until
    * commitAttemptWithResponses has durably written the QuestionResponse rows
    * and the AssignmentAttempt grade. Callers invoke this immediately after
-   * that commit succeeds; when the commit fails they must not call it at all,
-   * leaving the row at PROCESSING for the failure handler to move to FAILED.
+   * that commit succeeds; when the commit fails they must not call it at all.
+   *
+   * On the queued grading path, a commit failure leaves the row at
+   * PROCESSING and the job's own failure handler is what moves it to
+   * FAILED. The inline (non-queued, synchronous) submission path has no
+   * equivalent repair today, so a commit failure there currently strands
+   * the row at PROCESSING rather than FAILED — a known gap, not something
+   * this method papers over.
    */
   async markGradingComplete(assignmentAttemptId: number): Promise<void> {
     await this.progressService?.markComplete(assignmentAttemptId);

--- a/apps/api/src/api/attempt/services/question-response/question-response.service.ts
+++ b/apps/api/src/api/attempt/services/question-response/question-response.service.ts
@@ -12,7 +12,6 @@ import {
   NotFoundException,
 } from "@nestjs/common";
 import { QuestionType } from "@prisma/client";
-import * as cheerio from "cheerio";
 import { WINSTON_MODULE_PROVIDER } from "nest-winston";
 import {
   authorAssignmentDetailsDTO,
@@ -30,7 +29,10 @@ import {
   VideoPresentationConfig,
 } from "src/api/assignment/dto/update.questions.request.dto";
 import { QuestionService } from "src/api/assignment/question/question.service";
-import { safeGet } from "src/api/attempt/common/utils/ssrf-safe-http";
+import {
+  convertGitHubUrlToRaw,
+  fetchUrlContentForGrading,
+} from "src/api/attempt/common/utils/github-content-fetch.util";
 import { QuestionAnswerContext } from "src/api/llm/model/base.question.evaluate.model";
 import { LearnerFacingGradingError } from "../../../llm/features/grading/errors/learner-facing-grading.error";
 import { Logger } from "winston";
@@ -991,7 +993,7 @@ export class QuestionResponseService {
         QuestionType.URL,
       );
       const url = requestDto.learnerUrlResponse;
-      const rawUrl = this.convertGitHubUrlToRaw(url);
+      const rawUrl = convertGitHubUrlToRaw(url);
       if (rawUrl) {
         requestDto.learnerUrlResponse = rawUrl;
       }
@@ -1381,7 +1383,10 @@ export class QuestionResponseService {
             const url =
               typeof urlValue === "object" ? urlValue.url : String(urlValue);
 
-            const content = await this.fetchUrlContent(String(url));
+            const content = await fetchUrlContentForGrading(String(url), {
+              assignmentId,
+              questionId: contextQuestion.id,
+            });
 
             learnerResponse = JSON.stringify({
               url,
@@ -1481,168 +1486,5 @@ export class QuestionResponseService {
     }
 
     return field;
-  }
-
-  /**
-   * Convert GitHub blob URL to raw content URL
-   */
-  private convertGitHubUrlToRaw(url: string): string | null {
-    const match = url.match(
-      /^https:\/\/github\.com\/([^/]+)\/([^/]+)\/blob\/(.+)$/,
-    );
-    if (!match) {
-      return null;
-    }
-    const [, user, repo, path] = match;
-    return `https://raw.githubusercontent.com/${user}/${repo}/${path}`;
-  }
-
-  /**
-   * Fetch content from a URL
-   */
-  private async fetchUrlContent(
-    url: string,
-  ): Promise<{ body: string; isFunctional: boolean }> {
-    const MAX_CONTENT_SIZE = 100_000;
-    try {
-      if (url.includes("github.com")) {
-        if (url.includes("/blob/")) {
-          const rawUrl = this.convertGitHubUrlToRaw(url);
-          if (!rawUrl) {
-            return { body: "", isFunctional: false };
-          }
-
-          const rawContentResponse = await safeGet<string>(rawUrl);
-          if (rawContentResponse.status === 200) {
-            let body = rawContentResponse.data;
-            if (body.length > MAX_CONTENT_SIZE) {
-              body = body.slice(0, MAX_CONTENT_SIZE);
-            }
-            return { body, isFunctional: true };
-          }
-        } else {
-          try {
-            const repoMatch = url.match(
-              /^https:\/\/github\.com\/([^/]+)\/([^/]+)\/?$/,
-            );
-            if (repoMatch) {
-              const [, user, repo] = repoMatch;
-
-              const readmeUrl = `https://raw.githubusercontent.com/${user}/${repo}/main/README.md`;
-              try {
-                const readmeResponse = await safeGet<string>(readmeUrl);
-                if (readmeResponse.status === 200) {
-                  let body = readmeResponse.data;
-                  if (body.length > MAX_CONTENT_SIZE) {
-                    body = body.slice(0, MAX_CONTENT_SIZE);
-                  }
-                  return { body, isFunctional: true };
-                }
-              } catch {
-                try {
-                  const masterReadmeUrl = `https://raw.githubusercontent.com/${user}/${repo}/master/README.md`;
-                  const masterReadmeResponse =
-                    await safeGet<string>(masterReadmeUrl);
-                  if (masterReadmeResponse.status === 200) {
-                    let body = masterReadmeResponse.data;
-                    if (body.length > MAX_CONTENT_SIZE) {
-                      body = body.slice(0, MAX_CONTENT_SIZE);
-                    }
-                    return { body, isFunctional: true };
-                  }
-                } catch {
-                  const apiUrl = `https://api.github.com/repos/${user}/${repo}`;
-                  try {
-                    const apiResponse = await safeGet<{
-                      full_name?: string;
-                      description?: string;
-                      stargazers_count?: number;
-                      forks_count?: number;
-                      language?: string;
-                      updated_at?: string;
-                    }>(apiUrl);
-                    if (apiResponse.status === 200) {
-                      const repoInfo = apiResponse.data;
-                      const body = `Repository: ${
-                        repoInfo.full_name
-                      }\nDescription: ${
-                        repoInfo.description || "No description"
-                      }\nStars: ${repoInfo.stargazers_count}\nForks: ${
-                        repoInfo.forks_count
-                      }\nLanguage: ${
-                        repoInfo.language || "Not specified"
-                      }\nLast Updated: ${repoInfo.updated_at}`;
-                      return { body, isFunctional: true };
-                    }
-                  } catch {
-                    return { body: "", isFunctional: false };
-                  }
-                }
-              }
-            }
-          } catch {
-            return { body: "", isFunctional: false };
-          }
-
-          try {
-            const response = await safeGet<string>(url);
-            const $ = cheerio.load(response.data);
-
-            $(
-              "script, style, noscript, iframe, noembed, embed, object",
-            ).remove();
-
-            let content = "";
-            const readmeElement = $("article.markdown-body");
-            if (readmeElement.length > 0) {
-              content = readmeElement.text().trim();
-            } else {
-              const aboutSection = $(".Box-body");
-              if (aboutSection.length > 0) {
-                content += aboutSection.text().trim() + "\n\n";
-              }
-
-              const fileList = $(
-                "div.js-details-container div.js-navigation-container tr.js-navigation-item",
-              );
-              if (fileList.length > 0) {
-                content += "Repository Files:\n";
-                fileList.each((index, element) => {
-                  const fileName = $(element)
-                    .find(".js-navigation-open")
-                    .text()
-                    .trim();
-                  if (fileName) {
-                    content += `- ${fileName}\n`;
-                  }
-                });
-              }
-            }
-
-            if (content) {
-              return {
-                body: content.replaceAll(/\s+/g, " ").trim(),
-                isFunctional: true,
-              };
-            }
-          } catch {
-            // Ignore HTTP parsing failures and fall back to an empty response.
-          }
-        }
-
-        return { body: "", isFunctional: false };
-      } else {
-        const response = await safeGet<string>(url);
-        const $ = cheerio.load(response.data);
-
-        $("script, style, noscript, iframe, noembed, embed, object").remove();
-
-        const plainText = $("body").text().trim().replaceAll(/\s+/g, " ");
-
-        return { body: plainText, isFunctional: true };
-      }
-    } catch {
-      return { body: "", isFunctional: false };
-    }
   }
 }

--- a/apps/api/src/api/attempt/services/question-response/question-response.service.ts
+++ b/apps/api/src/api/attempt/services/question-response/question-response.service.ts
@@ -34,6 +34,7 @@ import {
   fetchUrlContentForGrading,
 } from "src/api/attempt/common/utils/github-content-fetch.util";
 import { QuestionAnswerContext } from "src/api/llm/model/base.question.evaluate.model";
+import { GithubRateLimitedError } from "../../../llm/features/grading/errors/github-rate-limited.error";
 import { LearnerFacingGradingError } from "../../../llm/features/grading/errors/learner-facing-grading.error";
 import { Logger } from "winston";
 import { UserRole } from "../../../../auth/interfaces/user.session.interface";
@@ -952,6 +953,14 @@ export class QuestionResponseService {
       // retries and surface their learner-facing message. Wrapping them in
       // BadRequestException erased that.
       if (error instanceof LearnerFacingGradingError) {
+        throw error;
+      }
+
+      // Same reasoning as above: a rate-limited GitHub fetch is a transient
+      // system fault the caller must be able to retry, not a 400. Wrapping
+      // it here would erase the class identity the retry classification
+      // depends on.
+      if (error instanceof GithubRateLimitedError) {
         throw error;
       }
 

--- a/apps/api/src/api/attempt/services/question-response/question-response.service.ts
+++ b/apps/api/src/api/attempt/services/question-response/question-response.service.ts
@@ -405,10 +405,12 @@ export class QuestionResponseService {
       },
     });
 
-    if (this.progressService) {
-      await this.progressService.markComplete(assignmentAttemptId);
-    }
-
+    // Deliberately does NOT mark grading complete. The progress row is the
+    // learner-facing "your grade is ready" signal, and at this point nothing
+    // has been written: the grade still has to be computed, the LTI callback
+    // still has to run, and commitAttemptWithResponses still has to persist
+    // the responses and the grade. The caller flips the row once that commit
+    // returns — see markGradingComplete.
     return gradedItems;
   }
 
@@ -508,6 +510,20 @@ export class QuestionResponseService {
       },
       { timeout: 60_000 },
     );
+  }
+
+  /**
+   * Flip the attempt's grading progress to COMPLETED.
+   *
+   * Split out of the grading phase on purpose: COMPLETED is what tells a
+   * learner their grade is readable, so it must not become visible until
+   * commitAttemptWithResponses has durably written the QuestionResponse rows
+   * and the AssignmentAttempt grade. Callers invoke this immediately after
+   * that commit succeeds; when the commit fails they must not call it at all,
+   * leaving the row at PROCESSING for the failure handler to move to FAILED.
+   */
+  async markGradingComplete(assignmentAttemptId: number): Promise<void> {
+    await this.progressService?.markComplete(assignmentAttemptId);
   }
 
   // ─────────────────────────────────────────────────────────────────────────────
@@ -651,10 +667,6 @@ export class QuestionResponseService {
       },
     });
 
-    if (reportProgress && this.progressService) {
-      await this.progressService.markComplete(assignmentAttemptId);
-    }
-
     // ── Phase 3: Write (short transaction) — LEARNER only ────────────────────
     if (role !== UserRole.AUTHOR) {
       await this.prisma.$transaction(
@@ -676,6 +688,13 @@ export class QuestionResponseService {
         },
         { timeout: 60_000 },
       );
+    }
+
+    // COMPLETED after the write, for the same reason as the split learner
+    // flow. Author preview has no write phase and no persisted progress row
+    // (its attempt id is negative), so this is simply the end of its pipeline.
+    if (reportProgress && this.progressService) {
+      await this.progressService.markComplete(assignmentAttemptId);
     }
 
     return gradedItems.map((g) => g.responseDto);

--- a/apps/api/src/api/attempt/services/question-response/question-response.service.url-fetch.spec.ts
+++ b/apps/api/src/api/attempt/services/question-response/question-response.service.url-fetch.spec.ts
@@ -2,6 +2,7 @@
 import { Test, TestingModule } from "@nestjs/testing";
 import { QuestionType } from "@prisma/client";
 import { WINSTON_MODULE_PROVIDER } from "nest-winston";
+import { GithubRateLimitedError } from "src/api/llm/features/grading/errors/github-rate-limited.error";
 import { PrismaService } from "../../../../database/prisma.service";
 import { QuestionService } from "../../../assignment/question/question.service";
 import { LocalizationService } from "../../common/utils/localization.service";
@@ -143,7 +144,13 @@ describe("QuestionResponseService URL-fetch delegation", () => {
         learnerResponse: "https://github.com/octocat/hello-world",
       },
     ]);
-    mockedFetch.mockRejectedValue(new Error("GithubRateLimitedError"));
+    mockedFetch.mockRejectedValue(
+      new GithubRateLimitedError({
+        owner: "octocat",
+        repo: "hello-world",
+        requestUrl: "https://api.github.com/repos/octocat/hello-world",
+      }),
+    );
 
     await expect(
       (service as any).getAssignmentContext(5, 20, 10, undefined, new Map()),

--- a/apps/api/src/api/attempt/services/question-response/question-response.service.url-fetch.spec.ts
+++ b/apps/api/src/api/attempt/services/question-response/question-response.service.url-fetch.spec.ts
@@ -1,0 +1,152 @@
+/* eslint-disable */
+import { Test, TestingModule } from "@nestjs/testing";
+import { QuestionType } from "@prisma/client";
+import { WINSTON_MODULE_PROVIDER } from "nest-winston";
+import { PrismaService } from "../../../../database/prisma.service";
+import { QuestionService } from "../../../assignment/question/question.service";
+import { LocalizationService } from "../../common/utils/localization.service";
+import { GradingFactoryService } from "../grading-factory.service";
+import { GradingRateLimiterService } from "../grading-rate-limiter.service";
+import * as githubContentFetch from "src/api/attempt/common/utils/github-content-fetch.util";
+import { QuestionResponseService } from "./question-response.service";
+
+jest.mock("src/api/attempt/common/utils/github-content-fetch.util");
+
+const mockedFetch =
+  githubContentFetch.fetchUrlContentForGrading as jest.MockedFunction<
+    typeof githubContentFetch.fetchUrlContentForGrading
+  >;
+const mockedConvert =
+  githubContentFetch.convertGitHubUrlToRaw as jest.MockedFunction<
+    typeof githubContentFetch.convertGitHubUrlToRaw
+  >;
+
+const mockRateLimiter = {
+  schedule: jest.fn(async (_name: string, op: () => Promise<any>) => op()),
+};
+
+describe("QuestionResponseService URL-fetch delegation", () => {
+  let service: QuestionResponseService;
+
+  const mockPrisma = {
+    assignment: { findUnique: jest.fn() },
+    question: { findUnique: jest.fn(), findMany: jest.fn() },
+    questionResponse: { findMany: jest.fn() },
+  };
+  const mockQuestionService = { findOne: jest.fn() };
+  const mockLocalizationService = {};
+  const mockGradingFactoryService = {};
+  const mockLogger = {
+    child: jest.fn().mockReturnValue({
+      info: jest.fn(),
+      error: jest.fn(),
+      warn: jest.fn(),
+      debug: jest.fn(),
+    }),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        QuestionResponseService,
+        { provide: PrismaService, useValue: mockPrisma },
+        { provide: QuestionService, useValue: mockQuestionService },
+        { provide: LocalizationService, useValue: mockLocalizationService },
+        { provide: GradingFactoryService, useValue: mockGradingFactoryService },
+        { provide: GradingRateLimiterService, useValue: mockRateLimiter },
+        { provide: WINSTON_MODULE_PROVIDER, useValue: mockLogger },
+        { provide: "GradingProgressService", useValue: undefined },
+      ],
+    }).compile();
+
+    service = module.get<QuestionResponseService>(QuestionResponseService);
+    jest.clearAllMocks();
+    mockedFetch.mockReset();
+    mockedConvert.mockReset();
+  });
+
+  it("delegates blob-URL rewriting in handleLinkFileQuestion to the shared convertGitHubUrlToRaw", async () => {
+    // handleLinkFileQuestion is private; call it the same way the existing
+    // suite exercises other private methods on this service.
+    mockedConvert.mockReturnValue(
+      "https://raw.githubusercontent.com/octocat/hello-world/main/index.js",
+    );
+
+    // Minimal stub grading strategy so the call proceeds past the rewrite.
+    const urlGradingStrategy = {
+      validateResponse: jest.fn().mockResolvedValue(true),
+      extractLearnerResponse: jest.fn().mockResolvedValue("rewritten"),
+      gradeResponse: jest
+        .fn()
+        .mockResolvedValue({ totalPoints: 5, feedback: [] }),
+    };
+    (service as any).gradingFactoryService = {
+      getStrategy: jest.fn().mockReturnValue(urlGradingStrategy),
+    };
+
+    const question = { id: 1, type: QuestionType.LINK_FILE, totalPoints: 5 };
+    const requestDto: any = {
+      learnerUrlResponse:
+        "https://github.com/octocat/hello-world/blob/main/index.js",
+      language: "en",
+    };
+
+    await (service as any).handleLinkFileQuestion(question, requestDto, {});
+
+    expect(mockedConvert).toHaveBeenCalledWith(
+      "https://github.com/octocat/hello-world/blob/main/index.js",
+    );
+  });
+
+  it("delegates context-building URL fetches to the shared helper and still swallows failures", async () => {
+    mockPrisma.assignment.findUnique.mockResolvedValue({ instructions: "" });
+    mockPrisma.question.findUnique.mockResolvedValue({
+      gradingContextQuestionIds: [30],
+    });
+    mockPrisma.question.findMany.mockResolvedValue([
+      { id: 30, question: "Link your repo", type: QuestionType.URL },
+    ]);
+    mockPrisma.questionResponse.findMany.mockResolvedValue([
+      {
+        questionId: 30,
+        learnerResponse: "https://github.com/octocat/hello-world",
+      },
+    ]);
+    mockedFetch.mockResolvedValue({ body: "# Readme", isFunctional: true });
+
+    const ctx = await (service as any).getAssignmentContext(
+      5,
+      20,
+      10,
+      undefined,
+      new Map(),
+    );
+
+    expect(mockedFetch).toHaveBeenCalledWith(
+      "https://github.com/octocat/hello-world",
+      expect.objectContaining({ assignmentId: 5, questionId: 30 }),
+    );
+    expect(ctx.questionAnswerContext[0].answer).toContain("# Readme");
+  });
+
+  it("still ignores a rate-limit failure while building context (does not throw)", async () => {
+    mockPrisma.assignment.findUnique.mockResolvedValue({ instructions: "" });
+    mockPrisma.question.findUnique.mockResolvedValue({
+      gradingContextQuestionIds: [30],
+    });
+    mockPrisma.question.findMany.mockResolvedValue([
+      { id: 30, question: "Link your repo", type: QuestionType.URL },
+    ]);
+    mockPrisma.questionResponse.findMany.mockResolvedValue([
+      {
+        questionId: 30,
+        learnerResponse: "https://github.com/octocat/hello-world",
+      },
+    ]);
+    mockedFetch.mockRejectedValue(new Error("GithubRateLimitedError"));
+
+    await expect(
+      (service as any).getAssignmentContext(5, 20, 10, undefined, new Map()),
+    ).resolves.toBeDefined();
+  });
+});

--- a/apps/api/src/api/llm/features/grading/errors/github-rate-limited.error.spec.ts
+++ b/apps/api/src/api/llm/features/grading/errors/github-rate-limited.error.spec.ts
@@ -1,0 +1,46 @@
+import { LearnerFacingGradingError } from "./learner-facing-grading.error";
+import { GithubRateLimitedError } from "./github-rate-limited.error";
+
+describe("GithubRateLimitedError", () => {
+  it("carries owner/repo/requestUrl/resetAt/retryAfterSeconds as own properties", () => {
+    const error = new GithubRateLimitedError({
+      owner: "octocat",
+      repo: "hello-world",
+      requestUrl: "https://api.github.com/repos/octocat/hello-world",
+      resetAt: 1_800_000_000,
+      retryAfterSeconds: 30,
+    });
+
+    expect(error.name).toBe("GithubRateLimitedError");
+    expect(error.owner).toBe("octocat");
+    expect(error.repo).toBe("hello-world");
+    expect(error.requestUrl).toBe(
+      "https://api.github.com/repos/octocat/hello-world",
+    );
+    expect(error.resetAt).toBe(1_800_000_000);
+    expect(error.retryAfterSeconds).toBe(30);
+    expect(error.message).toContain("octocat/hello-world");
+  });
+
+  it("is a retryable system error, not a learner-facing terminal one", () => {
+    const error = new GithubRateLimitedError({
+      owner: "a",
+      repo: "b",
+      requestUrl: "https://api.github.com/repos/a/b",
+    });
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error).not.toBeInstanceOf(LearnerFacingGradingError);
+  });
+
+  it("omits optional fields cleanly when not provided", () => {
+    const error = new GithubRateLimitedError({
+      owner: "a",
+      repo: "b",
+      requestUrl: "https://api.github.com/repos/a/b",
+    });
+
+    expect(error.resetAt).toBeUndefined();
+    expect(error.retryAfterSeconds).toBeUndefined();
+  });
+});

--- a/apps/api/src/api/llm/features/grading/errors/github-rate-limited.error.ts
+++ b/apps/api/src/api/llm/features/grading/errors/github-rate-limited.error.ts
@@ -1,0 +1,47 @@
+/**
+ * Thrown when a GitHub API call made while fetching a learner's submitted
+ * URL for grading (README lookup, default-branch resolution, or repository
+ * metadata) is rejected because the server's GitHub API rate limit has been
+ * exhausted. Deliberately does NOT extend LearnerFacingGradingError: this is
+ * a transient system fault, not something the learner did wrong, so the job
+ * worker must treat it as retryable. See apps/jobs job-worker.service.ts
+ * classifyAttemptError — anything that is not a LearnerFacingGradingError
+ * and not in TERMINAL_GRADING_ERROR_NAMES is rethrown untouched and picked
+ * up by BullMQ's normal retry policy.
+ *
+ * Fields are exposed as own enumerable properties so the project logger can
+ * serialize them as structured context.
+ */
+export interface GithubRateLimitedErrorFields {
+  owner: string;
+  repo: string;
+  requestUrl: string;
+  /** Epoch seconds from the `x-ratelimit-reset` response header, when present. */
+  resetAt?: number;
+  /** Seconds from the `retry-after` response header (secondary/abuse-detection limits). */
+  retryAfterSeconds?: number;
+}
+
+export class GithubRateLimitedError extends Error {
+  public readonly owner: string;
+  public readonly repo: string;
+  public readonly requestUrl: string;
+  public readonly resetAt?: number;
+  public readonly retryAfterSeconds?: number;
+
+  constructor(fields: GithubRateLimitedErrorFields) {
+    super(
+      `GitHub API rate limit exceeded while fetching ${fields.owner}/${fields.repo} for grading. This is a temporary system limit, not a problem with the submitted URL.`,
+    );
+    this.name = "GithubRateLimitedError";
+    this.owner = fields.owner;
+    this.repo = fields.repo;
+    this.requestUrl = fields.requestUrl;
+    this.resetAt = fields.resetAt;
+    this.retryAfterSeconds = fields.retryAfterSeconds;
+
+    // Restore the prototype chain when extending a built-in, so `instanceof`
+    // works correctly under the project's TypeScript compile target.
+    Object.setPrototypeOf(this, GithubRateLimitedError.prototype);
+  }
+}

--- a/apps/api/src/config/github-grading-token.spec.ts
+++ b/apps/api/src/config/github-grading-token.spec.ts
@@ -1,0 +1,28 @@
+import { getGithubGradingApiToken } from "./github-grading-token";
+
+describe("getGithubGradingApiToken", () => {
+  const ORIGINAL_ENV = process.env.GITHUB_GRADING_API_TOKEN;
+
+  afterEach(() => {
+    if (ORIGINAL_ENV === undefined) {
+      delete process.env.GITHUB_GRADING_API_TOKEN;
+    } else {
+      process.env.GITHUB_GRADING_API_TOKEN = ORIGINAL_ENV;
+    }
+  });
+
+  it("returns undefined when the env var is unset", () => {
+    delete process.env.GITHUB_GRADING_API_TOKEN;
+    expect(getGithubGradingApiToken()).toBeUndefined();
+  });
+
+  it("returns undefined for an empty or whitespace-only value", () => {
+    process.env.GITHUB_GRADING_API_TOKEN = "   ";
+    expect(getGithubGradingApiToken()).toBeUndefined();
+  });
+
+  it("returns the trimmed token when set", () => {
+    process.env.GITHUB_GRADING_API_TOKEN = "  ghp_example_token_value  ";
+    expect(getGithubGradingApiToken()).toBe("ghp_example_token_value");
+  });
+});

--- a/apps/api/src/config/github-grading-token.ts
+++ b/apps/api/src/config/github-grading-token.ts
@@ -1,0 +1,18 @@
+/**
+ * Optional server-side GitHub token applied to api.github.com requests made
+ * while fetching a learner's submitted URL for grading (default-branch
+ * resolution, repository-metadata fallback). This is a server credential —
+ * never a learner's own OAuth token. Contrast with
+ * src/api/github/github.service.ts, which manages a per-user GitHub token
+ * for a completely different feature (linking a learner's own GitHub
+ * account); that token must never be reused here.
+ *
+ * When unset, GitHub API calls fall back to the unauthenticated 60
+ * requests/hour/IP limit, shared across every concurrent learner
+ * submission from the same egress IP.
+ */
+export function getGithubGradingApiToken(): string | undefined {
+  const raw = process.env.GITHUB_GRADING_API_TOKEN;
+  const trimmed = raw?.trim();
+  return trimmed || undefined;
+}

--- a/apps/web/app/learner/(components)/GradingProgressModal.tsx
+++ b/apps/web/app/learner/(components)/GradingProgressModal.tsx
@@ -3,15 +3,17 @@ import { motion, AnimatePresence, useTransform } from "framer-motion";
 import { subscribeToGradingNotification } from "@/lib/learner";
 import type {
   GradingProgressDetails,
+  GradingProgressStatus,
   QuestionGradingState,
   QuestionGradingStatus,
 } from "@/lib/learner";
 import { toast } from "sonner";
 import GradeSyncStatus from "@/components/GradeSyncStatus";
+import ReportErrorButton from "@/components/ReportErrorButton";
 import { useCreepingProgress } from "./useCreepingProgress";
 
 export interface ProgressState {
-  status: "processing" | "completed" | "failed" | "idle";
+  status: GradingProgressStatus | "idle";
   progress: number;
   currentStage: string;
   currentQuestion?: number;
@@ -87,6 +89,11 @@ interface GradingProgressModalProps {
   assignmentId: number;
   attemptId: number | null;
   progressData: ProgressState;
+  /**
+   * Navigates the learner to their results. Supplied only when there is
+   * somewhere to go; the re-check action is hidden without it.
+   */
+  onCheckResults?: () => void;
 }
 
 export default function GradingProgressModal({
@@ -94,6 +101,7 @@ export default function GradingProgressModal({
   assignmentId,
   attemptId,
   progressData,
+  onCheckResults,
 }: GradingProgressModalProps) {
   const [isSubscribing, setIsSubscribing] = useState(false);
   const [emailNotified, setEmailNotified] = useState(false);
@@ -159,13 +167,20 @@ export default function GradingProgressModal({
     (v) => `${v * 2.64} 264`,
   );
   const barWidth = useTransform(displayProgress, (v) => `${Math.round(v)}%`);
+  // `stalled` keeps the working presentation on purpose: grading really is
+  // still running, so anything red would be a lie.
+  const isWorking = status === "processing" || status === "stalled";
+
   const getStatusColor = () => {
     switch (status) {
       case "completed":
         return "bg-green-500";
       case "failed":
         return "bg-red-500";
+      case "disconnected":
+        return "bg-amber-500";
       case "processing":
+      case "stalled":
         return "bg-purple-500";
       default:
         return "bg-gray-400";
@@ -208,9 +223,36 @@ export default function GradingProgressModal({
           </svg>
         );
 
+      case "disconnected":
+        return (
+          <svg
+            className="w-16 h-16 text-white"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2.5}
+              d="M12 9v4m0 4h.01M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z"
+            />
+          </svg>
+        );
+
       default:
         return null;
     }
+  };
+
+  const errorReportContext = {
+    statusCode: 0,
+    headline:
+      status === "stalled"
+        ? "Grading stopped responding"
+        : "Lost contact with the grading service",
+    message: progressData.currentStage,
+    context: `Assignment ${assignmentId}, attempt ${attemptId ?? "unknown"}`,
   };
 
   return (
@@ -262,7 +304,7 @@ export default function GradingProgressModal({
             >
               <div className="text-center relative">
                 {/* Floating particles */}
-                {status === "processing" && (
+                {isWorking && (
                   <>
                     {[...Array(6)].map((_, i) => (
                       <motion.div
@@ -290,7 +332,7 @@ export default function GradingProgressModal({
                 )}
 
                 <div className="mb-8 relative">
-                  {status === "processing" ? (
+                  {isWorking ? (
                     <div className="relative w-40 h-40 mx-auto">
                       {/* Outer glow ring */}
                       <motion.div
@@ -416,7 +458,9 @@ export default function GradingProgressModal({
                           className={`absolute inset-0 rounded-full blur-2xl ${
                             status === "completed"
                               ? "bg-green-500/40"
-                              : "bg-red-500/40"
+                              : status === "disconnected"
+                                ? "bg-amber-500/40"
+                                : "bg-red-500/40"
                           }`}
                           animate={{
                             scale: [1, 1.2, 1],
@@ -489,8 +533,10 @@ export default function GradingProgressModal({
                   className="text-2xl font-bold mb-3 bg-gradient-to-r from-gray-800 via-gray-900 to-gray-800 dark:from-gray-100 dark:via-white dark:to-gray-100 bg-clip-text text-transparent"
                 >
                   {status === "processing" && "Grading Your Assignment"}
+                  {status === "stalled" && "Still Grading"}
                   {status === "completed" && "🎉 Grading Complete!"}
                   {status === "failed" && "Grading Failed"}
+                  {status === "disconnected" && "We Lost Contact With Grading"}
                 </motion.h3>
 
                 <motion.p
@@ -501,6 +547,58 @@ export default function GradingProgressModal({
                 >
                   {message}
                 </motion.p>
+
+                {status === "stalled" && (
+                  <motion.div
+                    initial={{ opacity: 0, y: 6 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    className="mb-6 px-4 py-3 rounded-xl bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 text-sm text-amber-900 dark:text-amber-200 text-left"
+                    role="status"
+                  >
+                    <p className="font-semibold mb-1">
+                      Grading is running long
+                    </p>
+                    <p>
+                      Your answers are submitted and grading is still running.
+                      You can keep waiting, ask for an email when it finishes,
+                      or tell us about it.
+                    </p>
+                    <div className="mt-3">
+                      <ReportErrorButton error={errorReportContext} />
+                    </div>
+                  </motion.div>
+                )}
+
+                {status === "disconnected" && (
+                  <motion.div
+                    initial={{ opacity: 0, y: 6 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    className="mb-6 space-y-3 text-left"
+                  >
+                    <div className="px-4 py-3 rounded-xl bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 text-sm text-amber-900 dark:text-amber-200">
+                      <p className="font-semibold mb-1">
+                        Your submission is safe
+                      </p>
+                      <p>
+                        We stopped receiving updates, so we can&apos;t show you
+                        live progress. Grading may have finished — check your
+                        results, and report this if the grade isn&apos;t there.
+                      </p>
+                    </div>
+                    <div className="flex flex-col sm:flex-row gap-2">
+                      {onCheckResults && (
+                        <button
+                          type="button"
+                          onClick={onCheckResults}
+                          className="inline-flex items-center justify-center rounded-lg bg-purple-600 px-5 py-2.5 text-sm font-semibold text-white shadow-md transition hover:bg-purple-700 focus:outline-none focus:ring-2 focus:ring-purple-500 focus:ring-offset-2"
+                        >
+                          Check my results
+                        </button>
+                      )}
+                      <ReportErrorButton error={errorReportContext} />
+                    </div>
+                  </motion.div>
+                )}
 
                 {/* Show grade sync status when grading is complete */}
                 {status === "completed" && attemptId && (
@@ -517,11 +615,11 @@ export default function GradingProgressModal({
                   </motion.div>
                 )}
 
-                {status === "processing" && progressData.gradingState && (
+                {isWorking && progressData.gradingState && (
                   <QuestionGradingList state={progressData.gradingState} />
                 )}
 
-                {status === "processing" && (
+                {isWorking && (
                   <>
                     {/* Modern linear progress bar */}
                     <motion.div

--- a/apps/web/app/learner/(components)/GradingProgressModal.tsx
+++ b/apps/web/app/learner/(components)/GradingProgressModal.tsx
@@ -245,15 +245,24 @@ export default function GradingProgressModal({
     }
   };
 
-  const errorReportContext = {
-    statusCode: 0,
-    headline:
-      status === "stalled"
-        ? "Grading stopped responding"
-        : "Lost contact with the grading service",
-    message: progressData.currentStage,
-    context: `Assignment ${assignmentId}, attempt ${attemptId ?? "unknown"}`,
-  };
+  // Memoized so the identity only changes when the content actually does.
+  // ReportErrorButton feeds this straight into a useMemo keyed on this
+  // object, which feeds ReportPreviewModal's field-reset effects — a fresh
+  // object here on every render (this modal re-renders on several store
+  // subscriptions upstream) silently wipes whatever the learner has typed
+  // into an open report form.
+  const errorReportContext = useMemo(
+    () => ({
+      statusCode: 0,
+      headline:
+        status === "stalled"
+          ? "Grading stopped responding"
+          : "Lost contact with the grading service",
+      message: progressData.currentStage,
+      context: `Assignment ${assignmentId}, attempt ${attemptId ?? "unknown"}`,
+    }),
+    [status, progressData.currentStage, assignmentId, attemptId],
+  );
 
   return (
     <AnimatePresence>

--- a/apps/web/app/learner/(components)/Header.tsx
+++ b/apps/web/app/learner/(components)/Header.tsx
@@ -44,9 +44,32 @@ import Button from "../../../components/Button";
 import GradingProgressModal, {
   type ProgressState,
 } from "./GradingProgressModal";
+import type { GradingProgressStatus } from "@/lib/learner";
 
 const TRANSLATION_PREVIEW_DISABLED_TOOLTIP =
   "Translations are only available after publishing this assignment. Publish to preview translated content.";
+
+/**
+ * Bridges the grading stream's five-state status vocabulary onto the modal's
+ * current four states. The modal does not yet have dedicated "stalled" /
+ * "disconnected" treatments, so this keeps behavior identical to before that
+ * type widened: a stall stays in the ordinary "processing" look (the stream
+ * is still open, nothing destructive happened) and a lost stream reuses the
+ * existing "failed" state so the learner sees the same error affordance a
+ * real grading failure would show.
+ */
+function toModalStatus(
+  status: GradingProgressStatus,
+): ProgressState["status"] {
+  switch (status) {
+    case "stalled":
+      return "processing";
+    case "disconnected":
+      return "failed";
+    default:
+      return status;
+  }
+}
 
 function LearnerHeader() {
   const pathname = usePathname();
@@ -328,7 +351,7 @@ function LearnerHeader() {
         undefined,
         (status, progress, message, metadata) => {
           setProgressData({
-            status,
+            status: toModalStatus(status),
             progress: status === "completed" ? 100 : progress,
             currentStage:
               status === "completed" ? "Grading complete!" : message,

--- a/apps/web/app/learner/(components)/Header.tsx
+++ b/apps/web/app/learner/(components)/Header.tsx
@@ -44,32 +44,10 @@ import Button from "../../../components/Button";
 import GradingProgressModal, {
   type ProgressState,
 } from "./GradingProgressModal";
-import type { GradingProgressStatus } from "@/lib/learner";
+import { isGradingStreamLostError } from "@/lib/learner";
 
 const TRANSLATION_PREVIEW_DISABLED_TOOLTIP =
   "Translations are only available after publishing this assignment. Publish to preview translated content.";
-
-/**
- * Bridges the grading stream's five-state status vocabulary onto the modal's
- * current four states. The modal does not yet have dedicated "stalled" /
- * "disconnected" treatments, so this keeps behavior identical to before that
- * type widened: a stall stays in the ordinary "processing" look (the stream
- * is still open, nothing destructive happened) and a lost stream reuses the
- * existing "failed" state so the learner sees the same error affordance a
- * real grading failure would show.
- */
-function toModalStatus(
-  status: GradingProgressStatus,
-): ProgressState["status"] {
-  switch (status) {
-    case "stalled":
-      return "processing";
-    case "disconnected":
-      return "failed";
-    default:
-      return status;
-  }
-}
 
 function LearnerHeader() {
   const pathname = usePathname();
@@ -350,15 +328,28 @@ function LearnerHeader() {
         role === "author" ? authorAssignmentDetails : undefined,
         undefined,
         (status, progress, message, metadata) => {
-          setProgressData({
-            status: toModalStatus(status),
+          // "processing" and "stalled" are non-terminal: the stream is still
+          // open and grading is still (or again) advancing, so a frame with
+          // no metadata (e.g. a bare "Reconnecting..." message) must not wipe
+          // out the question list/progress the learner already saw. Terminal
+          // statuses ("completed", "failed", "disconnected") replace outright
+          // — each is a definite transition, not an update to carry forward.
+          const isNonTerminal = status === "processing" || status === "stalled";
+          setProgressData((prev) => ({
+            status,
             progress: status === "completed" ? 100 : progress,
             currentStage:
               status === "completed" ? "Grading complete!" : message,
-            currentQuestion: metadata?.currentQuestion,
-            totalQuestions: metadata?.totalQuestions,
-            gradingState: metadata?.gradingState,
-          });
+            currentQuestion:
+              metadata?.currentQuestion ??
+              (isNonTerminal ? prev.currentQuestion : undefined),
+            totalQuestions:
+              metadata?.totalQuestions ??
+              (isNonTerminal ? prev.totalQuestions : undefined),
+            gradingState:
+              metadata?.gradingState ??
+              (isNonTerminal ? prev.gradingState : undefined),
+          }));
         },
         undefined,
       );
@@ -427,10 +418,19 @@ function LearnerHeader() {
       }
     } catch (error) {
       setSubmitting(false);
+      submitInFlightRef.current = false;
+
+      if (isGradingStreamLostError(error)) {
+        // The submission itself succeeded — only our view of it died. Leave
+        // the modal up in its "lost contact" state so the learner can check
+        // their results or report the problem, instead of dropping them back
+        // onto the questions page with nothing to act on.
+        return;
+      }
+
       setTimeout(() => {
         setShowGradingModal(false);
       }, 2000);
-      submitInFlightRef.current = false;
       return;
     }
   }, [
@@ -693,6 +693,16 @@ function LearnerHeader() {
         assignmentId={assignmentId || 0}
         attemptId={currentAttemptId}
         progressData={progressData}
+        onCheckResults={
+          assignmentId && currentAttemptId
+            ? () => {
+                setShowGradingModal(false);
+                router.push(
+                  `/learner/${assignmentId}/successPage/${currentAttemptId}`,
+                );
+              }
+            : undefined
+        }
       />
     </>
   );

--- a/apps/web/app/learner/(components)/Question/Timer.tsx
+++ b/apps/web/app/learner/(components)/Question/Timer.tsx
@@ -5,6 +5,7 @@ import type {
 } from "@/config/types";
 import { useAssignmentId } from "@/hooks/use-assignment-id";
 import useCountdown from "@/hooks/use-countdown";
+import { isGradingStreamLostError } from "@/lib/learner";
 import { cn } from "@/lib/strings";
 import { getUser, submitAssignment } from "@/lib/talkToBackend";
 import {
@@ -165,6 +166,20 @@ function Timer(props: Props) {
       // Auto-submit runs from a fire-and-forget setTimeout; without this catch a
       // 401/network rejection is an unhandled promise and the learner is told
       // their work "will be graded automatically" while it was silently lost.
+      if (isGradingStreamLostError(error)) {
+        // The submission itself went through — only the grading status
+        // stream gave up watching it. Telling the learner to resubmit here
+        // would be actively wrong (their answers are already in) and risks
+        // a duplicate attempt, so this reuses the stream's own honest
+        // message instead of the generic "try again" copy below.
+        console.error("[learner] auto-submit lost the grading stream", {
+          assignmentId,
+          activeAttemptId,
+          reason: error.reason,
+        });
+        toast.error(error.message);
+        return;
+      }
       console.error("[learner] auto-submit failed", {
         assignmentId,
         activeAttemptId,

--- a/apps/web/app/learner/(components)/Question/__tests__/Timer.test.tsx
+++ b/apps/web/app/learner/(components)/Question/__tests__/Timer.test.tsx
@@ -5,6 +5,7 @@
 import { render, act } from "@testing-library/react";
 import { toast } from "sonner";
 import type { QuestionStore } from "@/config/types";
+import { GradingStreamLostError } from "@/lib/learner";
 import { useAssignmentDetails, useLearnerStore } from "@/stores/learner";
 import Timer from "../Timer";
 
@@ -95,5 +96,29 @@ describe("Timer auto-submit", () => {
 
     expect(mockSubmitAssignment).toHaveBeenCalled();
     expect(toast.error).toHaveBeenCalled();
+  });
+
+  it("tells the learner their answers were submitted when the grading stream is lost, instead of prompting a resubmission", async () => {
+    mockUseParams.mockReturnValue({ assignmentId: "3428" });
+    // The submission succeeded server-side; only the watchdog gave up on the
+    // stream. The generic "use the Submit button to try again" copy would be
+    // actively wrong here and risks a duplicate attempt.
+    const lostStreamMessage =
+      "We lost contact with the grading service. Your answers were submitted — check your results in a moment.";
+    mockSubmitAssignment.mockRejectedValue(
+      new GradingStreamLostError(lostStreamMessage, 3428, 999, "disconnected"),
+    );
+
+    render(<Timer />);
+
+    await act(async () => {
+      jest.advanceTimersByTime(2100);
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(mockSubmitAssignment).toHaveBeenCalled();
+    expect(toast.error).toHaveBeenCalledWith(lostStreamMessage);
   });
 });

--- a/apps/web/app/learner/(components)/__tests__/GradingProgressModal.test.tsx
+++ b/apps/web/app/learner/(components)/__tests__/GradingProgressModal.test.tsx
@@ -1,0 +1,112 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import React, { createElement } from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import GradingProgressModal, {
+  type ProgressState,
+} from "../GradingProgressModal";
+
+jest.mock("sonner", () => ({
+  toast: { error: jest.fn(), success: jest.fn(), info: jest.fn() },
+}));
+
+jest.mock("@/lib/learner", () => ({
+  subscribeToGradingNotification: jest.fn().mockResolvedValue({
+    success: true,
+    message: "ok",
+  }),
+}));
+
+jest.mock("@/components/GradeSyncStatus", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.mock("@/components/ReportErrorButton", () => ({
+  __esModule: true,
+  default: () =>
+    createElement("button", { "data-testid": "report-error" }, "Report this issue"),
+}));
+
+const baseState: ProgressState = {
+  status: "processing",
+  progress: 40,
+  currentStage: "Grading 2 of 5 questions complete",
+};
+
+const renderModal = (
+  overrides: Partial<ProgressState>,
+  onCheckResults?: () => void,
+) =>
+  render(
+    <GradingProgressModal
+      isOpen
+      assignmentId={11}
+      attemptId={22}
+      progressData={{ ...baseState, ...overrides }}
+      onCheckResults={onCheckResults}
+    />,
+  );
+
+describe("GradingProgressModal stalled state", () => {
+  it("keeps the spinner and tells the learner grading is still running", () => {
+    renderModal({
+      status: "stalled",
+      currentStage:
+        "This is taking longer than usual. Your answers are submitted and grading is still running.",
+    });
+
+    expect(screen.getByText("Still Grading")).toBeInTheDocument();
+    expect(
+      screen.getByText(/taking longer than usual/i),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("report-error")).toBeInTheDocument();
+  });
+
+  it("still offers the email-when-done escape hatch while stalled", () => {
+    renderModal({ status: "stalled" });
+
+    expect(screen.getByText("Get email when done")).toBeInTheDocument();
+  });
+});
+
+describe("GradingProgressModal disconnected state", () => {
+  it("says contact was lost, not that grading failed", () => {
+    renderModal({
+      status: "disconnected",
+      currentStage:
+        "We lost contact with the grading service. Your answers were submitted — check your results in a moment.",
+    });
+
+    expect(screen.getByText("We Lost Contact With Grading")).toBeInTheDocument();
+    expect(screen.queryByText("Grading Failed")).not.toBeInTheDocument();
+    expect(screen.getByText(/answers were submitted/i)).toBeInTheDocument();
+  });
+
+  it("offers a results re-check and the standard report button", () => {
+    const onCheckResults = jest.fn();
+    renderModal({ status: "disconnected" }, onCheckResults);
+
+    fireEvent.click(screen.getByText("Check my results"));
+
+    expect(onCheckResults).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId("report-error")).toBeInTheDocument();
+  });
+
+  it("hides the re-check action when the caller supplies no handler", () => {
+    renderModal({ status: "disconnected" });
+
+    expect(screen.queryByText("Check my results")).not.toBeInTheDocument();
+  });
+});
+
+describe("GradingProgressModal existing states", () => {
+  it("still renders the failure state for a real grading failure", () => {
+    renderModal({ status: "failed", currentStage: "Grading failed" });
+
+    expect(screen.getByText("Grading Failed")).toBeInTheDocument();
+    expect(screen.queryByText("Check my results")).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/app/learner/(components)/__tests__/GradingProgressModal.test.tsx
+++ b/apps/web/app/learner/(components)/__tests__/GradingProgressModal.test.tsx
@@ -24,10 +24,22 @@ jest.mock("@/components/GradeSyncStatus", () => ({
   default: () => null,
 }));
 
+// Captures every `error` prop ReportErrorButton receives so tests can assert
+// on its referential identity across re-renders. Name must start with
+// "mock" — Jest's module-factory hoisting only allows out-of-scope
+// references to identifiers matching that prefix.
+const mockReportErrorProps: unknown[] = [];
+
 jest.mock("@/components/ReportErrorButton", () => ({
   __esModule: true,
-  default: () =>
-    createElement("button", { "data-testid": "report-error" }, "Report this issue"),
+  default: (props: { error: unknown }) => {
+    mockReportErrorProps.push(props.error);
+    return createElement(
+      "button",
+      { "data-testid": "report-error" },
+      "Report this issue",
+    );
+  },
 }));
 
 const baseState: ProgressState = {
@@ -50,6 +62,32 @@ const renderModal = (
     />,
   );
 
+beforeEach(() => {
+  mockReportErrorProps.length = 0;
+});
+
+describe("GradingProgressModal error report context identity", () => {
+  it("keeps the report context reference stable across a re-render that leaves status and stage unchanged", () => {
+    const { rerender } = renderModal({ status: "stalled" });
+
+    // Simulates the real trigger: the modal re-renders (e.g. progress ticking
+    // up) while the status and stage the learner is looking at haven't
+    // changed. Before the fix, the inline object literal was recreated on
+    // every render regardless, which reset any in-progress report form.
+    rerender(
+      <GradingProgressModal
+        isOpen
+        assignmentId={11}
+        attemptId={22}
+        progressData={{ ...baseState, status: "stalled", progress: 55 }}
+      />,
+    );
+
+    expect(mockReportErrorProps).toHaveLength(2);
+    expect(mockReportErrorProps[1]).toBe(mockReportErrorProps[0]);
+  });
+});
+
 describe("GradingProgressModal stalled state", () => {
   it("keeps the spinner and tells the learner grading is still running", () => {
     renderModal({
@@ -59,9 +97,7 @@ describe("GradingProgressModal stalled state", () => {
     });
 
     expect(screen.getByText("Still Grading")).toBeInTheDocument();
-    expect(
-      screen.getByText(/taking longer than usual/i),
-    ).toBeInTheDocument();
+    expect(screen.getByText(/taking longer than usual/i)).toBeInTheDocument();
     expect(screen.getByTestId("report-error")).toBeInTheDocument();
   });
 
@@ -80,7 +116,9 @@ describe("GradingProgressModal disconnected state", () => {
         "We lost contact with the grading service. Your answers were submitted — check your results in a moment.",
     });
 
-    expect(screen.getByText("We Lost Contact With Grading")).toBeInTheDocument();
+    expect(
+      screen.getByText("We Lost Contact With Grading"),
+    ).toBeInTheDocument();
     expect(screen.queryByText("Grading Failed")).not.toBeInTheDocument();
     expect(screen.getByText(/answers were submitted/i)).toBeInTheDocument();
   });

--- a/apps/web/app/learner/(components)/__tests__/Header.test.tsx
+++ b/apps/web/app/learner/(components)/__tests__/Header.test.tsx
@@ -207,7 +207,7 @@ describe("LearnerHeader submit path", () => {
     );
   });
 
-  it("keeps the grading modal open when the grading stream is lost", async () => {
+  it("keeps the grading modal open showing disconnected when the grading stream is lost", async () => {
     const { isGradingStreamLostError } = jest.requireActual("@/lib/learner");
     expect(isGradingStreamLostError).toBeDefined();
 
@@ -220,7 +220,26 @@ describe("LearnerHeader submit path", () => {
 
     mockUseParams.mockReturnValue({ assignmentId: "3428" });
     seedLearnerState(null);
-    mockSubmitAssignment.mockRejectedValue(new GradingStreamLostError());
+
+    // Mirrors the real watchdog (lib/learner.ts's handleStreamLost): it
+    // reports the terminal "disconnected" frame through onProgress before
+    // rejecting with GradingStreamLostError. Capturing the real onProgress
+    // closure and driving it the same way proves the full chain — rejection
+    // sets the status, and the modal stays up showing it — rather than only
+    // asserting the modal is still mounted.
+    mockSubmitAssignment.mockImplementation((...args: unknown[]) => {
+      const onProgress = args[7] as (
+        status: string,
+        progress: number,
+        message: string,
+      ) => void;
+      onProgress(
+        "disconnected",
+        0,
+        "We lost contact with the grading service. Your answers were submitted — check your results in a moment.",
+      );
+      return Promise.reject(new GradingStreamLostError());
+    });
 
     jest.useFakeTimers();
     try {
@@ -233,7 +252,9 @@ describe("LearnerHeader submit path", () => {
         jest.advanceTimersByTime(5000);
       });
 
-      expect(screen.getByTestId("grading-modal")).toBeInTheDocument();
+      const modal = screen.getByTestId("grading-modal");
+      expect(modal).toBeInTheDocument();
+      expect(modal).toHaveAttribute("data-status", "disconnected");
     } finally {
       jest.useRealTimers();
     }

--- a/apps/web/app/learner/(components)/__tests__/Header.test.tsx
+++ b/apps/web/app/learner/(components)/__tests__/Header.test.tsx
@@ -36,6 +36,11 @@ jest.mock("@/lib/talkToBackend", () => ({
   getUser: jest.fn().mockResolvedValue({ role: "learner", returnUrl: "" }),
 }));
 
+jest.mock("@/lib/learner", () => ({
+  ...jest.requireActual("@/lib/learner"),
+  subscribeToGradingNotification: jest.fn(),
+}));
+
 jest.mock("sonner", () => ({
   toast: {
     error: jest.fn(),
@@ -52,11 +57,18 @@ jest.mock("@/app/chatbot/store/useMarkChatStore", () => ({
 }));
 
 // --- presentational children stubbed to keep the render tree light ---
+// The status is surfaced as a data attribute (not just isOpen) so tests can
+// prove the widened "stalled"/"disconnected" statuses actually reach this
+// component through Header's onProgress callsite, rather than only checking
+// that the modal itself renders them correctly in isolation.
 jest.mock("../GradingProgressModal", () => ({
   __esModule: true,
-  default: (props: { isOpen?: boolean }) =>
+  default: (props: { isOpen?: boolean; progressData?: { status?: string } }) =>
     props.isOpen
-      ? createElement("div", { "data-testid": "grading-modal" })
+      ? createElement("div", {
+          "data-testid": "grading-modal",
+          "data-status": props.progressData?.status,
+        })
       : null,
 }));
 jest.mock("@/components/Button", () => ({
@@ -150,5 +162,80 @@ describe("LearnerHeader submit path", () => {
     expect(screen.queryByTestId("grading-modal")).not.toBeInTheDocument();
     expect(toast.error).toHaveBeenCalled();
     expect(mockSubmitAssignment).not.toHaveBeenCalled();
+  });
+
+  it("passes the widened stalled/disconnected statuses through to the modal untouched", async () => {
+    // Guards against a regression to the old bridge that collapsed
+    // stalled -> processing and disconnected -> failed at this callsite: if
+    // that mapping ever comes back, the modal would never see its dedicated
+    // states even though GradingProgressModal itself renders them correctly.
+    mockUseParams.mockReturnValue({ assignmentId: "3428" });
+    seedLearnerState(null);
+
+    let capturedOnProgress:
+      | ((
+          status: string,
+          progress: number,
+          message: string,
+          metadata?: unknown,
+        ) => void)
+      | undefined;
+    mockSubmitAssignment.mockImplementation(
+      (...args: unknown[]) =>
+        new Promise(() => {
+          capturedOnProgress = args[7] as typeof capturedOnProgress;
+        }),
+    );
+
+    render(<LearnerHeader />);
+    await triggerSubmit();
+
+    act(() => {
+      capturedOnProgress?.("stalled", 40, "still going");
+    });
+    expect(screen.getByTestId("grading-modal")).toHaveAttribute(
+      "data-status",
+      "stalled",
+    );
+
+    act(() => {
+      capturedOnProgress?.("disconnected", 0, "lost contact");
+    });
+    expect(screen.getByTestId("grading-modal")).toHaveAttribute(
+      "data-status",
+      "disconnected",
+    );
+  });
+
+  it("keeps the grading modal open when the grading stream is lost", async () => {
+    const { isGradingStreamLostError } = jest.requireActual("@/lib/learner");
+    expect(isGradingStreamLostError).toBeDefined();
+
+    class GradingStreamLostError extends Error {
+      constructor() {
+        super("We lost contact with the grading service.");
+        this.name = "GradingStreamLostError";
+      }
+    }
+
+    mockUseParams.mockReturnValue({ assignmentId: "3428" });
+    seedLearnerState(null);
+    mockSubmitAssignment.mockRejectedValue(new GradingStreamLostError());
+
+    jest.useFakeTimers();
+    try {
+      render(<LearnerHeader />);
+
+      await act(async () => {
+        window.dispatchEvent(new Event("triggerAssignmentSubmission"));
+      });
+      await act(async () => {
+        jest.advanceTimersByTime(5000);
+      });
+
+      expect(screen.getByTestId("grading-modal")).toBeInTheDocument();
+    } finally {
+      jest.useRealTimers();
+    }
   });
 });

--- a/apps/web/hooks/__tests__/use-auto-save-response.test.ts
+++ b/apps/web/hooks/__tests__/use-auto-save-response.test.ts
@@ -5,6 +5,7 @@ import { renderHook, waitFor } from "@testing-library/react";
 import { useAutoSaveResponse } from "../use-auto-save-response";
 import { useLearnerStore } from "@/stores/learner";
 import { submitQuestion } from "@/lib/talkToBackend";
+import { toast } from "sonner";
 
 jest.mock("@/lib/talkToBackend");
 jest.mock("@/stores/learner");
@@ -79,7 +80,7 @@ describe("useAutoSaveResponse", () => {
     const attemptId = 456;
     const questionId = 789;
 
-    mockSubmitQuestion.mockResolvedValue({} as any);
+    mockSubmitQuestion.mockResolvedValue({ ok: true, data: {} as any });
 
     const { rerender } = renderHook(() =>
       useAutoSaveResponse(assignmentId, attemptId, questionId, {
@@ -115,7 +116,7 @@ describe("useAutoSaveResponse", () => {
     const attemptId = 456;
     const questionId = 789;
 
-    mockSubmitQuestion.mockResolvedValue({} as any);
+    mockSubmitQuestion.mockResolvedValue({ ok: true, data: {} as any });
 
     const { rerender } = renderHook(() =>
       useAutoSaveResponse(assignmentId, attemptId, questionId, {
@@ -137,7 +138,7 @@ describe("useAutoSaveResponse", () => {
     const attemptId = 456;
     const questionId = 789;
 
-    mockSubmitQuestion.mockResolvedValue({} as any);
+    mockSubmitQuestion.mockResolvedValue({ ok: true, data: {} as any });
 
     const { rerender } = renderHook(() =>
       useAutoSaveResponse(assignmentId, attemptId, questionId, {
@@ -180,7 +181,7 @@ describe("useAutoSaveResponse", () => {
     const attemptId = 456;
     const questionId = 789;
 
-    mockSubmitQuestion.mockResolvedValue({} as any);
+    mockSubmitQuestion.mockResolvedValue({ ok: true, data: {} as any });
 
     const { rerender } = renderHook(() =>
       useAutoSaveResponse(assignmentId, attemptId, questionId, {
@@ -203,7 +204,7 @@ describe("useAutoSaveResponse", () => {
   });
 
   it("should not save when assignmentId or attemptId is null", async () => {
-    mockSubmitQuestion.mockResolvedValue({} as any);
+    mockSubmitQuestion.mockResolvedValue({ ok: true, data: {} as any });
 
     const { rerender } = renderHook(() =>
       useAutoSaveResponse(null, null, 789, {
@@ -225,47 +226,12 @@ describe("useAutoSaveResponse", () => {
     });
   });
 
-  it("should handle save errors gracefully", async () => {
-    const assignmentId = 123;
-    const attemptId = 456;
-    const questionId = 789;
-
-    mockSubmitQuestion.mockRejectedValue(new Error("Network error"));
-
-    const consoleError = jest.spyOn(console, "error").mockImplementation();
-
-    const { rerender } = renderHook(() =>
-      useAutoSaveResponse(assignmentId, attemptId, questionId, {
-        enabled: true,
-        debounceMs: 1000,
-      }),
-    );
-
-    (useLearnerStore as unknown as jest.Mock).mockReturnValue({
-      id: 789,
-      learnerTextResponse: "Test answer",
-    });
-    rerender();
-
-    jest.advanceTimersByTime(1000);
-
-    await waitFor(() => {
-      expect(mockSubmitQuestion).toHaveBeenCalled();
-      expect(consoleError).toHaveBeenCalledWith(
-        "Auto-save failed:",
-        expect.any(Error),
-      );
-    });
-
-    consoleError.mockRestore();
-  });
-
   it("should support immediate save via saveNow", async () => {
     const assignmentId = 123;
     const attemptId = 456;
     const questionId = 789;
 
-    mockSubmitQuestion.mockResolvedValue({} as any);
+    mockSubmitQuestion.mockResolvedValue({ ok: true, data: {} as any });
 
     (useLearnerStore as unknown as jest.Mock).mockReturnValue({
       id: 789,
@@ -326,7 +292,7 @@ describe("useAutoSaveResponse", () => {
     const attemptId = 456;
     const questionId = 789;
 
-    mockSubmitQuestion.mockResolvedValue({} as any);
+    mockSubmitQuestion.mockResolvedValue({ ok: true, data: {} as any });
 
     let selectedIndices: number[] | undefined = undefined;
 
@@ -387,7 +353,7 @@ describe("useAutoSaveResponse", () => {
     const attemptId = 456;
     const questionId = 789;
 
-    mockSubmitQuestion.mockResolvedValue({} as any);
+    mockSubmitQuestion.mockResolvedValue({ ok: true, data: {} as any });
 
     (useLearnerStore as unknown as jest.Mock).mockImplementation((selector) => {
       const mockState = {
@@ -436,13 +402,13 @@ describe("useAutoSaveResponse", () => {
     const questionId = 789;
 
     let resolveFirstSave: () => void;
-    const firstSavePromise = new Promise<void>((resolve) => {
-      resolveFirstSave = resolve;
+    const firstSavePromise = new Promise((resolve) => {
+      resolveFirstSave = () => resolve({ ok: true, data: {} as any });
     });
 
     mockSubmitQuestion
       .mockReturnValueOnce(firstSavePromise as any)
-      .mockResolvedValue({} as any);
+      .mockResolvedValue({ ok: true, data: {} as any });
 
     (useLearnerStore as unknown as jest.Mock).mockImplementation((selector) => {
       const mockState = {
@@ -501,5 +467,194 @@ describe("useAutoSaveResponse", () => {
     expect(mockSubmitQuestion).toHaveBeenCalledTimes(1);
 
     resolveFirstSave();
+  });
+
+  it("does not show a false success toast when the save fails", async () => {
+    const assignmentId = 123;
+    const attemptId = 456;
+    const questionId = 789;
+
+    mockSubmitQuestion.mockResolvedValue({
+      ok: false,
+      status: 400,
+      message:
+        "Your submission is too large for automatic grading. Try reducing its length and submit it again.",
+    });
+
+    const { rerender } = renderHook(() =>
+      useAutoSaveResponse(assignmentId, attemptId, questionId, {
+        enabled: true,
+        debounceMs: 1000,
+        showToast: true,
+      }),
+    );
+
+    mockStoreWithQuestion(questionId, { learnerTextResponse: "Test answer" });
+    rerender();
+    jest.advanceTimersByTime(1000);
+
+    await waitFor(() => {
+      expect(mockSubmitQuestion).toHaveBeenCalled();
+    });
+
+    expect(toast.success).not.toHaveBeenCalled();
+    expect(toast.error).toHaveBeenCalledWith(
+      "Your submission is too large for automatic grading. Try reducing its length and submit it again.",
+      { duration: 8000 },
+    );
+  });
+
+  it("does not retry a terminal 4xx failure (resubmitting the same oversized payload cannot succeed)", async () => {
+    const assignmentId = 123;
+    const attemptId = 456;
+    const questionId = 789;
+
+    mockSubmitQuestion.mockResolvedValue({ ok: false, status: 400 });
+
+    const { rerender } = renderHook(() =>
+      useAutoSaveResponse(assignmentId, attemptId, questionId, {
+        enabled: true,
+        debounceMs: 1000,
+      }),
+    );
+
+    mockStoreWithQuestion(questionId, { learnerTextResponse: "Test answer" });
+    rerender();
+    jest.advanceTimersByTime(1000);
+
+    await waitFor(() => {
+      expect(mockSubmitQuestion).toHaveBeenCalledTimes(1);
+    });
+
+    // Advance past every backoff window in the retry schedule — a terminal
+    // failure must not produce a second call.
+    jest.advanceTimersByTime(30_000);
+    expect(mockSubmitQuestion).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries a transient failure on the documented backoff schedule, then gives up honestly", async () => {
+    const assignmentId = 123;
+    const attemptId = 456;
+    const questionId = 789;
+
+    mockSubmitQuestion.mockResolvedValue({ ok: false, status: 503 });
+
+    const { rerender } = renderHook(() =>
+      useAutoSaveResponse(assignmentId, attemptId, questionId, {
+        enabled: true,
+        debounceMs: 1000,
+      }),
+    );
+
+    mockStoreWithQuestion(questionId, { learnerTextResponse: "Test answer" });
+    rerender();
+    jest.advanceTimersByTime(1000);
+
+    await waitFor(() => {
+      expect(mockSubmitQuestion).toHaveBeenCalledTimes(1);
+    });
+
+    jest.advanceTimersByTime(2000);
+    await waitFor(() => expect(mockSubmitQuestion).toHaveBeenCalledTimes(2));
+
+    jest.advanceTimersByTime(5000);
+    await waitFor(() => expect(mockSubmitQuestion).toHaveBeenCalledTimes(3));
+
+    jest.advanceTimersByTime(10_000);
+    await waitFor(() => expect(mockSubmitQuestion).toHaveBeenCalledTimes(4));
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith(
+        "We couldn't save your last response after several tries. Copy it somewhere safe, then reload the page and try again.",
+        { duration: 8000 },
+      );
+    });
+
+    // All 3 retries (4 attempts total) are exhausted — no fifth attempt.
+    jest.advanceTimersByTime(30_000);
+    expect(mockSubmitQuestion).toHaveBeenCalledTimes(4);
+  });
+
+  it("recovers silently if a retry succeeds (no error toast, no further retries)", async () => {
+    const assignmentId = 123;
+    const attemptId = 456;
+    const questionId = 789;
+
+    mockSubmitQuestion
+      .mockResolvedValueOnce({ ok: false, status: 503 })
+      .mockResolvedValueOnce({ ok: true, data: {} as any });
+
+    const { rerender } = renderHook(() =>
+      useAutoSaveResponse(assignmentId, attemptId, questionId, {
+        enabled: true,
+        debounceMs: 1000,
+      }),
+    );
+
+    mockStoreWithQuestion(questionId, { learnerTextResponse: "Test answer" });
+    rerender();
+    jest.advanceTimersByTime(1000);
+
+    await waitFor(() => expect(mockSubmitQuestion).toHaveBeenCalledTimes(1));
+
+    jest.advanceTimersByTime(2000);
+    await waitFor(() => expect(mockSubmitQuestion).toHaveBeenCalledTimes(2));
+
+    expect(toast.error).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(30_000);
+    expect(mockSubmitQuestion).toHaveBeenCalledTimes(2);
+  });
+
+  it("never marks a failed save as saved: a reverted edit after a terminal failure still gets saved", async () => {
+    const assignmentId = 123;
+    const attemptId = 456;
+    const questionId = 789;
+
+    // Every attempt in this test fails terminally, so nothing here is ever
+    // retried automatically — each call below is driven by a genuine edit.
+    mockSubmitQuestion.mockResolvedValue({ ok: false, status: 400 });
+
+    const { rerender } = renderHook(() =>
+      useAutoSaveResponse(assignmentId, attemptId, questionId, {
+        enabled: true,
+        debounceMs: 1000,
+      }),
+    );
+
+    mockStoreWithQuestion(questionId, { learnerTextResponse: "abc" });
+    rerender();
+    jest.advanceTimersByTime(1000);
+    await waitFor(() => {
+      expect(mockSubmitQuestion).toHaveBeenLastCalledWith(
+        assignmentId,
+        attemptId,
+        questionId,
+        expect.objectContaining({ learnerTextResponse: "abc" }),
+      );
+    });
+    expect(mockSubmitQuestion).toHaveBeenCalledTimes(1);
+
+    mockStoreWithQuestion(questionId, { learnerTextResponse: "abcd" });
+    rerender();
+    jest.advanceTimersByTime(1000);
+    await waitFor(() => expect(mockSubmitQuestion).toHaveBeenCalledTimes(2));
+
+    // Revert to the exact text that already failed once. If the earlier
+    // failure had (bug) marked "abc" as saved, this would be silently
+    // skipped as "unchanged since last save" and submitQuestion would not
+    // be called a third time.
+    mockStoreWithQuestion(questionId, { learnerTextResponse: "abc" });
+    rerender();
+    jest.advanceTimersByTime(1000);
+    await waitFor(() => {
+      expect(mockSubmitQuestion).toHaveBeenCalledTimes(3);
+      expect(mockSubmitQuestion).toHaveBeenLastCalledWith(
+        assignmentId,
+        attemptId,
+        questionId,
+        expect.objectContaining({ learnerTextResponse: "abc" }),
+      );
+    });
   });
 });

--- a/apps/web/hooks/__tests__/use-auto-save-response.test.ts
+++ b/apps/web/hooks/__tests__/use-auto-save-response.test.ts
@@ -657,4 +657,195 @@ describe("useAutoSaveResponse", () => {
       );
     });
   });
+
+  it("cancels a stale pending retry when a fresh edit arrives, and saves the fresh payload instead", async () => {
+    const assignmentId = 123;
+    const attemptId = 456;
+    const questionId = 789;
+
+    mockSubmitQuestion
+      .mockResolvedValueOnce({ ok: false, status: 503 })
+      .mockResolvedValue({ ok: true, data: {} as any });
+
+    const { rerender } = renderHook(() =>
+      useAutoSaveResponse(assignmentId, attemptId, questionId, {
+        enabled: true,
+        debounceMs: 1000,
+      }),
+    );
+
+    mockStoreWithQuestion(questionId, { learnerTextResponse: "abc" });
+    rerender();
+    jest.advanceTimersByTime(1000);
+    await waitFor(() => expect(mockSubmitQuestion).toHaveBeenCalledTimes(1));
+
+    // The first attempt just failed transiently and is now waiting to
+    // retry at +2000ms. Before that fires, a fresh edit arrives.
+    jest.advanceTimersByTime(500);
+
+    mockStoreWithQuestion(questionId, { learnerTextResponse: "abcd" });
+    rerender();
+    jest.advanceTimersByTime(1000);
+
+    await waitFor(() => expect(mockSubmitQuestion).toHaveBeenCalledTimes(2));
+    expect(mockSubmitQuestion).toHaveBeenLastCalledWith(
+      assignmentId,
+      attemptId,
+      questionId,
+      expect.objectContaining({ learnerTextResponse: "abcd" }),
+    );
+
+    // Advance well past when the original retry (scheduled for the stale
+    // "abc" attempt) would have fired — it must have been cancelled, not
+    // merely delayed.
+    jest.advanceTimersByTime(10_000);
+    expect(mockSubmitQuestion).toHaveBeenCalledTimes(2);
+  });
+
+  it("queues a fresh edit that arrives while a save is in flight, and saves it once the stale attempt settles", async () => {
+    const assignmentId = 123;
+    const attemptId = 456;
+    const questionId = 789;
+
+    let resolveFirstSave: (value: unknown) => void;
+    const firstSavePromise = new Promise((resolve) => {
+      resolveFirstSave = resolve;
+    });
+
+    mockSubmitQuestion
+      .mockReturnValueOnce(firstSavePromise as any)
+      .mockResolvedValue({ ok: true, data: {} as any });
+
+    const { rerender } = renderHook(() =>
+      useAutoSaveResponse(assignmentId, attemptId, questionId, {
+        enabled: true,
+        debounceMs: 100,
+      }),
+    );
+
+    mockStoreWithQuestion(questionId, { learnerTextResponse: "abc" });
+    rerender();
+    jest.advanceTimersByTime(100);
+    await waitFor(() => expect(mockSubmitQuestion).toHaveBeenCalledTimes(1));
+
+    // A fresh edit arrives while the first attempt is still awaiting the
+    // network. It must be queued, not dropped.
+    mockStoreWithQuestion(questionId, { learnerTextResponse: "abcd" });
+    rerender();
+    jest.advanceTimersByTime(100);
+
+    // Still only one call: the queued save does not run until the
+    // in-flight attempt settles.
+    expect(mockSubmitQuestion).toHaveBeenCalledTimes(1);
+
+    // The stale attempt now succeeds — its own outcome is superseded by the
+    // queued fresh save, which fires immediately instead.
+    resolveFirstSave({ ok: true, data: {} as any });
+
+    await waitFor(() => expect(mockSubmitQuestion).toHaveBeenCalledTimes(2));
+    expect(mockSubmitQuestion).toHaveBeenLastCalledWith(
+      assignmentId,
+      attemptId,
+      questionId,
+      expect.objectContaining({ learnerTextResponse: "abcd" }),
+    );
+
+    // lastSavedDataRef must reflect the fresh payload, not the stale one: a
+    // later save of the exact same "abcd" text is skipped as unchanged
+    // rather than firing a third call.
+    mockStoreWithQuestion(questionId, { learnerTextResponse: "abcd" });
+    rerender();
+    jest.advanceTimersByTime(100);
+    expect(mockSubmitQuestion).toHaveBeenCalledTimes(2);
+  });
+
+  it("supersedes a stale attempt's retry chain with a queued fresh save when the stale attempt fails", async () => {
+    const assignmentId = 123;
+    const attemptId = 456;
+    const questionId = 789;
+
+    let resolveFirstSave: (value: unknown) => void;
+    const firstSavePromise = new Promise((resolve) => {
+      resolveFirstSave = resolve;
+    });
+
+    mockSubmitQuestion
+      .mockReturnValueOnce(firstSavePromise as any)
+      .mockResolvedValue({ ok: true, data: {} as any });
+
+    const { rerender } = renderHook(() =>
+      useAutoSaveResponse(assignmentId, attemptId, questionId, {
+        enabled: true,
+        debounceMs: 100,
+      }),
+    );
+
+    mockStoreWithQuestion(questionId, { learnerTextResponse: "abc" });
+    rerender();
+    jest.advanceTimersByTime(100);
+    await waitFor(() => expect(mockSubmitQuestion).toHaveBeenCalledTimes(1));
+
+    mockStoreWithQuestion(questionId, { learnerTextResponse: "abcd" });
+    rerender();
+    jest.advanceTimersByTime(100);
+    expect(mockSubmitQuestion).toHaveBeenCalledTimes(1);
+
+    // The stale attempt fails transiently. Ordinarily this would schedule a
+    // retry of the stale "abc" payload, but the queued fresh edit
+    // supersedes it entirely — no retry of "abc" is ever scheduled.
+    resolveFirstSave({ ok: false, status: 503 });
+
+    await waitFor(() => expect(mockSubmitQuestion).toHaveBeenCalledTimes(2));
+    expect(mockSubmitQuestion).toHaveBeenLastCalledWith(
+      assignmentId,
+      attemptId,
+      questionId,
+      expect.objectContaining({ learnerTextResponse: "abcd" }),
+    );
+
+    // No retry of the stale "abc" payload ever fires, even after every
+    // backoff window in the schedule elapses.
+    jest.advanceTimersByTime(30_000);
+    expect(mockSubmitQuestion).toHaveBeenCalledTimes(2);
+  });
+
+  it("makes an in-flight save's resolution a no-op after unmount: no retry scheduled, no toast shown", async () => {
+    const assignmentId = 123;
+    const attemptId = 456;
+    const questionId = 789;
+
+    let resolveSave: (value: unknown) => void;
+    const savePromise = new Promise((resolve) => {
+      resolveSave = resolve;
+    });
+
+    mockSubmitQuestion.mockReturnValueOnce(savePromise as any);
+
+    const { rerender, unmount } = renderHook(() =>
+      useAutoSaveResponse(assignmentId, attemptId, questionId, {
+        enabled: true,
+        debounceMs: 100,
+      }),
+    );
+
+    mockStoreWithQuestion(questionId, { learnerTextResponse: "Test answer" });
+    rerender();
+    jest.advanceTimersByTime(100);
+    await waitFor(() => expect(mockSubmitQuestion).toHaveBeenCalledTimes(1));
+
+    unmount();
+
+    // The in-flight attempt resolves as a transient failure after the
+    // component is already gone.
+    resolveSave({ ok: false, status: 503 });
+    await waitFor(() => expect(mockSubmitQuestion).toHaveBeenCalledTimes(1));
+
+    // A live component would have scheduled a retry at +2000ms — advance
+    // past the entire backoff schedule to prove none of that happened.
+    jest.advanceTimersByTime(30_000);
+
+    expect(mockSubmitQuestion).toHaveBeenCalledTimes(1);
+    expect(toast.error).not.toHaveBeenCalled();
+    expect(toast.success).not.toHaveBeenCalled();
+  });
 });

--- a/apps/web/hooks/__tests__/use-auto-save-response.test.ts
+++ b/apps/web/hooks/__tests__/use-auto-save-response.test.ts
@@ -500,7 +500,7 @@ describe("useAutoSaveResponse", () => {
     expect(toast.success).not.toHaveBeenCalled();
     expect(toast.error).toHaveBeenCalledWith(
       "Your submission is too large for automatic grading. Try reducing its length and submit it again.",
-      { duration: 8000 },
+      { duration: 8000, id: `autosave-failure-${questionId}` },
     );
   });
 
@@ -530,6 +530,48 @@ describe("useAutoSaveResponse", () => {
     // failure must not produce a second call.
     jest.advanceTimersByTime(30_000);
     expect(mockSubmitQuestion).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses a stable per-question toast id so repeated terminal failures don't stack up a new toast every debounce cycle", async () => {
+    const assignmentId = 123;
+    const attemptId = 456;
+    const questionId = 789;
+
+    mockSubmitQuestion.mockResolvedValue({ ok: false, status: 400 });
+
+    const { rerender } = renderHook(() =>
+      useAutoSaveResponse(assignmentId, attemptId, questionId, {
+        enabled: true,
+        debounceMs: 1000,
+      }),
+    );
+
+    // A learner who keeps typing an answer that still won't save (e.g. it
+    // stays oversized) triggers a fresh terminal failure on every debounce
+    // cycle — each one must reuse the same toast id.
+    mockStoreWithQuestion(questionId, { learnerTextResponse: "abc" });
+    rerender();
+    jest.advanceTimersByTime(1000);
+    await waitFor(() => expect(toast.error).toHaveBeenCalledTimes(1));
+
+    mockStoreWithQuestion(questionId, { learnerTextResponse: "abcd" });
+    rerender();
+    jest.advanceTimersByTime(1000);
+    await waitFor(() => expect(toast.error).toHaveBeenCalledTimes(2));
+
+    mockStoreWithQuestion(questionId, { learnerTextResponse: "abcde" });
+    rerender();
+    jest.advanceTimersByTime(1000);
+    await waitFor(() => expect(toast.error).toHaveBeenCalledTimes(3));
+
+    const idsUsed = (toast.error as jest.Mock).mock.calls.map(
+      (call) => call[1]?.id,
+    );
+    expect(idsUsed).toEqual([
+      `autosave-failure-${questionId}`,
+      `autosave-failure-${questionId}`,
+      `autosave-failure-${questionId}`,
+    ]);
   });
 
   it("retries a transient failure on the documented backoff schedule, then gives up honestly", async () => {
@@ -566,7 +608,7 @@ describe("useAutoSaveResponse", () => {
     await waitFor(() => {
       expect(toast.error).toHaveBeenCalledWith(
         "We couldn't save your last response after several tries. Copy it somewhere safe, then reload the page and try again.",
-        { duration: 8000 },
+        { duration: 8000, id: `autosave-failure-${questionId}` },
       );
     });
 
@@ -847,5 +889,42 @@ describe("useAutoSaveResponse", () => {
     expect(mockSubmitQuestion).toHaveBeenCalledTimes(1);
     expect(toast.error).not.toHaveBeenCalled();
     expect(toast.success).not.toHaveBeenCalled();
+  });
+
+  it("still auto-saves under React StrictMode's double-invoked mount effects", async () => {
+    // Regression test: StrictMode (React 19 dev) runs setup -> cleanup ->
+    // setup on mount for every effect, reusing the same refs across both
+    // invocations. If the mount effect never re-arms isUnmountedRef back to
+    // false, the first (churned) cleanup leaves it permanently true and
+    // every future save resolution silently no-ops. A plain <StrictMode>
+    // wrapper around the rendered element does not reproduce this timing;
+    // the `reactStrictMode` render option is what's required.
+    const assignmentId = 123;
+    const attemptId = 456;
+    const questionId = 789;
+
+    mockSubmitQuestion.mockResolvedValue({ ok: true, data: {} as any });
+
+    const { rerender } = renderHook(
+      () =>
+        useAutoSaveResponse(assignmentId, attemptId, questionId, {
+          enabled: true,
+          debounceMs: 1000,
+        }),
+      { reactStrictMode: true },
+    );
+
+    mockStoreWithQuestion(questionId, { learnerTextResponse: "Test answer" });
+    rerender();
+    jest.advanceTimersByTime(1000);
+
+    await waitFor(() => {
+      expect(mockSubmitQuestion).toHaveBeenCalledWith(
+        assignmentId,
+        attemptId,
+        questionId,
+        expect.objectContaining({ learnerTextResponse: "Test answer" }),
+      );
+    });
   });
 });

--- a/apps/web/hooks/use-auto-save-response.ts
+++ b/apps/web/hooks/use-auto-save-response.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef } from "react";
 import { toast } from "sonner";
-import { submitQuestion } from "@/lib/talkToBackend";
+import { submitQuestion, type SubmitQuestionResult } from "@/lib/talkToBackend";
 import type { QuestionAttemptRequest } from "@/config/types";
 import { useLearnerStore } from "@/stores/learner";
 
@@ -10,10 +10,30 @@ interface AutoSaveConfig {
   showToast?: boolean;
 }
 
+// Backoff schedule for a failed save: 2s, then 5s, then 10s (3 retries, 4
+// attempts total) before giving up and telling the learner to act.
+const RETRY_DELAYS_MS = [2000, 5000, 10_000];
+
+// Statuses where resubmitting the exact same payload will fail identically —
+// retrying just delays telling the learner something needs to change on
+// their end (shorten the answer, log back in). Everything else (no status at
+// all, i.e. a network failure; 408/429/5xx) is treated as transient and
+// retried on the schedule above.
+const AUTOSAVE_TERMINAL_STATUSES = new Set([400, 401, 403, 404, 413, 422]);
+
+const AUTOSAVE_GIVE_UP_MESSAGE =
+  "We couldn't save your last response after several tries. Copy it somewhere safe, then reload the page and try again.";
+
 /**
  * Hook to automatically save question responses to the backend.
  * This ensures that if the timer expires, the learner's work is preserved
  * and can be graded based on their last saved responses.
+ *
+ * A save is only ever considered successful — and only ever marks the
+ * in-memory data as saved / shows a success toast — when the server actually
+ * confirms it. A failed save keeps the data dirty, retries transient
+ * failures with backoff, and eventually shows an honest failure toast
+ * instead of silently giving up.
  *
  * @param assignmentId - The ID of the assignment
  * @param attemptId - The ID of the current attempt
@@ -30,6 +50,7 @@ export function useAutoSaveResponse(
   const { enabled = true, debounceMs = 3000, showToast = false } = config;
 
   const saveTimeoutRef = useRef<NodeJS.Timeout>();
+  const retryTimeoutRef = useRef<NodeJS.Timeout>();
   const isSavingRef = useRef(false);
   const lastSavedDataRef = useRef<string>("");
 
@@ -83,36 +104,89 @@ export function useAutoSaveResponse(
         clearTimeout(saveTimeoutRef.current);
       }
 
-      const performSave = async () => {
+      const performSave = async (attempt = 0) => {
+        // A fresh save attempt (a new edit's debounce firing, or an
+        // immediate saveNow()) always supersedes a stale retry that was
+        // scheduled for an older payload — cancel it rather than let both
+        // fire.
+        if (retryTimeoutRef.current) {
+          clearTimeout(retryTimeoutRef.current);
+          retryTimeoutRef.current = undefined;
+        }
+
         if (isSavingRef.current) return;
 
         isSavingRef.current = true;
+        let result: SubmitQuestionResult;
         try {
-          await submitQuestion(
+          result = await submitQuestion(
             assignmentId,
             attemptId,
             questionId,
             responsePayload,
           );
+        } catch (error) {
+          // submitQuestion is contracted to resolve, never reject. This is a
+          // defensive net against a genuinely unexpected throw so it still
+          // drives the same honest failure/retry path below instead of an
+          // unhandled rejection.
+          console.error("Auto-save threw unexpectedly:", error);
+          result = { ok: false };
+        } finally {
+          isSavingRef.current = false;
+        }
 
+        // Compared against the literal `true` (not a truthy check) because
+        // this project builds with strictNullChecks disabled, under which
+        // TypeScript does not reliably narrow a discriminated union from a
+        // plain `if (result.ok)` — the explicit literal comparison is what
+        // actually narrows `result` to the `ok: false` branch below.
+        if (result.ok === true) {
           lastSavedDataRef.current = currentData;
-
           if (showToast) {
             toast.success("Response saved", {
               duration: 2000,
             });
           }
-        } catch (error) {
-          console.error("Auto-save failed:", error);
-        } finally {
-          isSavingRef.current = false;
+          return;
         }
+
+        // Failure path: lastSavedDataRef is deliberately left untouched so
+        // this payload stays "dirty" — a later identical edit still gets a
+        // fresh save attempt instead of being silently treated as saved.
+        console.error("Auto-save failed:", {
+          assignmentId,
+          attemptId,
+          questionId,
+          status: result.status,
+          attempt,
+        });
+
+        const isTerminal =
+          result.status !== undefined &&
+          AUTOSAVE_TERMINAL_STATUSES.has(result.status);
+
+        if (!isTerminal && attempt < RETRY_DELAYS_MS.length) {
+          retryTimeoutRef.current = setTimeout(
+            () => void performSave(attempt + 1),
+            RETRY_DELAYS_MS[attempt],
+          );
+          return;
+        }
+
+        // Either a terminal failure (retrying the same payload would just
+        // fail the same way) or every retry is exhausted: this is the point
+        // where silence would look exactly like a false "Response saved" to
+        // the learner, so a real, specific failure toast always fires here.
+        toast.error(result.message ?? AUTOSAVE_GIVE_UP_MESSAGE, {
+          duration: 8000,
+        });
       };
 
       if (immediate) {
         await performSave();
       } else {
-        saveTimeoutRef.current = setTimeout(performSave, debounceMs);
+        saveTimeoutRef.current = setTimeout(() => void performSave(), debounceMs);
       }
     },
     [
@@ -146,6 +220,9 @@ export function useAutoSaveResponse(
     return () => {
       if (saveTimeoutRef.current) {
         clearTimeout(saveTimeoutRef.current);
+      }
+      if (retryTimeoutRef.current) {
+        clearTimeout(retryTimeoutRef.current);
       }
     };
   }, []);

--- a/apps/web/hooks/use-auto-save-response.ts
+++ b/apps/web/hooks/use-auto-save-response.ts
@@ -24,6 +24,17 @@ const AUTOSAVE_TERMINAL_STATUSES = new Set([400, 401, 403, 404, 413, 422]);
 const AUTOSAVE_GIVE_UP_MESSAGE =
   "We couldn't save your last response after several tries. Copy it somewhere safe, then reload the page and try again.";
 
+// A save request that arrived while a previous attempt (or its retry chain)
+// was still running, captured with everything a standalone save needs so it
+// can be replayed with no dependency on the call that originally queued it.
+interface QueuedSave {
+  assignmentId: number;
+  attemptId: number;
+  questionId: number;
+  payload: QuestionAttemptRequest;
+  serializedData: string;
+}
+
 /**
  * Hook to automatically save question responses to the backend.
  * This ensures that if the timer expires, the learner's work is preserved
@@ -33,7 +44,10 @@ const AUTOSAVE_GIVE_UP_MESSAGE =
  * in-memory data as saved / shows a success toast — when the server actually
  * confirms it. A failed save keeps the data dirty, retries transient
  * failures with backoff, and eventually shows an honest failure toast
- * instead of silently giving up.
+ * instead of silently giving up. A save that arrives while a previous
+ * attempt is still in flight is queued and replayed the instant that
+ * attempt settles, so the latest edit is never silently dropped in favor of
+ * a stale one.
  *
  * @param assignmentId - The ID of the assignment
  * @param attemptId - The ID of the current attempt
@@ -53,12 +67,156 @@ export function useAutoSaveResponse(
   const retryTimeoutRef = useRef<NodeJS.Timeout>();
   const isSavingRef = useRef(false);
   const lastSavedDataRef = useRef<string>("");
+  // Set the moment a fresh save arrives while a previous attempt is still
+  // in flight (awaiting the network, not merely a scheduled retry timer).
+  // The in-flight attempt's completion handler checks this and — if set —
+  // runs the queued save immediately instead of trusting its own (by then
+  // stale) result, so a fresher edit is never silently dropped.
+  const queuedSaveRef = useRef<QueuedSave | null>(null);
+  // Flipped once in the unmount cleanup effect. An in-flight submitQuestion
+  // call has no way to be cancelled, so its resolution is checked against
+  // this ref before it's allowed to touch any ref, schedule a retry, run a
+  // queued save, or show a toast — a resolution arriving after unmount must
+  // be completely inert.
+  const isUnmountedRef = useRef(false);
 
   const question = useLearnerStore((state) =>
     state.questions.find((q) => q.id === questionId),
   );
   const userPreferedLanguage = useLearnerStore(
     (state) => state.userPreferedLanguage,
+  );
+
+  const performSave = useCallback(
+    async (
+      currentAssignmentId: number,
+      currentAttemptId: number,
+      currentQuestionId: number,
+      payload: QuestionAttemptRequest,
+      serializedData: string,
+      attempt = 0,
+    ) => {
+      // A fresh save attempt (a new edit's debounce firing, or an immediate
+      // saveNow()) always supersedes a stale retry that was scheduled for an
+      // older payload — cancel it rather than let both fire.
+      if (retryTimeoutRef.current) {
+        clearTimeout(retryTimeoutRef.current);
+        retryTimeoutRef.current = undefined;
+      }
+
+      if (isSavingRef.current) {
+        // A different (now-stale) attempt is currently awaiting the network
+        // — queue this newer request rather than dropping it. Whichever
+        // outcome the in-flight attempt reaches, its completion handler
+        // below will see this queued save and run it immediately instead.
+        queuedSaveRef.current = {
+          assignmentId: currentAssignmentId,
+          attemptId: currentAttemptId,
+          questionId: currentQuestionId,
+          payload,
+          serializedData,
+        };
+        return;
+      }
+
+      isSavingRef.current = true;
+      let result: SubmitQuestionResult;
+      try {
+        result = await submitQuestion(
+          currentAssignmentId,
+          currentAttemptId,
+          currentQuestionId,
+          payload,
+        );
+      } catch (error) {
+        // submitQuestion is contracted to resolve, never reject. This is a
+        // defensive net against a genuinely unexpected throw so it still
+        // drives the same honest failure/retry path below instead of an
+        // unhandled rejection.
+        console.error("Auto-save threw unexpectedly:", error);
+        result = { ok: false };
+      } finally {
+        isSavingRef.current = false;
+      }
+
+      if (isUnmountedRef.current) {
+        // The component is gone. Do not touch lastSavedDataRef, do not
+        // schedule a retry, do not run a queued save, do not show a toast —
+        // this resolution has nothing left to affect.
+        return;
+      }
+
+      // A fresher edit arrived while this attempt was in flight. It always
+      // wins: run it now, with its own fresh attempt count, and let it
+      // decide this data's fate instead of trusting this now-stale result.
+      const queued = queuedSaveRef.current;
+      if (queued) {
+        queuedSaveRef.current = null;
+        await performSave(
+          queued.assignmentId,
+          queued.attemptId,
+          queued.questionId,
+          queued.payload,
+          queued.serializedData,
+          0,
+        );
+        return;
+      }
+
+      // Compared against the literal `true` (not a truthy check) because
+      // this project builds with strictNullChecks disabled, under which
+      // TypeScript does not reliably narrow a discriminated union from a
+      // plain `if (result.ok)` — the explicit literal comparison is what
+      // actually narrows `result` to the `ok: false` branch below.
+      if (result.ok === true) {
+        lastSavedDataRef.current = serializedData;
+        if (showToast) {
+          toast.success("Response saved", {
+            duration: 2000,
+          });
+        }
+        return;
+      }
+
+      // Failure path: lastSavedDataRef is deliberately left untouched so
+      // this payload stays "dirty" — a later identical edit still gets a
+      // fresh save attempt instead of being silently treated as saved.
+      console.error("Auto-save failed:", {
+        assignmentId: currentAssignmentId,
+        attemptId: currentAttemptId,
+        questionId: currentQuestionId,
+        status: result.status,
+        attempt,
+      });
+
+      const isTerminal =
+        result.status !== undefined &&
+        AUTOSAVE_TERMINAL_STATUSES.has(result.status);
+
+      if (!isTerminal && attempt < RETRY_DELAYS_MS.length) {
+        retryTimeoutRef.current = setTimeout(() => {
+          if (isUnmountedRef.current) return;
+          void performSave(
+            currentAssignmentId,
+            currentAttemptId,
+            currentQuestionId,
+            payload,
+            serializedData,
+            attempt + 1,
+          );
+        }, RETRY_DELAYS_MS[attempt]);
+        return;
+      }
+
+      // Either a terminal failure (retrying the same payload would just
+      // fail the same way) or every retry is exhausted: this is the point
+      // where silence would look exactly like a false "Response saved" to
+      // the learner, so a real, specific failure toast always fires here.
+      toast.error(result.message ?? AUTOSAVE_GIVE_UP_MESSAGE, {
+        duration: 8000,
+      });
+    },
+    [showToast],
   );
 
   const saveResponse = useCallback(
@@ -104,89 +262,22 @@ export function useAutoSaveResponse(
         clearTimeout(saveTimeoutRef.current);
       }
 
-      const performSave = async (attempt = 0) => {
-        // A fresh save attempt (a new edit's debounce firing, or an
-        // immediate saveNow()) always supersedes a stale retry that was
-        // scheduled for an older payload — cancel it rather than let both
-        // fire.
-        if (retryTimeoutRef.current) {
-          clearTimeout(retryTimeoutRef.current);
-          retryTimeoutRef.current = undefined;
-        }
-
-        if (isSavingRef.current) return;
-
-        isSavingRef.current = true;
-        let result: SubmitQuestionResult;
-        try {
-          result = await submitQuestion(
-            assignmentId,
-            attemptId,
-            questionId,
-            responsePayload,
-          );
-        } catch (error) {
-          // submitQuestion is contracted to resolve, never reject. This is a
-          // defensive net against a genuinely unexpected throw so it still
-          // drives the same honest failure/retry path below instead of an
-          // unhandled rejection.
-          console.error("Auto-save threw unexpectedly:", error);
-          result = { ok: false };
-        } finally {
-          isSavingRef.current = false;
-        }
-
-        // Compared against the literal `true` (not a truthy check) because
-        // this project builds with strictNullChecks disabled, under which
-        // TypeScript does not reliably narrow a discriminated union from a
-        // plain `if (result.ok)` — the explicit literal comparison is what
-        // actually narrows `result` to the `ok: false` branch below.
-        if (result.ok === true) {
-          lastSavedDataRef.current = currentData;
-          if (showToast) {
-            toast.success("Response saved", {
-              duration: 2000,
-            });
-          }
-          return;
-        }
-
-        // Failure path: lastSavedDataRef is deliberately left untouched so
-        // this payload stays "dirty" — a later identical edit still gets a
-        // fresh save attempt instead of being silently treated as saved.
-        console.error("Auto-save failed:", {
+      const runSave = () =>
+        performSave(
           assignmentId,
           attemptId,
           questionId,
-          status: result.status,
-          attempt,
-        });
-
-        const isTerminal =
-          result.status !== undefined &&
-          AUTOSAVE_TERMINAL_STATUSES.has(result.status);
-
-        if (!isTerminal && attempt < RETRY_DELAYS_MS.length) {
-          retryTimeoutRef.current = setTimeout(
-            () => void performSave(attempt + 1),
-            RETRY_DELAYS_MS[attempt],
-          );
-          return;
-        }
-
-        // Either a terminal failure (retrying the same payload would just
-        // fail the same way) or every retry is exhausted: this is the point
-        // where silence would look exactly like a false "Response saved" to
-        // the learner, so a real, specific failure toast always fires here.
-        toast.error(result.message ?? AUTOSAVE_GIVE_UP_MESSAGE, {
-          duration: 8000,
-        });
-      };
+          responsePayload,
+          currentData,
+        );
 
       if (immediate) {
-        await performSave();
+        await runSave();
       } else {
-        saveTimeoutRef.current = setTimeout(() => void performSave(), debounceMs);
+        saveTimeoutRef.current = setTimeout(() => {
+          if (isUnmountedRef.current) return;
+          void runSave();
+        }, debounceMs);
       }
     },
     [
@@ -197,7 +288,7 @@ export function useAutoSaveResponse(
       question,
       userPreferedLanguage,
       debounceMs,
-      showToast,
+      performSave,
     ],
   );
 
@@ -218,12 +309,14 @@ export function useAutoSaveResponse(
 
   useEffect(() => {
     return () => {
+      isUnmountedRef.current = true;
       if (saveTimeoutRef.current) {
         clearTimeout(saveTimeoutRef.current);
       }
       if (retryTimeoutRef.current) {
         clearTimeout(retryTimeoutRef.current);
       }
+      queuedSaveRef.current = null;
     };
   }, []);
 

--- a/apps/web/hooks/use-auto-save-response.ts
+++ b/apps/web/hooks/use-auto-save-response.ts
@@ -212,8 +212,13 @@ export function useAutoSaveResponse(
       // fail the same way) or every retry is exhausted: this is the point
       // where silence would look exactly like a false "Response saved" to
       // the learner, so a real, specific failure toast always fires here.
+      // A stable per-question id keeps a terminal failure from stacking a
+      // fresh toast on every debounce cycle while the learner keeps typing
+      // an answer that still won't save — sonner updates the existing
+      // toast in place instead of piling up a new one.
       toast.error(result.message ?? AUTOSAVE_GIVE_UP_MESSAGE, {
         duration: 8000,
+        id: `autosave-failure-${currentQuestionId}`,
       });
     },
     [showToast],
@@ -308,6 +313,13 @@ export function useAutoSaveResponse(
   ]);
 
   useEffect(() => {
+    // React StrictMode (dev only) double-invokes this effect on mount —
+    // setup, cleanup, setup again — reusing the same refs across both
+    // invocations. Without resetting this here, the first (churned)
+    // cleanup below would leave isUnmountedRef stuck true forever, making
+    // every future save resolution silently no-op.
+    isUnmountedRef.current = false;
+
     return () => {
       isUnmountedRef.current = true;
       if (saveTimeoutRef.current) {
@@ -321,6 +333,16 @@ export function useAutoSaveResponse(
   }, []);
 
   return {
+    /**
+     * Triggers an immediate save, bypassing the debounce.
+     *
+     * The returned promise resolving does NOT mean the data was saved — it
+     * always resolves to `undefined`, and can resolve well before the
+     * server has confirmed anything: e.g. immediately, if this save gets
+     * queued behind an already-in-flight attempt, or as soon as a
+     * transient failure schedules a retry. Rely on the success/failure
+     * toast (or `isSaving`) to know the actual outcome, not this promise.
+     */
     saveNow: () => saveResponse(true),
     isSaving: isSavingRef.current,
   };

--- a/apps/web/lib/__tests__/grading-stream-watchdog.test.ts
+++ b/apps/web/lib/__tests__/grading-stream-watchdog.test.ts
@@ -30,7 +30,8 @@ describe("watchdog budgets", () => {
     // Worst case = idle timeout per attempt plus the linear reconnect backoff
     // between them. This is the number that used to be ~15 minutes.
     const backoff = 2000 + 4000;
-    const worstCase = SSE_IDLE_TIMEOUT_MS * SSE_MAX_CONNECTION_ATTEMPTS + backoff;
+    const worstCase =
+      SSE_IDLE_TIMEOUT_MS * SSE_MAX_CONNECTION_ATTEMPTS + backoff;
 
     expect(worstCase).toBeLessThanOrEqual(180_000);
   });
@@ -72,7 +73,11 @@ describe("connection idle clock", () => {
     watchdog.startGradingClock();
     watchdog.noteStreamActivity();
 
-    for (let elapsed = 0; elapsed < GRADING_STALL_WARNING_MS; elapsed += 10_000) {
+    for (
+      let elapsed = 0;
+      elapsed < GRADING_STALL_WARNING_MS;
+      elapsed += 10_000
+    ) {
       jest.advanceTimersByTime(10_000);
       watchdog.noteStreamActivity();
     }
@@ -99,7 +104,11 @@ describe("grading stall clock", () => {
 
     watchdog.startGradingClock();
 
-    for (let elapsed = 0; elapsed < GRADING_STALL_WARNING_MS; elapsed += 10_000) {
+    for (
+      let elapsed = 0;
+      elapsed < GRADING_STALL_WARNING_MS;
+      elapsed += 10_000
+    ) {
       jest.advanceTimersByTime(10_000);
       watchdog.noteStreamActivity();
     }

--- a/apps/web/lib/__tests__/grading-stream-watchdog.test.ts
+++ b/apps/web/lib/__tests__/grading-stream-watchdog.test.ts
@@ -1,0 +1,210 @@
+/**
+ * @jest-environment node
+ */
+
+import {
+  GRADING_STALL_TIMEOUT_MS,
+  GRADING_STALL_WARNING_MS,
+  GradingWatchdog,
+  SSE_IDLE_TIMEOUT_MS,
+  SSE_MAX_CONNECTION_ATTEMPTS,
+} from "../grading-stream-watchdog";
+
+const handlers = () => ({
+  onIdleTimeout: jest.fn(),
+  onStallWarning: jest.fn(),
+  onStallTimeout: jest.fn(),
+});
+
+beforeEach(() => {
+  jest.useFakeTimers();
+});
+
+afterEach(() => {
+  jest.clearAllTimers();
+  jest.useRealTimers();
+});
+
+describe("watchdog budgets", () => {
+  it("gives a dead connection an honest outcome inside three minutes", () => {
+    // Worst case = idle timeout per attempt plus the linear reconnect backoff
+    // between them. This is the number that used to be ~15 minutes.
+    const backoff = 2000 + 4000;
+    const worstCase = SSE_IDLE_TIMEOUT_MS * SSE_MAX_CONNECTION_ATTEMPTS + backoff;
+
+    expect(worstCase).toBeLessThanOrEqual(180_000);
+  });
+
+  it("keeps the idle budget well clear of the server heartbeat cadence", () => {
+    const serverHeartbeatIntervalMs = 10_000;
+
+    expect(SSE_IDLE_TIMEOUT_MS).toBeGreaterThanOrEqual(
+      serverHeartbeatIntervalMs * 4,
+    );
+  });
+
+  it("keeps the hard stall stop above the worker's own dead-worker detection", () => {
+    // Attempt lock duration (600000) plus one stall-check tick (30000). Below
+    // this the client would pre-empt a failure the server is about to report
+    // properly.
+    expect(GRADING_STALL_TIMEOUT_MS).toBeGreaterThan(630_000);
+    expect(GRADING_STALL_WARNING_MS).toBeLessThan(GRADING_STALL_TIMEOUT_MS);
+  });
+});
+
+describe("connection idle clock", () => {
+  it("fires when nothing at all arrives", () => {
+    const h = handlers();
+    const watchdog = new GradingWatchdog(h);
+
+    watchdog.noteStreamActivity();
+    jest.advanceTimersByTime(SSE_IDLE_TIMEOUT_MS - 1);
+    expect(h.onIdleTimeout).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(1);
+    expect(h.onIdleTimeout).toHaveBeenCalledTimes(1);
+  });
+
+  it("is re-armed by a heartbeat, so a live-but-slow grade is never cut off", () => {
+    const h = handlers();
+    const watchdog = new GradingWatchdog(h);
+
+    watchdog.startGradingClock();
+    watchdog.noteStreamActivity();
+
+    for (let elapsed = 0; elapsed < GRADING_STALL_WARNING_MS; elapsed += 10_000) {
+      jest.advanceTimersByTime(10_000);
+      watchdog.noteStreamActivity();
+    }
+
+    expect(h.onIdleTimeout).not.toHaveBeenCalled();
+  });
+
+  it("stops firing once the connection is torn down", () => {
+    const h = handlers();
+    const watchdog = new GradingWatchdog(h);
+
+    watchdog.noteStreamActivity();
+    watchdog.clearStreamActivity();
+    jest.advanceTimersByTime(SSE_IDLE_TIMEOUT_MS * 2);
+
+    expect(h.onIdleTimeout).not.toHaveBeenCalled();
+  });
+});
+
+describe("grading stall clock", () => {
+  it("warns when only heartbeats arrive for the warning window", () => {
+    const h = handlers();
+    const watchdog = new GradingWatchdog(h);
+
+    watchdog.startGradingClock();
+
+    for (let elapsed = 0; elapsed < GRADING_STALL_WARNING_MS; elapsed += 10_000) {
+      jest.advanceTimersByTime(10_000);
+      watchdog.noteStreamActivity();
+    }
+
+    expect(h.onStallWarning).toHaveBeenCalledTimes(1);
+    expect(h.onStallTimeout).not.toHaveBeenCalled();
+    expect(watchdog.hasWarned).toBe(true);
+  });
+
+  it("hard-stops when the stall outlasts the timeout window", () => {
+    const h = handlers();
+    const watchdog = new GradingWatchdog(h);
+
+    watchdog.startGradingClock();
+    jest.advanceTimersByTime(GRADING_STALL_TIMEOUT_MS);
+
+    expect(h.onStallTimeout).toHaveBeenCalledTimes(1);
+  });
+
+  it("is re-armed by a substantive update and clears the warning", () => {
+    const h = handlers();
+    const watchdog = new GradingWatchdog(h);
+
+    watchdog.startGradingClock();
+    jest.advanceTimersByTime(GRADING_STALL_WARNING_MS);
+    expect(watchdog.hasWarned).toBe(true);
+
+    watchdog.noteGradingUpdate();
+    expect(watchdog.hasWarned).toBe(false);
+
+    jest.advanceTimersByTime(GRADING_STALL_WARNING_MS - 1);
+    expect(h.onStallWarning).toHaveBeenCalledTimes(1);
+
+    jest.advanceTimersByTime(1);
+    expect(h.onStallWarning).toHaveBeenCalledTimes(2);
+    expect(h.onStallTimeout).not.toHaveBeenCalled();
+  });
+
+  it("survives a reconnect: the grading clock is not reset by the new connection alone", () => {
+    const h = handlers();
+    const watchdog = new GradingWatchdog(h);
+
+    watchdog.startGradingClock();
+    jest.advanceTimersByTime(GRADING_STALL_WARNING_MS - 1000);
+
+    // Connection drops and comes back; only connection-level state resets.
+    watchdog.clearStreamActivity();
+    watchdog.noteStreamActivity();
+
+    jest.advanceTimersByTime(1000);
+    expect(h.onStallWarning).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("stop()", () => {
+  it("silences every clock", () => {
+    const h = handlers();
+    const watchdog = new GradingWatchdog(h);
+
+    watchdog.startGradingClock();
+    watchdog.noteStreamActivity();
+    watchdog.stop();
+
+    jest.advanceTimersByTime(GRADING_STALL_TIMEOUT_MS * 2);
+
+    expect(h.onIdleTimeout).not.toHaveBeenCalled();
+    expect(h.onStallWarning).not.toHaveBeenCalled();
+    expect(h.onStallTimeout).not.toHaveBeenCalled();
+  });
+
+  it("ignores activity notes after stopping", () => {
+    const h = handlers();
+    const watchdog = new GradingWatchdog(h);
+
+    watchdog.stop();
+    watchdog.startGradingClock();
+    watchdog.noteStreamActivity();
+    watchdog.noteGradingUpdate();
+
+    jest.advanceTimersByTime(GRADING_STALL_TIMEOUT_MS * 2);
+
+    expect(h.onIdleTimeout).not.toHaveBeenCalled();
+    expect(h.onStallTimeout).not.toHaveBeenCalled();
+  });
+});
+
+describe("option overrides", () => {
+  it("honours injected windows so callers can test fast", () => {
+    const h = handlers();
+    const watchdog = new GradingWatchdog(h, {
+      idleTimeoutMs: 50,
+      stallWarningMs: 100,
+      stallTimeoutMs: 200,
+    });
+
+    watchdog.startGradingClock();
+    watchdog.noteStreamActivity();
+
+    jest.advanceTimersByTime(50);
+    expect(h.onIdleTimeout).toHaveBeenCalledTimes(1);
+
+    jest.advanceTimersByTime(50);
+    expect(h.onStallWarning).toHaveBeenCalledTimes(1);
+
+    jest.advanceTimersByTime(100);
+    expect(h.onStallTimeout).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/lib/__tests__/learner.submit-question.test.ts
+++ b/apps/web/lib/__tests__/learner.submit-question.test.ts
@@ -1,0 +1,144 @@
+jest.mock("../api-client", () => {
+  class MockAPIError extends Error {
+    constructor(
+      message: string,
+      public status: number,
+      public statusText: string,
+      public body?: unknown,
+    ) {
+      super(message);
+      this.name = "APIError";
+    }
+  }
+  return {
+    apiClient: { post: jest.fn() },
+    APIError: MockAPIError,
+  };
+});
+
+import { apiClient, APIError } from "../api-client";
+import { submitQuestion } from "../learner";
+import type { QuestionAttemptRequest } from "@config/types";
+
+const samplePayload: QuestionAttemptRequest = {
+  learnerTextResponse: "answer",
+};
+
+describe("submitQuestion", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns ok:true with the response data on success", async () => {
+    (apiClient.post as jest.Mock).mockResolvedValue({
+      id: 1,
+      questionId: 2,
+      question: "",
+    });
+
+    const result = await submitQuestion(10, 20, 2, samplePayload);
+
+    expect(result).toEqual({
+      ok: true,
+      data: { id: 1, questionId: 2, question: "" },
+    });
+  });
+
+  it("passes quiet:true so apiClient's generic status-code toast never fires for this call", async () => {
+    (apiClient.post as jest.Mock).mockResolvedValue({
+      id: 1,
+      questionId: 2,
+      question: "",
+    });
+
+    await submitQuestion(10, 20, 2, samplePayload);
+
+    expect((apiClient.post as jest.Mock).mock.calls[0]).toEqual([
+      expect.any(String),
+      expect.anything(),
+      expect.objectContaining({ quiet: true }),
+    ]);
+  });
+
+  it("surfaces the server's learner-safe message for a 4xx failure", async () => {
+    (apiClient.post as jest.Mock).mockRejectedValue(
+      new APIError("Bad Request", 400, "Bad Request", {
+        statusCode: 400,
+        message:
+          "Your submission is too large for automatic grading. Try reducing its length (fewer pages, rows, or sheets) and submit it again.",
+        error: "Bad Request",
+      }),
+    );
+
+    const result = await submitQuestion(10, 20, 2, samplePayload);
+
+    expect(result).toEqual({
+      ok: false,
+      status: 400,
+      message:
+        "Your submission is too large for automatic grading. Try reducing its length (fewer pages, rows, or sheets) and submit it again.",
+    });
+  });
+
+  it("never leaks a 5xx response body as a learner-facing message", async () => {
+    (apiClient.post as jest.Mock).mockRejectedValue(
+      new APIError("Internal Server Error", 500, "Internal Server Error", {
+        statusCode: 500,
+        message: "Internal server error",
+      }),
+    );
+
+    const result = await submitQuestion(10, 20, 2, samplePayload);
+
+    expect(result).toEqual({ ok: false, status: 500, message: undefined });
+  });
+
+  it("returns ok:false with no status for a non-HTTP failure (e.g. a network error)", async () => {
+    (apiClient.post as jest.Mock).mockRejectedValue(
+      new TypeError("Failed to fetch"),
+    );
+
+    const result = await submitQuestion(10, 20, 2, samplePayload);
+
+    expect(result).toEqual({ ok: false, status: undefined, message: undefined });
+  });
+
+  it("never throws, even when apiClient.post rejects with a bare Error", async () => {
+    (apiClient.post as jest.Mock).mockRejectedValue(new Error("boom"));
+
+    await expect(submitQuestion(10, 20, 2, samplePayload)).resolves.toEqual({
+      ok: false,
+      status: undefined,
+      message: undefined,
+    });
+  });
+
+  it("logs the failure with structured context, not the raw answer payload", async () => {
+    const consoleError = jest.spyOn(console, "error").mockImplementation();
+    (apiClient.post as jest.Mock).mockRejectedValue(
+      new APIError("Bad Request", 400, "Bad Request", {
+        statusCode: 400,
+        message: "Too large",
+      }),
+    );
+
+    await submitQuestion(10, 20, 2, samplePayload);
+
+    expect(consoleError).toHaveBeenCalledWith(
+      "submitQuestion failed",
+      expect.objectContaining({
+        assignmentId: 10,
+        attemptId: 20,
+        questionId: 2,
+        status: 400,
+      }),
+    );
+    // The learner's actual answer text must never end up in the log call.
+    expect(consoleError).not.toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ requestBody: expect.anything() }),
+    );
+
+    consoleError.mockRestore();
+  });
+});

--- a/apps/web/lib/__tests__/learner.submit-watchdog.test.ts
+++ b/apps/web/lib/__tests__/learner.submit-watchdog.test.ts
@@ -1,0 +1,248 @@
+/**
+ * @jest-environment node
+ */
+
+jest.mock("../api-client", () => ({
+  apiClient: { patch: jest.fn(), post: jest.fn() },
+  APIError: class APIError extends Error {},
+}));
+
+jest.mock("sonner", () => ({
+  toast: { error: jest.fn(), success: jest.fn(), info: jest.fn() },
+}));
+
+jest.mock("@/lib/talkToBackend", () => ({
+  submitReportAuthor: jest.fn().mockResolvedValue({ success: true }),
+}));
+
+import { apiClient } from "../api-client";
+import {
+  GRADING_STALL_TIMEOUT_MS,
+  GRADING_STALL_WARNING_MS,
+  SSE_IDLE_TIMEOUT_MS,
+} from "../grading-stream-watchdog";
+import {
+  isGradingStreamLostError,
+  submitAssignment,
+  type GradingProgressStatus,
+} from "../learner";
+
+type Listener = (event: { data?: string }) => void;
+
+class FakeEventSource {
+  static instances: FakeEventSource[] = [];
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+  static readonly CLOSED = 2;
+
+  readyState = FakeEventSource.CONNECTING;
+  onopen: (() => void) | null = null;
+  onmessage: Listener | null = null;
+  closed = false;
+
+  private readonly listeners = new Map<string, Listener[]>();
+
+  constructor(readonly url: string) {
+    FakeEventSource.instances.push(this);
+  }
+
+  addEventListener(type: string, listener: Listener): void {
+    const existing = this.listeners.get(type) ?? [];
+    existing.push(listener);
+    this.listeners.set(type, existing);
+  }
+
+  close(): void {
+    this.closed = true;
+    this.readyState = FakeEventSource.CLOSED;
+  }
+
+  emit(type: string, data?: string): void {
+    for (const listener of this.listeners.get(type) ?? []) {
+      listener({ data });
+    }
+  }
+
+  open(): void {
+    this.readyState = FakeEventSource.OPEN;
+    this.onopen?.();
+  }
+}
+
+const heartbeat = () =>
+  JSON.stringify({ heartbeat: true, jobId: "job-1", timestamp: "now" });
+
+const progressFrame = (percentage: number) =>
+  JSON.stringify({
+    jobId: "job-1",
+    status: "Processing",
+    progress: `Grading ${percentage}%`,
+    percentage,
+    done: false,
+  });
+
+beforeEach(() => {
+  jest.useFakeTimers();
+  FakeEventSource.instances = [];
+  (globalThis as { EventSource?: unknown }).EventSource = FakeEventSource;
+  (apiClient.patch as jest.Mock).mockResolvedValue({
+    gradingJobId: "job-1",
+    message: "queued",
+  });
+  (apiClient.post as jest.Mock).mockResolvedValue({ success: true });
+});
+
+afterEach(() => {
+  jest.clearAllTimers();
+  jest.useRealTimers();
+  delete (globalThis as { EventSource?: unknown }).EventSource;
+});
+
+/** Flush the microtask queue so awaited internals settle between tick pushes. */
+const flush = async () => {
+  await Promise.resolve();
+  await Promise.resolve();
+};
+
+describe("submitAssignment connection watchdog", () => {
+  it("does not give up while heartbeats keep arriving", async () => {
+    const statuses: GradingProgressStatus[] = [];
+    const pending = submitAssignment(1, 2, [], "en", undefined, undefined, undefined, (status) => {
+      statuses.push(status);
+    });
+    void pending.catch(() => undefined);
+
+    await flush();
+    const source = FakeEventSource.instances[0];
+    source.open();
+
+    for (let elapsed = 0; elapsed < SSE_IDLE_TIMEOUT_MS * 3; elapsed += 10_000) {
+      jest.advanceTimersByTime(10_000);
+      source.emit("heartbeat", heartbeat());
+    }
+
+    expect(FakeEventSource.instances).toHaveLength(1);
+    expect(statuses).not.toContain("disconnected");
+  });
+
+  it("reconnects and then reports a lost stream once the retries run out", async () => {
+    const statuses: GradingProgressStatus[] = [];
+    const pending = submitAssignment(1, 2, [], "en", undefined, undefined, undefined, (status) => {
+      statuses.push(status);
+    });
+    const settled = pending.catch((error: unknown) => error);
+
+    await flush();
+    FakeEventSource.instances[0].open();
+
+    // Attempt 1 goes silent.
+    jest.advanceTimersByTime(SSE_IDLE_TIMEOUT_MS);
+    await flush();
+    jest.advanceTimersByTime(2000);
+    await flush();
+    expect(FakeEventSource.instances).toHaveLength(2);
+
+    // Attempt 2 goes silent.
+    jest.advanceTimersByTime(SSE_IDLE_TIMEOUT_MS);
+    await flush();
+    jest.advanceTimersByTime(4000);
+    await flush();
+    expect(FakeEventSource.instances).toHaveLength(3);
+
+    // Attempt 3 goes silent — no attempts left.
+    jest.advanceTimersByTime(SSE_IDLE_TIMEOUT_MS);
+    await flush();
+    await jest.runOnlyPendingTimersAsync();
+
+    const error = await settled;
+    expect(isGradingStreamLostError(error)).toBe(true);
+    expect(statuses).toContain("disconnected");
+  });
+
+  it("surfaces a stall without closing a connection that is still alive", async () => {
+    const statuses: GradingProgressStatus[] = [];
+    const pending = submitAssignment(1, 2, [], "en", undefined, undefined, undefined, (status) => {
+      statuses.push(status);
+    });
+    void pending.catch(() => undefined);
+
+    await flush();
+    const source = FakeEventSource.instances[0];
+    source.open();
+
+    for (let elapsed = 0; elapsed < GRADING_STALL_WARNING_MS; elapsed += 10_000) {
+      jest.advanceTimersByTime(10_000);
+      source.emit("heartbeat", heartbeat());
+    }
+
+    expect(statuses).toContain("stalled");
+    expect(source.closed).toBe(false);
+    expect(FakeEventSource.instances).toHaveLength(1);
+  });
+
+  it("clears the stall once real progress resumes", async () => {
+    const statuses: GradingProgressStatus[] = [];
+    const pending = submitAssignment(1, 2, [], "en", undefined, undefined, undefined, (status) => {
+      statuses.push(status);
+    });
+    void pending.catch(() => undefined);
+
+    await flush();
+    const source = FakeEventSource.instances[0];
+    source.open();
+
+    for (let elapsed = 0; elapsed < GRADING_STALL_WARNING_MS; elapsed += 10_000) {
+      jest.advanceTimersByTime(10_000);
+      source.emit("heartbeat", heartbeat());
+    }
+    expect(statuses).toContain("stalled");
+
+    source.emit("update", progressFrame(40));
+    expect(statuses[statuses.length - 1]).toBe("processing");
+  });
+
+  it("hard-stops a wedged grade with a lost-stream error", async () => {
+    const statuses: GradingProgressStatus[] = [];
+    const pending = submitAssignment(1, 2, [], "en", undefined, undefined, undefined, (status) => {
+      statuses.push(status);
+    });
+    const settled = pending.catch((error: unknown) => error);
+
+    await flush();
+    const source = FakeEventSource.instances[0];
+    source.open();
+
+    for (let elapsed = 0; elapsed < GRADING_STALL_TIMEOUT_MS; elapsed += 10_000) {
+      jest.advanceTimersByTime(10_000);
+      source.emit("heartbeat", heartbeat());
+    }
+
+    await flush();
+    await jest.runOnlyPendingTimersAsync();
+
+    const error = await settled;
+    expect(isGradingStreamLostError(error)).toBe(true);
+    expect((error as { reason?: string }).reason).toBe("stalled");
+    expect(statuses).toContain("disconnected");
+  });
+
+  it("still resolves normally on a finalize frame", async () => {
+    const pending = submitAssignment(1, 2, []);
+
+    await flush();
+    const source = FakeEventSource.instances[0];
+    source.open();
+    source.emit(
+      "finalize",
+      JSON.stringify({
+        jobId: "job-1",
+        status: "Completed",
+        result: JSON.stringify({ id: 2, grade: 0.9 }),
+        done: true,
+      }),
+    );
+
+    await expect(pending).resolves.toMatchObject({ id: 2, grade: 0.9 });
+    expect(source.closed).toBe(true);
+  });
+});

--- a/apps/web/lib/__tests__/learner.submit-watchdog.test.ts
+++ b/apps/web/lib/__tests__/learner.submit-watchdog.test.ts
@@ -119,16 +119,29 @@ const flush = async () => {
 describe("submitAssignment connection watchdog", () => {
   it("does not give up while heartbeats keep arriving", async () => {
     const statuses: GradingProgressStatus[] = [];
-    const pending = submitAssignment(1, 2, [], "en", undefined, undefined, undefined, (status) => {
-      statuses.push(status);
-    });
+    const pending = submitAssignment(
+      1,
+      2,
+      [],
+      "en",
+      undefined,
+      undefined,
+      undefined,
+      (status) => {
+        statuses.push(status);
+      },
+    );
     void pending.catch(() => undefined);
 
     await flush();
     const source = FakeEventSource.instances[0];
     source.open();
 
-    for (let elapsed = 0; elapsed < SSE_IDLE_TIMEOUT_MS * 3; elapsed += 10_000) {
+    for (
+      let elapsed = 0;
+      elapsed < SSE_IDLE_TIMEOUT_MS * 3;
+      elapsed += 10_000
+    ) {
       jest.advanceTimersByTime(10_000);
       source.emit("heartbeat", heartbeat());
     }
@@ -139,9 +152,18 @@ describe("submitAssignment connection watchdog", () => {
 
   it("reconnects and then reports a lost stream once the retries run out", async () => {
     const statuses: GradingProgressStatus[] = [];
-    const pending = submitAssignment(1, 2, [], "en", undefined, undefined, undefined, (status) => {
-      statuses.push(status);
-    });
+    const pending = submitAssignment(
+      1,
+      2,
+      [],
+      "en",
+      undefined,
+      undefined,
+      undefined,
+      (status) => {
+        statuses.push(status);
+      },
+    );
     const settled = pending.catch((error: unknown) => error);
 
     await flush();
@@ -173,9 +195,18 @@ describe("submitAssignment connection watchdog", () => {
 
   it("surfaces a stall without closing a connection that is still alive, carrying the last-known progress forward instead of resetting it", async () => {
     const calls: ProgressCall[] = [];
-    const pending = submitAssignment(1, 2, [], "en", undefined, undefined, undefined, (status, progress, message, metadata) => {
-      calls.push({ status, progress, message, metadata });
-    });
+    const pending = submitAssignment(
+      1,
+      2,
+      [],
+      "en",
+      undefined,
+      undefined,
+      undefined,
+      (status, progress, message, metadata) => {
+        calls.push({ status, progress, message, metadata });
+      },
+    );
     void pending.catch(() => undefined);
 
     await flush();
@@ -184,9 +215,16 @@ describe("submitAssignment connection watchdog", () => {
 
     // Real progress arrives before the stall — this is what the warning
     // must not wipe out.
-    source.emit("update", progressFrame(55, { currentQuestion: 3, totalQuestions: 10 }));
+    source.emit(
+      "update",
+      progressFrame(55, { currentQuestion: 3, totalQuestions: 10 }),
+    );
 
-    for (let elapsed = 0; elapsed < GRADING_STALL_WARNING_MS; elapsed += 10_000) {
+    for (
+      let elapsed = 0;
+      elapsed < GRADING_STALL_WARNING_MS;
+      elapsed += 10_000
+    ) {
       jest.advanceTimersByTime(10_000);
       source.emit("heartbeat", heartbeat());
     }
@@ -205,16 +243,29 @@ describe("submitAssignment connection watchdog", () => {
 
   it("clears the stall once real progress resumes, and genuinely re-arms the grading clock rather than just reporting a status once", async () => {
     const statuses: GradingProgressStatus[] = [];
-    const pending = submitAssignment(1, 2, [], "en", undefined, undefined, undefined, (status) => {
-      statuses.push(status);
-    });
+    const pending = submitAssignment(
+      1,
+      2,
+      [],
+      "en",
+      undefined,
+      undefined,
+      undefined,
+      (status) => {
+        statuses.push(status);
+      },
+    );
     void pending.catch(() => undefined);
 
     await flush();
     const source = FakeEventSource.instances[0];
     source.open();
 
-    for (let elapsed = 0; elapsed < GRADING_STALL_WARNING_MS; elapsed += 10_000) {
+    for (
+      let elapsed = 0;
+      elapsed < GRADING_STALL_WARNING_MS;
+      elapsed += 10_000
+    ) {
       jest.advanceTimersByTime(10_000);
       source.emit("heartbeat", heartbeat());
     }
@@ -234,7 +285,11 @@ describe("submitAssignment connection watchdog", () => {
       (s) => s === "stalled",
     ).length;
 
-    for (let elapsed = 0; elapsed < GRADING_STALL_WARNING_MS; elapsed += 10_000) {
+    for (
+      let elapsed = 0;
+      elapsed < GRADING_STALL_WARNING_MS;
+      elapsed += 10_000
+    ) {
       jest.advanceTimersByTime(10_000);
       source.emit("heartbeat", heartbeat());
     }
@@ -255,9 +310,18 @@ describe("submitAssignment connection watchdog", () => {
     (apiClient.post as jest.Mock).mockReturnValue(new Promise(() => undefined));
 
     const statuses: GradingProgressStatus[] = [];
-    const pending = submitAssignment(1, 2, [], "en", undefined, undefined, undefined, (status) => {
-      statuses.push(status);
-    });
+    const pending = submitAssignment(
+      1,
+      2,
+      [],
+      "en",
+      undefined,
+      undefined,
+      undefined,
+      (status) => {
+        statuses.push(status);
+      },
+    );
     const settled = pending.catch((error: unknown) => error);
 
     await flush();
@@ -283,16 +347,29 @@ describe("submitAssignment connection watchdog", () => {
 
   it("hard-stops a wedged grade with a lost-stream error", async () => {
     const statuses: GradingProgressStatus[] = [];
-    const pending = submitAssignment(1, 2, [], "en", undefined, undefined, undefined, (status) => {
-      statuses.push(status);
-    });
+    const pending = submitAssignment(
+      1,
+      2,
+      [],
+      "en",
+      undefined,
+      undefined,
+      undefined,
+      (status) => {
+        statuses.push(status);
+      },
+    );
     const settled = pending.catch((error: unknown) => error);
 
     await flush();
     const source = FakeEventSource.instances[0];
     source.open();
 
-    for (let elapsed = 0; elapsed < GRADING_STALL_TIMEOUT_MS; elapsed += 10_000) {
+    for (
+      let elapsed = 0;
+      elapsed < GRADING_STALL_TIMEOUT_MS;
+      elapsed += 10_000
+    ) {
       jest.advanceTimersByTime(10_000);
       source.emit("heartbeat", heartbeat());
     }

--- a/apps/web/lib/__tests__/learner.submit-watchdog.test.ts
+++ b/apps/web/lib/__tests__/learner.submit-watchdog.test.ts
@@ -72,14 +72,26 @@ class FakeEventSource {
 const heartbeat = () =>
   JSON.stringify({ heartbeat: true, jobId: "job-1", timestamp: "now" });
 
-const progressFrame = (percentage: number) =>
+const progressFrame = (
+  percentage: number,
+  metadata?: { currentQuestion?: number; totalQuestions?: number },
+) =>
   JSON.stringify({
     jobId: "job-1",
     status: "Processing",
     progress: `Grading ${percentage}%`,
     percentage,
+    currentQuestion: metadata?.currentQuestion,
+    totalQuestions: metadata?.totalQuestions,
     done: false,
   });
+
+interface ProgressCall {
+  status: GradingProgressStatus;
+  progress: number;
+  message: string;
+  metadata?: { currentQuestion?: number; totalQuestions?: number };
+}
 
 beforeEach(() => {
   jest.useFakeTimers();
@@ -159,10 +171,10 @@ describe("submitAssignment connection watchdog", () => {
     expect(statuses).toContain("disconnected");
   });
 
-  it("surfaces a stall without closing a connection that is still alive", async () => {
-    const statuses: GradingProgressStatus[] = [];
-    const pending = submitAssignment(1, 2, [], "en", undefined, undefined, undefined, (status) => {
-      statuses.push(status);
+  it("surfaces a stall without closing a connection that is still alive, carrying the last-known progress forward instead of resetting it", async () => {
+    const calls: ProgressCall[] = [];
+    const pending = submitAssignment(1, 2, [], "en", undefined, undefined, undefined, (status, progress, message, metadata) => {
+      calls.push({ status, progress, message, metadata });
     });
     void pending.catch(() => undefined);
 
@@ -170,17 +182,28 @@ describe("submitAssignment connection watchdog", () => {
     const source = FakeEventSource.instances[0];
     source.open();
 
+    // Real progress arrives before the stall — this is what the warning
+    // must not wipe out.
+    source.emit("update", progressFrame(55, { currentQuestion: 3, totalQuestions: 10 }));
+
     for (let elapsed = 0; elapsed < GRADING_STALL_WARNING_MS; elapsed += 10_000) {
       jest.advanceTimersByTime(10_000);
       source.emit("heartbeat", heartbeat());
     }
 
+    const statuses = calls.map((c) => c.status);
     expect(statuses).toContain("stalled");
     expect(source.closed).toBe(false);
     expect(FakeEventSource.instances).toHaveLength(1);
+
+    const stalledCall = calls.find((c) => c.status === "stalled");
+    expect(stalledCall).toBeDefined();
+    expect(stalledCall?.progress).toBe(55);
+    expect(stalledCall?.metadata?.currentQuestion).toBe(3);
+    expect(stalledCall?.metadata?.totalQuestions).toBe(10);
   });
 
-  it("clears the stall once real progress resumes", async () => {
+  it("clears the stall once real progress resumes, and genuinely re-arms the grading clock rather than just reporting a status once", async () => {
     const statuses: GradingProgressStatus[] = [];
     const pending = submitAssignment(1, 2, [], "en", undefined, undefined, undefined, (status) => {
       statuses.push(status);
@@ -199,6 +222,63 @@ describe("submitAssignment connection watchdog", () => {
 
     source.emit("update", progressFrame(40));
     expect(statuses[statuses.length - 1]).toBe("processing");
+
+    // The update above must have re-armed the grading-liveness clock itself,
+    // not just cleared the displayed status. Feed it another full warning
+    // window of heartbeats alone (no further real progress) and confirm the
+    // stall fires again — a second "stalled" only appears if the clock was
+    // genuinely rescheduled from the update, not left running from the
+    // first arm (in which case it would already have fired once and never
+    // again).
+    const stalledCountAfterFirstWarning = statuses.filter(
+      (s) => s === "stalled",
+    ).length;
+
+    for (let elapsed = 0; elapsed < GRADING_STALL_WARNING_MS; elapsed += 10_000) {
+      jest.advanceTimersByTime(10_000);
+      source.emit("heartbeat", heartbeat());
+    }
+
+    const stalledCountAfterSecondWindow = statuses.filter(
+      (s) => s === "stalled",
+    ).length;
+    expect(stalledCountAfterSecondWindow).toBeGreaterThan(
+      stalledCountAfterFirstWarning,
+    );
+  });
+
+  it("rejects the caller and reports 'disconnected' even when the diagnostic report never resolves", async () => {
+    // A dead network can hang the report POST (and its author-report
+    // fallback) indefinitely. The whole point of this watchdog is a bounded
+    // time-to-honest-state, so the learner must not be left waiting on a
+    // network call that may never settle.
+    (apiClient.post as jest.Mock).mockReturnValue(new Promise(() => undefined));
+
+    const statuses: GradingProgressStatus[] = [];
+    const pending = submitAssignment(1, 2, [], "en", undefined, undefined, undefined, (status) => {
+      statuses.push(status);
+    });
+    const settled = pending.catch((error: unknown) => error);
+
+    await flush();
+    FakeEventSource.instances[0].open();
+
+    jest.advanceTimersByTime(SSE_IDLE_TIMEOUT_MS);
+    await flush();
+    jest.advanceTimersByTime(2000);
+    await flush();
+
+    jest.advanceTimersByTime(SSE_IDLE_TIMEOUT_MS);
+    await flush();
+    jest.advanceTimersByTime(4000);
+    await flush();
+
+    jest.advanceTimersByTime(SSE_IDLE_TIMEOUT_MS);
+    await flush();
+
+    const error = await settled;
+    expect(isGradingStreamLostError(error)).toBe(true);
+    expect(statuses).toContain("disconnected");
   });
 
   it("hard-stops a wedged grade with a lost-stream error", async () => {

--- a/apps/web/lib/grading-stream-watchdog.ts
+++ b/apps/web/lib/grading-stream-watchdog.ts
@@ -1,0 +1,168 @@
+/**
+ * Timeouts for the learner's grading status stream.
+ *
+ * The server sends a named `heartbeat` frame every 10 seconds for as long as
+ * the stream is open, and it does so from the process serving the stream —
+ * not from the grading worker. That means two different things can go wrong,
+ * and they need two different clocks:
+ *
+ *  1. The stream itself dies (proxy drop, pod restart, network loss) and
+ *     nothing arrives at all. A healthy connection is never silent for longer
+ *     than a few heartbeats, so this clock can be short.
+ *  2. The stream is healthy but grading stops advancing. Heartbeats keep
+ *     re-arming clock 1, so without a second clock that ignores them the
+ *     learner watches the spinner forever.
+ *
+ * Only non-heartbeat frames count as evidence that grading is alive: the
+ * server publishes to the job channel exclusively when job state changes.
+ */
+
+/** Server heartbeat cadence. Mirrored here only to justify the idle budget. */
+const SERVER_HEARTBEAT_INTERVAL_MS = 10_000;
+
+/**
+ * No bytes of any kind for this long means the connection is dead. Four and a
+ * half missed heartbeats — enough to absorb GC pauses, background-tab
+ * throttling and proxy jitter, far short of anything grading-related.
+ */
+export const SSE_IDLE_TIMEOUT_MS = SERVER_HEARTBEAT_INTERVAL_MS * 4.5;
+
+/** Connection attempts before the stream is declared lost. */
+export const SSE_MAX_CONNECTION_ATTEMPTS = 3;
+
+/** Linear backoff step between reconnect attempts. */
+export const SSE_RECONNECT_BACKOFF_STEP_MS = 2000;
+
+/**
+ * Connection alive, but no grading progress for this long. Non-destructive:
+ * the stream stays open and the learner is told the truth rather than being
+ * cut off. Comfortably above the largest normal gap between two progress
+ * frames (one question chaining its LLM calls), so it does not cry wolf on
+ * ordinary slow file grading.
+ */
+export const GRADING_STALL_WARNING_MS = 180_000;
+
+/**
+ * Hard stop. Sits above the server's own dead-worker detection window (the
+ * attempt lock duration plus one stall-check tick), so a worker that died
+ * mid-grade has already been failed and reported through the stream before
+ * this fires. Reached only while heartbeats prove the pipe is alive, so it
+ * can never kill a grade that is genuinely progressing.
+ */
+export const GRADING_STALL_TIMEOUT_MS = 900_000;
+
+export interface GradingWatchdogHandlers {
+  /** No bytes at all for the idle window — this connection is dead. */
+  onIdleTimeout: () => void;
+  /** Connection alive, grading has not advanced for the warning window. */
+  onStallWarning: () => void;
+  /** Connection alive, grading has not advanced for the timeout window. */
+  onStallTimeout: () => void;
+}
+
+export interface GradingWatchdogOptions {
+  idleTimeoutMs?: number;
+  stallWarningMs?: number;
+  stallTimeoutMs?: number;
+}
+
+/**
+ * Owns the three clocks behind the grading spinner. Connection-level state
+ * (the idle clock) is reset by reconnects; grading-level state (the two stall
+ * clocks) deliberately is not, so a flapping connection cannot mask a grade
+ * that stopped moving.
+ */
+export class GradingWatchdog {
+  private idleTimer?: ReturnType<typeof setTimeout>;
+  private stallWarningTimer?: ReturnType<typeof setTimeout>;
+  private stallTimer?: ReturnType<typeof setTimeout>;
+  private stopped = false;
+  private warned = false;
+
+  private readonly idleTimeoutMs: number;
+  private readonly stallWarningMs: number;
+  private readonly stallTimeoutMs: number;
+
+  constructor(
+    private readonly handlers: GradingWatchdogHandlers,
+    options: GradingWatchdogOptions = {},
+  ) {
+    this.idleTimeoutMs = options.idleTimeoutMs ?? SSE_IDLE_TIMEOUT_MS;
+    this.stallWarningMs = options.stallWarningMs ?? GRADING_STALL_WARNING_MS;
+    this.stallTimeoutMs = options.stallTimeoutMs ?? GRADING_STALL_TIMEOUT_MS;
+  }
+
+  /** True once the warning window has elapsed with no grading progress. */
+  get hasWarned(): boolean {
+    return this.warned;
+  }
+
+  /** Arm the grading-liveness clocks. Call once, when the submission starts. */
+  startGradingClock(): void {
+    if (this.stopped) return;
+    this.armStallTimers();
+  }
+
+  /**
+   * (Re)arm the connection-liveness clock. Call on connect and on every
+   * inbound frame, heartbeats included — this clock measures the pipe, not
+   * the grade.
+   */
+  noteStreamActivity(): void {
+    if (this.stopped) return;
+    if (this.idleTimer) clearTimeout(this.idleTimer);
+    this.idleTimer = setTimeout(() => {
+      if (this.stopped) return;
+      this.handlers.onIdleTimeout();
+    }, this.idleTimeoutMs);
+  }
+
+  /** Disarm the connection clock while a reconnect is pending. */
+  clearStreamActivity(): void {
+    if (this.idleTimer) {
+      clearTimeout(this.idleTimer);
+      this.idleTimer = undefined;
+    }
+  }
+
+  /**
+   * Call for every non-heartbeat frame. The server publishes to the job
+   * channel only when job state actually changes, so any such frame is
+   * evidence that grading advanced.
+   */
+  noteGradingUpdate(): void {
+    if (this.stopped) return;
+    this.warned = false;
+    this.armStallTimers();
+  }
+
+  /** Terminal. Silences every clock; later notes are ignored. */
+  stop(): void {
+    this.stopped = true;
+    this.clearStreamActivity();
+    if (this.stallWarningTimer) {
+      clearTimeout(this.stallWarningTimer);
+      this.stallWarningTimer = undefined;
+    }
+    if (this.stallTimer) {
+      clearTimeout(this.stallTimer);
+      this.stallTimer = undefined;
+    }
+  }
+
+  private armStallTimers(): void {
+    if (this.stallWarningTimer) clearTimeout(this.stallWarningTimer);
+    if (this.stallTimer) clearTimeout(this.stallTimer);
+
+    this.stallWarningTimer = setTimeout(() => {
+      if (this.stopped) return;
+      this.warned = true;
+      this.handlers.onStallWarning();
+    }, this.stallWarningMs);
+
+    this.stallTimer = setTimeout(() => {
+      if (this.stopped) return;
+      this.handlers.onStallTimeout();
+    }, this.stallTimeoutMs);
+  }
+}

--- a/apps/web/lib/learner.ts
+++ b/apps/web/lib/learner.ts
@@ -541,15 +541,31 @@ export async function submitAssignment(
         url?: string;
       }> = [];
 
+      // The stall warning is non-destructive by design: the stream is still
+      // alive, so the learner should keep seeing whatever real progress they
+      // last had, not have it wiped back to zero just because the clock that
+      // reports it fired. Remember the last substantive update so the
+      // warning can carry it forward instead of 0/undefined.
+      let lastKnownProgress = 0;
+      let lastKnownMetadata:
+        | {
+            currentQuestion?: number;
+            totalQuestions?: number;
+            gradingState?: GradingProgressDetails;
+          }
+        | undefined;
+
       const watchdog = new GradingWatchdog({
         onIdleTimeout: () => handleIdleTimeout(),
         onStallWarning: () => {
           // Non-destructive: the stream is alive, so keep it open and keep
-          // grading. The learner just stops being lied to by a spinner.
+          // grading. The learner just stops being lied to by a spinner —
+          // and keeps seeing the progress they already had, not a reset.
           onProgress?.(
             "stalled",
-            0,
+            lastKnownProgress,
             "This is taking longer than usual. Your answers are submitted and grading is still running.",
+            lastKnownMetadata,
           );
         },
         onStallTimeout: () => {
@@ -641,11 +657,14 @@ export async function submitAssignment(
             if (data.status === "Processing" || data.status === "Pending") {
               const percentage = data.percentage || 0;
               const progress = data.progress || "Processing...";
-              onProgress?.("processing", percentage, progress, {
+              const metadata = {
                 currentQuestion: data.currentQuestion,
                 totalQuestions: data.totalQuestions,
                 gradingState: parseGradingState(data.result),
-              });
+              };
+              lastKnownProgress = percentage;
+              lastKnownMetadata = metadata;
+              onProgress?.("processing", percentage, progress, metadata);
             } else if (data.status === "Completed") {
               if (!settle()) return;
               onProgress?.("completed", 100, "Grading completed successfully!");
@@ -690,11 +709,14 @@ export async function submitAssignment(
             watchdog.noteGradingUpdate();
 
             if (data.progress && data.percentage !== undefined) {
-              onProgress?.("processing", data.percentage, data.progress, {
+              const metadata = {
                 currentQuestion: data.currentQuestion,
                 totalQuestions: data.totalQuestions,
                 gradingState: parseGradingState(data.result),
-              });
+              };
+              lastKnownProgress = data.percentage;
+              lastKnownMetadata = metadata;
+              onProgress?.("processing", data.percentage, data.progress, metadata);
             }
           } catch (error) {
             console.warn("SSE update event parse failed:", error);
@@ -806,14 +828,36 @@ export async function submitAssignment(
 
       /**
        * Terminal, but not a claim that grading failed: the job may still be
-       * running. File the diagnostic report, tell the caller what happened,
-       * and let the UI offer a re-check rather than declaring a lost
-       * submission.
+       * running. Tell the caller what happened and let the UI offer a
+       * re-check rather than declaring a lost submission — and do it before
+       * filing the diagnostic report, not after. The report is a network
+       * call (with its own author-report fallback network call behind it),
+       * and on a genuinely dead connection either can hang indefinitely; the
+       * whole point of this watchdog is a bounded time-to-honest-state, so
+       * the learner cannot be left waiting on a report that may never land.
+       * The report is best-effort from here on — its failure already falls
+       * back silently (see the catch below) and is not something the caller
+       * awaits.
        */
       const handleStreamLost = async (
         reason: "disconnected" | "stalled",
       ): Promise<void> => {
         if (!settle()) return;
+
+        const learnerMessage =
+          reason === "stalled"
+            ? "Grading stopped responding. Your answers were submitted — check your results in a moment."
+            : "We lost contact with the grading service. Your answers were submitted — check your results in a moment.";
+
+        onProgress?.("disconnected", 0, learnerMessage);
+        reject(
+          new GradingStreamLostError(
+            learnerMessage,
+            assignmentId,
+            attemptId,
+            reason,
+          ),
+        );
 
         const detailedErrorReport = {
           assignmentId,
@@ -857,21 +901,6 @@ export async function submitAssignment(
             );
           }
         }
-
-        const learnerMessage =
-          reason === "stalled"
-            ? "Grading stopped responding. Your answers were submitted — check your results in a moment."
-            : "We lost contact with the grading service. Your answers were submitted — check your results in a moment.";
-
-        onProgress?.("disconnected", 0, learnerMessage);
-        reject(
-          new GradingStreamLostError(
-            learnerMessage,
-            assignmentId,
-            attemptId,
-            reason,
-          ),
-        );
       };
 
       watchdog.startGradingClock();

--- a/apps/web/lib/learner.ts
+++ b/apps/web/lib/learner.ts
@@ -349,6 +349,11 @@ export async function submitQuestion(
       attemptId,
       questionId,
       status: getErrorStatus(err),
+      // The underlying failure reason, not the request/response payload:
+      // a generic Error.message (e.g. "Failed to fetch", "Internal Server
+      // Error") is safe to log and is exactly what this catch block would
+      // otherwise discard on translation to a SubmitQuestionResult.
+      error: err instanceof Error ? err.message : String(err),
     });
     return {
       ok: false,

--- a/apps/web/lib/learner.ts
+++ b/apps/web/lib/learner.ts
@@ -23,6 +23,11 @@ import { submitReportAuthor } from "@/lib/talkToBackend";
 import { apiClient, APIError } from "./api-client";
 import { isAuthApiError, withTransientRetry } from "./api-retry";
 import { normalizeAttemptTimestamps } from "@/app/learner/utils/attempts";
+import {
+  GradingWatchdog,
+  SSE_MAX_CONNECTION_ATTEMPTS,
+  SSE_RECONNECT_BACKOFF_STEP_MS,
+} from "./grading-stream-watchdog";
 
 /**
  * Machine-readable codes the API puts in 422 bodies from
@@ -118,6 +123,49 @@ export function isAiTemporarilyDisabled(err: unknown): boolean {
     getErrorCode(err) === "AI_TEMPORARILY_DISABLED" ||
     getErrorStatus(err) === 409
   );
+}
+
+/**
+ * States the grading spinner can be in. `stalled` means the stream is alive
+ * but grading has stopped advancing — the learner is told, nothing is torn
+ * down. `disconnected` is terminal: either the stream is gone or the stall
+ * outlasted its hard window.
+ */
+export type GradingProgressStatus =
+  | "processing"
+  | "completed"
+  | "failed"
+  | "stalled"
+  | "disconnected";
+
+/**
+ * Thrown when the grading stream stops being a usable source of truth. It is
+ * NOT a statement that grading failed — the job may well still be running
+ * server-side — so callers should keep the learner's context and offer a way
+ * to re-check, not report a failed submission.
+ */
+export class GradingStreamLostError extends Error {
+  constructor(
+    message: string,
+    readonly assignmentId: number,
+    readonly attemptId: number,
+    readonly reason: "disconnected" | "stalled",
+  ) {
+    super(message);
+    this.name = "GradingStreamLostError";
+  }
+}
+
+/**
+ * Duck-typed on purpose. `instanceof` is unreliable across Next's module
+ * boundary (the same reason the kill-switch check above does not use it), and
+ * a missed match here would close the modal on the learner instead of showing
+ * them the recovery actions.
+ */
+export function isGradingStreamLostError(
+  error: unknown,
+): error is GradingStreamLostError {
+  return error instanceof Error && error.name === "GradingStreamLostError";
 }
 
 /**
@@ -399,7 +447,7 @@ export async function submitAssignment(
   authorAssignmentDetails?: ReplaceAssignmentRequest,
   cookies?: string,
   onProgress?: (
-    status: "processing" | "completed" | "failed",
+    status: GradingProgressStatus,
     progress: number,
     message: string,
     metadata?: {
@@ -483,8 +531,9 @@ export async function submitAssignment(
 
     return new Promise((resolve, reject) => {
       let retryCount = 0;
-      const maxRetries = 3;
-      let allErrors: Array<{
+      let settled = false;
+      let activeSource: EventSource | undefined;
+      const allErrors: Array<{
         attempt: number;
         error: string;
         timestamp: string;
@@ -492,50 +541,73 @@ export async function submitAssignment(
         url?: string;
       }> = [];
 
+      const watchdog = new GradingWatchdog({
+        onIdleTimeout: () => handleIdleTimeout(),
+        onStallWarning: () => {
+          // Non-destructive: the stream is alive, so keep it open and keep
+          // grading. The learner just stops being lied to by a spinner.
+          onProgress?.(
+            "stalled",
+            0,
+            "This is taking longer than usual. Your answers are submitted and grading is still running.",
+          );
+        },
+        onStallTimeout: () => {
+          void handleStreamLost("stalled");
+        },
+      });
+
+      const settle = (): boolean => {
+        if (settled) return false;
+        settled = true;
+        watchdog.stop();
+        activeSource?.close();
+        return true;
+      };
+
+      const handleIdleTimeout = () => {
+        if (settled) return;
+        const currentAttempt = retryCount;
+        allErrors.push({
+          attempt: currentAttempt,
+          error: "Grading stream went silent",
+          timestamp: new Date().toISOString(),
+          readyState: activeSource?.readyState,
+          url: sseUrl,
+        });
+
+        watchdog.clearStreamActivity();
+        activeSource?.close();
+
+        if (currentAttempt < SSE_MAX_CONNECTION_ATTEMPTS) {
+          onProgress?.(
+            "processing",
+            0,
+            `Reconnecting to the grading service... (${currentAttempt}/${SSE_MAX_CONNECTION_ATTEMPTS})`,
+          );
+          setTimeout(
+            () => attemptConnection(),
+            SSE_RECONNECT_BACKOFF_STEP_MS * currentAttempt,
+          );
+        } else {
+          void handleStreamLost("disconnected");
+        }
+      };
+
       const attemptConnection = () => {
+        if (settled) return;
         retryCount++;
         const currentAttempt = retryCount;
 
         const eventSource = new EventSource(sseUrl, {
           withCredentials: true,
         });
-
-        let timeout: NodeJS.Timeout;
-        let isCompleted = false;
-
-        const resetTimeout = () => {
-          if (timeout) clearTimeout(timeout);
-          timeout = setTimeout(() => {
-            if (!isCompleted) {
-              const timeoutError = "Grading timeout - no updates received";
-              allErrors.push({
-                attempt: currentAttempt,
-                error: timeoutError,
-                timestamp: new Date().toISOString(),
-                readyState: eventSource.readyState,
-                url: sseUrl,
-              });
-
-              eventSource.close();
-
-              if (currentAttempt < maxRetries) {
-                onProgress?.(
-                  "processing",
-                  0,
-                  `Connection timed out. Retrying... (${currentAttempt}/${maxRetries})`,
-                );
-                setTimeout(() => attemptConnection(), 2000 * currentAttempt);
-              } else {
-                onProgress?.("failed", 0, timeoutError);
-                handleFinalFailure();
-              }
-            }
-          }, 300000);
-        };
-
-        resetTimeout();
+        activeSource = eventSource;
+        watchdog.noteStreamActivity();
 
         eventSource.onopen = () => {
+          if (settled) return;
+          watchdog.noteStreamActivity();
           onProgress?.(
             "processing",
             0,
@@ -544,7 +616,8 @@ export async function submitAssignment(
         };
 
         eventSource.onmessage = (event) => {
-          resetTimeout();
+          if (settled) return;
+          watchdog.noteStreamActivity();
 
           try {
             let data;
@@ -557,6 +630,8 @@ export async function submitAssignment(
             if (data.heartbeat) {
               return;
             }
+
+            watchdog.noteGradingUpdate();
 
             if (data.message && data.connectionId) {
               onProgress?.("processing", 0, data.message);
@@ -571,12 +646,9 @@ export async function submitAssignment(
                 totalQuestions: data.totalQuestions,
                 gradingState: parseGradingState(data.result),
               });
-            } else if (data.status === "Completed" && !isCompleted) {
-              isCompleted = true;
+            } else if (data.status === "Completed") {
+              if (!settle()) return;
               onProgress?.("completed", 100, "Grading completed successfully!");
-
-              eventSource.close();
-              clearTimeout(timeout);
 
               let result = data.result;
               if (typeof result === "string") {
@@ -590,16 +662,14 @@ export async function submitAssignment(
                 }
               }
               resolve(result);
-            } else if (data.status === "Failed" && !isCompleted) {
-              isCompleted = true;
-              onProgress?.("failed", 0, data.progress || "Grading failed");
-
-              eventSource.close();
-              clearTimeout(timeout);
+            } else if (data.status === "Failed") {
+              if (!settle()) return;
+              const failureMessage = data.progress || "Grading failed";
+              onProgress?.("failed", 0, failureMessage);
 
               setTimeout(() => {
-                toast.error(data.progress || "Grading failed");
-                reject(new Error(data.progress || "Grading failed"));
+                toast.error(failureMessage);
+                reject(new Error(failureMessage));
               }, 2000);
             }
           } catch (error) {
@@ -608,125 +678,118 @@ export async function submitAssignment(
         };
 
         eventSource.addEventListener("update", (event: any) => {
-          if (!isCompleted) {
-            resetTimeout();
-            try {
-              const data = JSON.parse(event.data);
+          if (settled) return;
+          watchdog.noteStreamActivity();
+          try {
+            const data = JSON.parse(event.data);
 
-              if (data.heartbeat) {
-                return;
-              }
-
-              if (data.progress && data.percentage !== undefined) {
-                onProgress?.("processing", data.percentage, data.progress, {
-                  currentQuestion: data.currentQuestion,
-                  totalQuestions: data.totalQuestions,
-                  gradingState: parseGradingState(data.result),
-                });
-              }
-            } catch (error) {
-              console.warn("SSE update event parse failed:", error);
+            if (data.heartbeat) {
+              return;
             }
+
+            watchdog.noteGradingUpdate();
+
+            if (data.progress && data.percentage !== undefined) {
+              onProgress?.("processing", data.percentage, data.progress, {
+                currentQuestion: data.currentQuestion,
+                totalQuestions: data.totalQuestions,
+                gradingState: parseGradingState(data.result),
+              });
+            }
+          } catch (error) {
+            console.warn("SSE update event parse failed:", error);
           }
         });
 
         eventSource.addEventListener("heartbeat", (event: any) => {
-          if (!isCompleted) {
-            resetTimeout();
-            try {
-              JSON.parse(event.data);
-            } catch (error) {
-              console.warn("SSE heartbeat parse failed:", error);
-            }
+          if (settled) return;
+          // Heartbeats prove the pipe is alive and nothing more, so they
+          // deliberately touch only the connection clock.
+          watchdog.noteStreamActivity();
+          try {
+            JSON.parse(event.data);
+          } catch (error) {
+            console.warn("SSE heartbeat parse failed:", error);
           }
         });
 
         eventSource.addEventListener("finalize", (event: any) => {
-          if (!isCompleted) {
-            try {
-              isCompleted = true;
-              const data = JSON.parse(event.data);
-              onProgress?.("completed", 100, "Grading completed successfully!");
+          if (settled) return;
+          try {
+            const data = JSON.parse(event.data);
+            if (!settle()) return;
+            onProgress?.("completed", 100, "Grading completed successfully!");
 
-              eventSource.close();
-              clearTimeout(timeout);
-
-              let result = data.result;
-              if (typeof result === "string") {
-                try {
-                  result = JSON.parse(result);
-                } catch (e) {
-                  console.warn(
-                    "SSE finalize: failed to JSON.parse result, returning raw string:",
-                    e,
-                  );
-                }
+            let result = data.result;
+            if (typeof result === "string") {
+              try {
+                result = JSON.parse(result);
+              } catch (e) {
+                console.warn(
+                  "SSE finalize: failed to JSON.parse result, returning raw string:",
+                  e,
+                );
               }
-              resolve(result);
-            } catch (error) {
-              reject(error);
             }
+            resolve(result);
+          } catch (error) {
+            if (!settle()) return;
+            reject(error);
           }
         });
 
         const handleConnectionError = () => {
-          if (!isCompleted) {
-            const errorDetails = {
-              attempt: currentAttempt,
-              error:
-                eventSource.readyState === EventSource.CLOSED
-                  ? "Connection to grading service lost"
-                  : "Grading stream error",
-              timestamp: new Date().toISOString(),
-              readyState: eventSource.readyState,
-              url: sseUrl,
-            };
+          if (settled) return;
+          allErrors.push({
+            attempt: currentAttempt,
+            error:
+              eventSource.readyState === EventSource.CLOSED
+                ? "Connection to grading service lost"
+                : "Grading stream error",
+            timestamp: new Date().toISOString(),
+            readyState: eventSource.readyState,
+            url: sseUrl,
+          });
 
-            allErrors.push(errorDetails);
+          watchdog.clearStreamActivity();
+          eventSource.close();
 
-            eventSource.close();
-            clearTimeout(timeout);
-
-            if (currentAttempt < maxRetries) {
-              const retryDelay = 2000 * currentAttempt;
-              onProgress?.(
-                "processing",
-                0,
-                `Connection lost. Retrying in ${retryDelay / 1000} seconds...`,
-              );
-              setTimeout(() => attemptConnection(), retryDelay);
-            } else {
-              handleFinalFailure();
-            }
+          if (currentAttempt < SSE_MAX_CONNECTION_ATTEMPTS) {
+            const retryDelay = SSE_RECONNECT_BACKOFF_STEP_MS * currentAttempt;
+            onProgress?.(
+              "processing",
+              0,
+              `Connection lost. Retrying in ${retryDelay / 1000} seconds...`,
+            );
+            setTimeout(() => attemptConnection(), retryDelay);
           } else {
-            eventSource.close();
+            void handleStreamLost("disconnected");
           }
         };
 
         eventSource.addEventListener("error", (event: any) => {
-          if (isCompleted) {
+          if (settled) {
+            eventSource.close();
             return;
           }
 
           if (event?.data) {
-            resetTimeout();
+            watchdog.noteStreamActivity();
             try {
               const data = JSON.parse(event.data);
 
               if (data?.status === "Failed") {
-                isCompleted = true;
+                if (!settle()) return;
                 const errorMessage =
                   data.progress || data.error || "Grading failed";
                 onProgress?.("failed", 0, errorMessage);
-
-                eventSource.close();
-                clearTimeout(timeout);
 
                 setTimeout(() => {
                   toast.error(errorMessage);
                   reject(new Error(errorMessage));
                 }, 2000);
               } else if (data?.error) {
+                watchdog.noteGradingUpdate();
                 const streamErrorMessage =
                   data.error || "Grading stream reported an error";
                 onProgress?.("processing", 0, streamErrorMessage);
@@ -741,25 +804,42 @@ export async function submitAssignment(
         });
       };
 
-      const handleFinalFailure = async () => {
+      /**
+       * Terminal, but not a claim that grading failed: the job may still be
+       * running. File the diagnostic report, tell the caller what happened,
+       * and let the UI offer a re-check rather than declaring a lost
+       * submission.
+       */
+      const handleStreamLost = async (
+        reason: "disconnected" | "stalled",
+      ): Promise<void> => {
+        if (!settle()) return;
+
         const detailedErrorReport = {
           assignmentId,
           attemptId,
           gradingJobId,
           sseUrl,
-          totalAttempts: maxRetries,
+          reason,
+          totalAttempts: retryCount,
           allErrors,
           finalFailureTime: new Date().toISOString(),
-          userAgent: navigator.userAgent,
-          url: window.location.href,
+          userAgent:
+            typeof navigator === "undefined" ? undefined : navigator.userAgent,
+          url: typeof window === "undefined" ? undefined : window.location.href,
         };
+
+        const summary =
+          reason === "stalled"
+            ? "Grading stream stalled with no progress"
+            : "Grading stream lost after all reconnect attempts";
 
         try {
           await submitReportLearner(
             assignmentId,
             attemptId,
             "TECHNICAL_ISSUE" as REPORT_TYPE,
-            `SSE Connection Failed After ${maxRetries} Attempts\n\nDetailed Error Report:\n${JSON.stringify(detailedErrorReport, null, 2)}`,
+            `${summary}\n\nDetailed Error Report:\n${JSON.stringify(detailedErrorReport, null, 2)}`,
             cookies,
           );
         } catch (reportError) {
@@ -767,27 +847,34 @@ export async function submitAssignment(
             await submitReportAuthor(
               assignmentId,
               "TECHNICAL_ISSUE" as REPORT_TYPE,
-              `SSE Connection Failed - Learner Report Fallback\n\nAttempt ID: ${attemptId}\nError Details:\n${JSON.stringify(detailedErrorReport, null, 2)}`,
+              `${summary} — learner report fallback\n\nAttempt ID: ${attemptId}\nError Details:\n${JSON.stringify(detailedErrorReport, null, 2)}`,
               cookies,
             );
           } catch (fallbackError) {
             console.error(
-              "💥 Author fallback report also failed:",
+              "Author fallback report also failed:",
               fallbackError,
             );
           }
         }
 
-        const finalErrorMessage = `Connection failed after ${maxRetries} attempts. Error details have been automatically reported.`;
-        onProgress?.("failed", 0, finalErrorMessage);
-        toast.error(finalErrorMessage);
+        const learnerMessage =
+          reason === "stalled"
+            ? "Grading stopped responding. Your answers were submitted — check your results in a moment."
+            : "We lost contact with the grading service. Your answers were submitted — check your results in a moment.";
+
+        onProgress?.("disconnected", 0, learnerMessage);
         reject(
-          new Error(
-            `SSE connection failed after ${maxRetries} attempts. Last error: ${allErrors[allErrors.length - 1]?.error || "Unknown error"}`,
+          new GradingStreamLostError(
+            learnerMessage,
+            assignmentId,
+            attemptId,
+            reason,
           ),
         );
       };
 
+      watchdog.startGradingClock();
       attemptConnection();
     });
   } catch (err) {

--- a/apps/web/lib/learner.ts
+++ b/apps/web/lib/learner.ts
@@ -275,8 +275,37 @@ export async function getSuccessPageData(
   }
 }
 
+export type SubmitQuestionResult =
+  | { ok: true; data: QuestionAttemptResponse }
+  | { ok: false; status?: number; message?: string };
+
+/**
+ * A message straight from a 4xx response body, safe to show a learner
+ * verbatim — e.g. `OversizedSubmissionError.learnerMessage`, which the API
+ * wraps in a `BadRequestException` specifically so this route can surface it.
+ * Never read for 5xx: those bodies are not written with a learner audience in
+ * mind and may contain internal detail.
+ */
+function getSafeErrorMessage(err: unknown): string | undefined {
+  const status = getErrorStatus(err);
+  if (status === undefined || status >= 500) {
+    return undefined;
+  }
+  const message = (err as { body?: { message?: string } } | undefined)?.body
+    ?.message;
+  return typeof message === "string" && message.length > 0
+    ? message
+    : undefined;
+}
+
 /**
  * Submits an answer for a given assignment, attempt, and question.
+ *
+ * Returns a discriminated result instead of throwing or returning `undefined`
+ * on failure: `ok: false` always carries whatever the server told us — the
+ * HTTP status, and (for 4xx responses only) a learner-safe `message` — so the
+ * caller can tell a real failure from a real success instead of treating
+ * every outcome as saved.
  */
 export async function submitQuestion(
   assignmentId: number,
@@ -284,7 +313,7 @@ export async function submitQuestion(
   questionId: number,
   requestBody: QuestionAttemptRequest,
   cookies?: string,
-): Promise<QuestionAttemptResponse | undefined> {
+): Promise<SubmitQuestionResult> {
   const endpointURL = `${getApiRoutes().assignments}/${assignmentId}/attempts/${attemptId}/questions/${questionId}/responses`;
 
   try {
@@ -305,11 +334,27 @@ export async function submitQuestion(
           "Content-Type": "application/json",
           ...(cookies ? { Cookie: cookies } : {}),
         },
+        // The caller (the auto-save hook) is the sole owner of user-facing
+        // messaging for this endpoint — it needs to tell a real failure from
+        // a real success and show its own honest toast. Suppress apiClient's
+        // generic status-code toast so the learner doesn't see a vague
+        // "Client Error: 400 Bad Request" moments before that honest toast.
+        quiet: true,
       },
     );
-    return data;
+    return { ok: true, data };
   } catch (err) {
-    return undefined;
+    console.error("submitQuestion failed", {
+      assignmentId,
+      attemptId,
+      questionId,
+      status: getErrorStatus(err),
+    });
+    return {
+      ok: false,
+      status: getErrorStatus(err),
+      message: getSafeErrorMessage(err),
+    };
   }
 }
 

--- a/apps/web/lib/learner.ts
+++ b/apps/web/lib/learner.ts
@@ -716,7 +716,12 @@ export async function submitAssignment(
               };
               lastKnownProgress = data.percentage;
               lastKnownMetadata = metadata;
-              onProgress?.("processing", data.percentage, data.progress, metadata);
+              onProgress?.(
+                "processing",
+                data.percentage,
+                data.progress,
+                metadata,
+              );
             }
           } catch (error) {
             console.warn("SSE update event parse failed:", error);
@@ -895,10 +900,7 @@ export async function submitAssignment(
               cookies,
             );
           } catch (fallbackError) {
-            console.error(
-              "Author fallback report also failed:",
-              fallbackError,
-            );
+            console.error("Author fallback report also failed:", fallbackError);
           }
         }
       };

--- a/apps/web/lib/talkToBackend.ts
+++ b/apps/web/lib/talkToBackend.ts
@@ -77,6 +77,7 @@ export const getAttempt = apiLearner.getAttempt;
 export const getCompletedAttempt = apiLearner.getCompletedAttempt;
 export const getSuccessPageData = apiLearner.getSuccessPageData;
 export const submitQuestion = apiLearner.submitQuestion;
+export type { SubmitQuestionResult } from "./learner";
 export const getLiveRecordingFeedback = apiLearner.getLiveRecordingFeedback;
 export const submitAssignment = apiLearner.submitAssignment;
 export const getFeedback = apiLearner.getFeedback;


### PR DESCRIPTION
Three reliability fixes, each developed and reviewed on its own branch, combined for a single merge.

## Grading progress delivery
- Server emits heartbeat/progress frames on the grading SSE stream; a new client watchdog (`grading-stream-watchdog.ts`) distinguishes a disconnected stream from a stalled one, reconnects, and surfaces an actionable state instead of an infinite spinner.
- Technical-issue reports now carry a `reason` field (`disconnected` vs `stalled`) — worth bucketing on from day one.
- Grading computation is untouched: no LLM, cache, or grade-write changes. Worst-case failure is a premature stall warning with a working report button; the submission itself is already safe server-side.
- Before rollout: measure the largest real inter-frame gap on heavy-tier file/presentation grading in staging — a single question chain exceeding ~900s with no progress frame trips the stall warning on a live grade.

## GitHub URL grading fetch
- URL-question grading resolves a repo's actual default branch via api.github.com instead of guessing `main`/`master` (repos with other default branches were silently graded on wrong or missing content).
- Three hand-copied fetch pipelines are deduplicated into `github-content-fetch.util.ts` (net −340 lines); the SSRF guard applies unchanged.
- GitHub rate limits now surface as typed retryable errors instead of silent zero grades; default-branch lookups are memoized (5 min) to cap API volume.
- **Ops, at rollout:** provision `GITHUB_GRADING_API_TOKEN` (optional env). Unauthenticated fallback works but stays at 60 req/hr/IP shared across all concurrent learners; the token raises this to 5000/hr. It is a server credential, separate from the per-user GitHub OAuth feature.

## Autosave hardening (ships as dead code)
- A hardened autosave path that stops swallowing save errors behind a false "Response saved" toast. Nothing calls it yet — zero behavior change; re-enablement lands as its own PR.

## Safety
- No changes to auth, session, cookies, LTI, or assignment publishing; no existing API route modified (verified against the diffs).
- Full api + web suites and typechecks green on the combined tree.