### PR TITLE
fix: never turn an upload grading failure into a learner's zero

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": null,
     "lines": null
   },
-  "generated_at": "2026-07-04T03:45:34Z",
+  "generated_at": "2026-08-07T18:30:43Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -238,7 +238,7 @@
       {
         "hashed_secret": "2c0580ffd7d80319531cf629f5e90f747b1386f1",
         "is_verified": false,
-        "line_number": 3209,
+        "line_number": 3304,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": null,
     "lines": null
   },
-  "generated_at": "2026-08-07T18:30:43Z",
+  "generated_at": "2026-08-07T18:47:08Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -238,7 +238,7 @@
       {
         "hashed_secret": "2c0580ffd7d80319531cf629f5e90f747b1386f1",
         "is_verified": false,
-        "line_number": 3304,
+        "line_number": 3334,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": null,
     "lines": null
   },
-  "generated_at": "2026-08-07T18:47:08Z",
+  "generated_at": "2026-08-07T20:32:36Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -238,7 +238,7 @@
       {
         "hashed_secret": "2c0580ffd7d80319531cf629f5e90f747b1386f1",
         "is_verified": false,
-        "line_number": 3334,
+        "line_number": 3329,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/apps/api/src/api/attempt/services/file-content-extraction.spec.ts
+++ b/apps/api/src/api/attempt/services/file-content-extraction.spec.ts
@@ -1,0 +1,102 @@
+import { S3Service } from "src/api/files/services/s3.service";
+import { UnextractableSubmissionError } from "../../llm/features/grading/errors/unextractable-submission.error";
+import { FileContentExtractionService } from "./file-content-extraction";
+import { PdfStructureExtractorService } from "./pdf-structure-extractor.service";
+
+/**
+ * The fallback strategies will return *something* for any bytes at all — a few
+ * ASCII fragments scraped out of a compressed archive, or a hex dump. Passed to
+ * a grader, that reads as a learner who submitted nothing of substance, and
+ * every criterion is scored zero. These tests pin the boundary where extraction
+ * refuses to produce gradable-looking output it cannot stand behind.
+ */
+describe("FileContentExtractionService — unextractable uploads are rejected", () => {
+  interface ExtractInternals {
+    extractTextFromBuffer(
+      buffer: Buffer,
+      filename: string,
+      mimeType: string,
+    ): Promise<{ text: string; encoding?: string }>;
+  }
+
+  function internals(): ExtractInternals {
+    const service = new FileContentExtractionService(
+      {} as S3Service,
+      {} as PdfStructureExtractorService,
+    );
+    return service as unknown as ExtractInternals;
+  }
+
+  it("rejects Apple iWork files with export guidance instead of scraping them", async () => {
+    // The observed production case: a Numbers file named to look like a
+    // spreadsheet. It is a ZIP archive, so extraction "succeeds" with fragments.
+    const buffer = Buffer.from("PKbinary numbers archive body");
+
+    const error = await internals()
+      .extractTextFromBuffer(
+        buffer,
+        "Fleet_Inventory_PART_1_END.XLSX..numbers",
+        "application/octet-stream",
+      )
+      .catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(UnextractableSubmissionError);
+    const typed = error as UnextractableSubmissionError;
+    expect(typed.reason).toBe("unsupported_format");
+    expect(typed.learnerMessage).toContain("Excel");
+    // The learner must be able to tell which upload to replace.
+    expect(typed.learnerMessage).toContain(
+      "Fleet_Inventory_PART_1_END.XLSX..numbers",
+    );
+  });
+
+  it("rejects an unrecognized file whose extraction yields only fragments", async () => {
+    // Five printable characters surrounded by binary — the exact shape that
+    // reached the grader in production as `"content":"InCos"`.
+    const buffer = Buffer.from([
+      0x00, 0x01, 0x02, 0x49, 0x6e, 0x43, 0x6f, 0x73, 0x00, 0x03, 0x04, 0xff,
+      0xfe, 0x00, 0x11,
+    ]);
+
+    const error = await internals()
+      .extractTextFromBuffer(
+        buffer,
+        "submission.bin",
+        "application/octet-stream",
+      )
+      .catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(UnextractableSubmissionError);
+    expect((error as UnextractableSubmissionError).reason).toMatch(
+      /binary_content|insufficient_text/,
+    );
+  });
+
+  it("names the file in the message when there is no format-specific advice", async () => {
+    const buffer = Buffer.from([0x00, 0x01, 0x02, 0x00, 0xff, 0xfe]);
+
+    const error = await internals()
+      .extractTextFromBuffer(
+        buffer,
+        "coursework.bin",
+        "application/octet-stream",
+      )
+      .catch((e: unknown) => e);
+
+    expect((error as UnextractableSubmissionError).learnerMessage).toContain(
+      "coursework.bin",
+    );
+  });
+
+  it("still extracts a readable text file", async () => {
+    const text =
+      "This is the learner's actual submitted answer, long enough to grade.";
+    const result = await internals().extractTextFromBuffer(
+      Buffer.from(text, "utf8"),
+      "answer.txt",
+      "text/plain",
+    );
+
+    expect(result.text).toContain("actual submitted answer");
+  });
+});

--- a/apps/api/src/api/attempt/services/file-content-extraction.spec.ts
+++ b/apps/api/src/api/attempt/services/file-content-extraction.spec.ts
@@ -99,4 +99,47 @@ describe("FileContentExtractionService — unextractable uploads are rejected", 
 
     expect(result.text).toContain("actual submitted answer");
   });
+
+  /**
+   * The production failure that neither the length nor the encoding check
+   * catches. UTF-16LE decoding does not produce the replacement characters
+   * that disqualify the other encodings, so an 800KB archive decoded into
+   * ~400k characters of plausible-looking CJK and was graded as the learner's
+   * work. Unpaired surrogates are the part that cannot survive UTF-8 encoding,
+   * which is what made the model provider reject the request outright.
+   */
+  it("rejects binary that UTF-16LE decoding turned into plausible text", async () => {
+    // Repeating U+D800 (bytes 00 D8 little-endian) then "A": a lone high
+    // surrogate. Invalid as UTF-8, so extraction falls through to UTF-16LE.
+    const pattern = Buffer.from([0x00, 0xd8, 0x41, 0x00]);
+    const buffer = Buffer.concat(Array.from({ length: 1000 }, () => pattern));
+
+    const error = await internals()
+      .extractTextFromBuffer(
+        buffer,
+        "coursework.dat",
+        "application/octet-stream",
+      )
+      .catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(UnextractableSubmissionError);
+    const typed = error as UnextractableSubmissionError;
+    expect(typed.reason).toBe("binary_content");
+    // Length alone would have passed this: it is far above the floor.
+    expect(typed.extractedLength).toBeGreaterThan(100);
+  });
+
+  it("does not mistake genuine non-Latin text for decoded binary", async () => {
+    // Well-formed CJK has no unpaired surrogates and must survive the guard,
+    // otherwise the check would reject real submissions in these languages.
+    const japanese =
+      "これは学習者が提出した実際の解答です。採点できる長さがあります。";
+    const result = await internals().extractTextFromBuffer(
+      Buffer.from(japanese, "utf8"),
+      "coursework.dat",
+      "application/octet-stream",
+    );
+
+    expect(result.text).toContain("学習者");
+  });
 });

--- a/apps/api/src/api/attempt/services/file-content-extraction.spec.ts
+++ b/apps/api/src/api/attempt/services/file-content-extraction.spec.ts
@@ -142,4 +142,95 @@ describe("FileContentExtractionService — unextractable uploads are rejected", 
 
     expect(result.text).toContain("学習者");
   });
+
+  it("keeps astral characters that arrive as correctly paired surrogates", async () => {
+    // Emoji and CJK extension characters live above the BMP and are encoded
+    // as surrogate *pairs* in JavaScript strings. The guard exists to catch
+    // lone halves; a paired one is ordinary text and must pass, or the check
+    // would start rejecting real submissions that merely contain an emoji.
+    const astral = "The answer 🎓 also cites 𠀀 from the reading list.";
+    const result = await internals().extractTextFromBuffer(
+      Buffer.from(astral, "utf8"),
+      "coursework.dat",
+      "application/octet-stream",
+    );
+
+    expect(result.text).toContain("🎓");
+    expect(result.text).toContain("𠀀");
+  });
+
+  it("accepts fallback text exactly at the minimum length", async () => {
+    const twentyChars = "a".repeat(20);
+    const result = await internals().extractTextFromBuffer(
+      Buffer.from(twentyChars, "utf8"),
+      "coursework.dat",
+      "application/octet-stream",
+    );
+
+    expect(result.text.trim()).toHaveLength(20);
+  });
+
+  it("rejects fallback text one character below the minimum", async () => {
+    const nineteenChars = "a".repeat(19);
+    const error = await internals()
+      .extractTextFromBuffer(
+        Buffer.from(nineteenChars, "utf8"),
+        "coursework.dat",
+        "application/octet-stream",
+      )
+      .catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(UnextractableSubmissionError);
+    expect((error as UnextractableSubmissionError).reason).toBe(
+      "insufficient_text",
+    );
+  });
+
+  it("does not reject a .key file that is not an iWork container", async () => {
+    // The unsupported-extension list names iWork suffixes, but "key" also
+    // means PEM key files in CS coursework, and a dotless filename makes its
+    // whole name the extension token. iWork documents are ZIP containers, so
+    // only the ZIP signature makes the extension token trustworthy.
+    const pem =
+      "-----BEGIN PUBLIC KEY-----\n" +
+      "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA7bq0\n" +
+      "-----END PUBLIC KEY-----\n";
+    const result = await internals().extractTextFromBuffer(
+      Buffer.from(pem, "utf8"),
+      "server.key",
+      "application/octet-stream",
+    );
+
+    expect(result.text).toContain("BEGIN PUBLIC KEY");
+  });
+});
+
+/**
+ * A file the service cannot even fetch is a different failure class from one
+ * it cannot read: the learner did nothing wrong and the bytes may be fine.
+ * Turning that into placeholder "content" hands the grader a note about a
+ * missing file to score — the job must fail and retry instead.
+ */
+describe("FileContentExtractionService — infrastructure failures fail the job", () => {
+  it("propagates a storage failure instead of returning gradable placeholder text", async () => {
+    const failingS3 = {
+      getObject: jest.fn().mockRejectedValue(new Error("connection reset")),
+    } as unknown as S3Service;
+    const service = new FileContentExtractionService(
+      failingS3,
+      {} as PdfStructureExtractorService,
+    );
+
+    await expect(
+      service.extractContentFromFiles([
+        {
+          filename: "essay.txt",
+          content: "",
+          fileType: "text/plain",
+          bucket: "submissions",
+          key: "attempt-1/essay.txt",
+        },
+      ]),
+    ).rejects.toThrow("Could not retrieve file");
+  });
 });

--- a/apps/api/src/api/attempt/services/file-content-extraction.ts
+++ b/apps/api/src/api/attempt/services/file-content-extraction.ts
@@ -99,6 +99,14 @@ interface JupyterOutput {
   execution_count?: number;
 }
 
+/**
+ * A high surrogate not followed by a low one, or a low surrogate not preceded
+ * by a high one. Deliberately not global: a /g regex carries lastIndex between
+ * .test() calls and would alternate between hits and misses.
+ */
+const LONE_SURROGATE_RE =
+  /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?:[^\uD800-\uDBFF]|^)[\uDC00-\uDFFF]/;
+
 @Injectable()
 export class FileContentExtractionService {
   private readonly logger = new Logger(FileContentExtractionService.name);
@@ -978,6 +986,28 @@ export class FileContentExtractionService {
       this.logger.warn(
         `extractTextFromBuffer rejected: filename=${filename} ` +
           `extension=${extension} encoding=${encoding} reason=binary_content`,
+      );
+      throw new UnextractableSubmissionError({
+        filename,
+        reason: "binary_content",
+        extension,
+        extractedLength: result.text.length,
+      });
+    }
+
+    // Arbitrary bytes decoded as UTF-16LE almost never produce the replacement
+    // characters that guard the other encodings, so binary sails through as
+    // hundreds of kilobytes of plausible-looking CJK. The tell is unpaired
+    // surrogates: valid text never carries them, and they cannot be encoded to
+    // UTF-8 — which is what made the model provider reject the whole request
+    // body and, in turn, zero every criterion. Length and encoding checks both
+    // miss this, so it is tested on its own.
+    if (LONE_SURROGATE_RE.test(result.text)) {
+      this.logger.warn(
+        `extractTextFromBuffer rejected: filename=${filename} ` +
+          `extension=${extension} encoding=${encoding} ` +
+          `extractedLength=${result.text.length} reason=binary_content ` +
+          `detail=lone_surrogates`,
       );
       throw new UnextractableSubmissionError({
         filename,

--- a/apps/api/src/api/attempt/services/file-content-extraction.ts
+++ b/apps/api/src/api/attempt/services/file-content-extraction.ts
@@ -216,31 +216,19 @@ export class FileContentExtractionService {
 
           return result;
         } catch (error) {
-          // Learner-facing failures are verdicts about the submission itself,
-          // so they must reach the learner. Degrading one into the placeholder
-          // below would hand the grader a note about a missing file and let it
-          // score the criteria zero — the silent wrong grade this class exists
-          // to prevent.
-          if (error instanceof LearnerFacingGradingError) {
-            throw error;
-          }
+          // Every failure propagates. Learner-facing errors are verdicts about
+          // the submission itself and must reach the learner; anything else —
+          // a COS blip, a parser crash — must fail the job so it retries or
+          // lands in triage. Returning a placeholder here would hand the
+          // grader a note about a missing file and let it score the criteria
+          // zero: a silent wrong grade for a fault that was never the
+          // learner's. Callers that prefer to degrade (author reference
+          // uploads, chat) already catch around this call.
           this.logger.error(
             `Failed to extract content from ${file.filename}:`,
             error,
           );
-
-          const errorMessage =
-            error instanceof Error ? error.message : "Unknown error";
-          return {
-            filename: file.filename,
-            content:
-              `[ERROR extracting ${file.filename}: ${errorMessage}]\n` +
-              `File type: ${file.fileType}\n` +
-              `This file could not be processed, but it exists in the submission.`,
-            error: errorMessage,
-            fileType: file.fileType,
-            metadata: { size: 0 },
-          };
+          throw error;
         }
       }),
     );
@@ -896,7 +884,14 @@ export class FileContentExtractionService {
         `byteSize=${byteSize} sha256=${sha256Short} magicBytes=${magicBytesHex}`,
     );
 
-    if (this.UNSUPPORTED_EXTENSIONS.has(fileExtension)) {
+    // iWork documents are always ZIP containers, so require the ZIP signature
+    // before trusting the extension token: a PEM-style .key file or a dotless
+    // file that happens to be named "numbers" is not an iWork document and
+    // deserves normal extraction, not export guidance for the wrong app.
+    if (
+      this.UNSUPPORTED_EXTENSIONS.has(fileExtension) &&
+      magicBytesHex.startsWith("504b")
+    ) {
       this.logger.warn(
         `extractTextFromBuffer rejected: filename=${filename} ` +
           `extension=${fileExtension} byteSize=${byteSize} sha256=${sha256Short} ` +

--- a/apps/api/src/api/attempt/services/file-content-extraction.ts
+++ b/apps/api/src/api/attempt/services/file-content-extraction.ts
@@ -10,7 +10,9 @@ import { S3Service } from "src/api/files/services/s3.service";
 import * as unzipper from "unzipper";
 import * as XLSX from "xlsx";
 import { parseStringPromise } from "xml2js";
+import { LearnerFacingGradingError } from "../../llm/features/grading/errors/learner-facing-grading.error";
 import { OversizedSubmissionError } from "../../llm/features/grading/errors/oversized-submission.error";
+import { UnextractableSubmissionError } from "../../llm/features/grading/errors/unextractable-submission.error";
 import { compactWorksheet } from "../../llm/features/grading/services/spreadsheet-used-range.utils";
 import { LearnerFileUpload } from "../common/interfaces/attempt.interface";
 import { provenanceArtifactKey } from "../common/utils/provenance-artifact.util";
@@ -104,6 +106,25 @@ export class FileContentExtractionService {
   private readonly CHUNK_SIZE = 10_000;
   private readonly BINARY_SAMPLE_SIZE = 5000;
 
+  /**
+   * Container formats with no extractor here. They are ZIP archives, so the
+   * fallback strategies happily scrape a few ASCII fragments out of their
+   * internals and return them as if they were the learner's work. Reject them
+   * up front, where we can name the format and tell the learner what to export.
+   */
+  private readonly UNSUPPORTED_EXTENSIONS = new Set([
+    "numbers",
+    "pages",
+    "key",
+  ]);
+
+  /**
+   * Below this many characters, an unrecognized file's extracted text is
+   * fragments rather than content. Applied only on the fallback path, so
+   * recognized formats keep their existing behaviour at any length.
+   */
+  private readonly MIN_FALLBACK_TEXT_LENGTH = 20;
+
   private readonly mimeTypeMap: Record<string, string[]> = {
     "text/plain": ["txt", "log", "md", "markdown", "rst", "asc", "text"],
     "application/json": ["json", "jsonl", "geojson", "topojson"],
@@ -187,7 +208,12 @@ export class FileContentExtractionService {
 
           return result;
         } catch (error) {
-          if (error instanceof OversizedSubmissionError) {
+          // Learner-facing failures are verdicts about the submission itself,
+          // so they must reach the learner. Degrading one into the placeholder
+          // below would hand the grader a note about a missing file and let it
+          // score the criteria zero — the silent wrong grade this class exists
+          // to prevent.
+          if (error instanceof LearnerFacingGradingError) {
             throw error;
           }
           this.logger.error(
@@ -862,6 +888,19 @@ export class FileContentExtractionService {
         `byteSize=${byteSize} sha256=${sha256Short} magicBytes=${magicBytesHex}`,
     );
 
+    if (this.UNSUPPORTED_EXTENSIONS.has(fileExtension)) {
+      this.logger.warn(
+        `extractTextFromBuffer rejected: filename=${filename} ` +
+          `extension=${fileExtension} byteSize=${byteSize} sha256=${sha256Short} ` +
+          `reason=unsupported_format`,
+      );
+      throw new UnextractableSubmissionError({
+        filename,
+        reason: "unsupported_format",
+        extension: fileExtension,
+      });
+    }
+
     try {
       const result = await this.extractByExtension(
         buffer,
@@ -892,6 +931,7 @@ export class FileContentExtractionService {
       }
 
       const fallbackResult = await this.extractWithFallback(buffer, filename);
+      this.assertFallbackIsGradable(fallbackResult, filename, fileExtension);
       this.logger.log(
         `extractTextFromBuffer completed: filename=${filename} ` +
           `extension=${fileExtension} byteSize=${byteSize} sha256=${sha256Short} ` +
@@ -899,6 +939,12 @@ export class FileContentExtractionService {
       );
       return fallbackResult;
     } catch (error) {
+      // A learner-facing error is a verdict, not a fault to recover from —
+      // retrying the fallback would only re-derive the garbage it rejected.
+      if (error instanceof LearnerFacingGradingError) {
+        throw error;
+      }
+
       this.logger.warn(
         `Primary extraction failed: filename=${filename} ` +
           `extension=${fileExtension} byteSize=${byteSize} sha256=${sha256Short} ` +
@@ -906,7 +952,54 @@ export class FileContentExtractionService {
           `error=${error instanceof Error ? error.message : String(error)}`,
         error instanceof Error ? error.stack : undefined,
       );
-      return await this.extractWithFallback(buffer, filename);
+      const fallbackResult = await this.extractWithFallback(buffer, filename);
+      this.assertFallbackIsGradable(fallbackResult, filename, fileExtension);
+      return fallbackResult;
+    }
+  }
+
+  /**
+   * Gate the fallback path's output before it can reach a grader.
+   *
+   * Reaching the fallback already means neither the extension nor the MIME type
+   * was recognized. When that path then yields a binary dump, an unrecognized-
+   * bytes summary, or a few stray characters, there is nothing to grade — and
+   * handing it to the model produces a confident zero against content the
+   * learner never wrote. Only the fallback path is checked, so recognized
+   * formats keep their existing behaviour no matter how short their text.
+   */
+  private assertFallbackIsGradable(
+    result: { text: string; encoding?: string },
+    filename: string,
+    extension: string,
+  ): void {
+    const encoding = result.encoding ?? "";
+    if (encoding === "binary" || encoding === "unknown") {
+      this.logger.warn(
+        `extractTextFromBuffer rejected: filename=${filename} ` +
+          `extension=${extension} encoding=${encoding} reason=binary_content`,
+      );
+      throw new UnextractableSubmissionError({
+        filename,
+        reason: "binary_content",
+        extension,
+        extractedLength: result.text.length,
+      });
+    }
+
+    const usableLength = result.text.trim().length;
+    if (usableLength < this.MIN_FALLBACK_TEXT_LENGTH) {
+      this.logger.warn(
+        `extractTextFromBuffer rejected: filename=${filename} ` +
+          `extension=${extension} extractedLength=${usableLength} ` +
+          `reason=insufficient_text`,
+      );
+      throw new UnextractableSubmissionError({
+        filename,
+        reason: "insufficient_text",
+        extension,
+        extractedLength: usableLength,
+      });
     }
   }
 

--- a/apps/api/src/api/llm/features/grading/errors/unextractable-submission.error.ts
+++ b/apps/api/src/api/llm/features/grading/errors/unextractable-submission.error.ts
@@ -1,0 +1,88 @@
+/**
+ * Thrown when an uploaded file yields no gradable text: either its format is
+ * one we have no extractor for, or every extraction strategy fell through to
+ * the binary/unrecognized fallbacks.
+ *
+ * Without this, the fallback's output — a handful of ASCII fragments scraped
+ * out of a compressed archive — is passed to the model as if it were the
+ * learner's work. The model cannot find anything to credit, so every criterion
+ * is scored zero and the learner is penalised for a format we never supported.
+ * Failing here converts that silent wrong grade into an actionable message.
+ *
+ * Terminal by construction: re-running the same bytes through the same
+ * extractors cannot produce a different result.
+ *
+ * The fields are exposed as own enumerable properties so the project logger
+ * can serialize them as structured context without leaking the message.
+ */
+import { LearnerFacingGradingError } from "./learner-facing-grading.error";
+
+export type UnextractableReason =
+  /** Extension is on the known-unsupported list — no extractor was tried. */
+  | "unsupported_format"
+  /** Every strategy fell through to a binary or unrecognized-bytes dump. */
+  | "binary_content"
+  /** An extractor ran but produced too little text to grade against. */
+  | "insufficient_text";
+
+export interface UnextractableSubmissionErrorFields {
+  filename: string;
+  reason: UnextractableReason;
+  extension?: string;
+  extractedLength?: number;
+  questionId?: number;
+  attemptId?: number;
+}
+
+/** Formats learners commonly submit that no extractor in this service handles. */
+const CONVERSION_GUIDANCE: Record<string, string> = {
+  numbers: "Excel (.xlsx) or CSV",
+  pages: "Word (.docx) or PDF",
+  key: "PowerPoint (.pptx) or PDF",
+};
+
+export class UnextractableSubmissionError extends LearnerFacingGradingError {
+  public readonly filename: string;
+  public readonly reason: UnextractableReason;
+  public readonly extension?: string;
+  public readonly extractedLength?: number;
+  public readonly questionId?: number;
+  public readonly attemptId?: number;
+
+  constructor(fields: UnextractableSubmissionErrorFields) {
+    super(
+      `No gradable text could be extracted from "${fields.filename}" (reason=${
+        fields.reason
+      }, extension=${fields.extension ?? "none"}, extractedLength=${
+        fields.extractedLength ?? 0
+      }).`,
+    );
+    this.name = "UnextractableSubmissionError";
+    this.filename = fields.filename;
+    this.reason = fields.reason;
+    this.extension = fields.extension;
+    this.extractedLength = fields.extractedLength;
+    this.questionId = fields.questionId;
+    this.attemptId = fields.attemptId;
+
+    // Restore the prototype chain when extending built-in Error so that
+    // `instanceof` works correctly under the project's TypeScript target.
+    Object.setPrototypeOf(this, UnextractableSubmissionError.prototype);
+  }
+
+  /**
+   * Message safe to show a learner in the grading modal. Names the file and the
+   * action that fixes it; extraction internals stay in `message` and the logs.
+   */
+  get learnerMessage(): string {
+    const guidance = this.extension
+      ? CONVERSION_GUIDANCE[this.extension]
+      : undefined;
+
+    if (guidance) {
+      return `We can't read "${this.filename}" — that file format isn't supported for grading. Please save or export your work as ${guidance} and submit it again.`;
+    }
+
+    return `We couldn't read any text from "${this.filename}", so it can't be graded. Check that you uploaded the right file and that it isn't empty, password-protected, or corrupted, then submit it again.`;
+  }
+}

--- a/apps/api/src/api/llm/features/grading/services/evidence-based-grading.service.spec.ts
+++ b/apps/api/src/api/llm/features/grading/services/evidence-based-grading.service.spec.ts
@@ -54,17 +54,13 @@ describe("EvidenceBasedGradingService — criterion failures never become scores
 
   function buildService(promptProcessor: IPromptProcessor): {
     service: EvidenceBasedGradingService;
-    errorLogs: string[];
   } {
-    const errorLogs: string[] = [];
     const logger = {
       child: () => logger,
       debug: jest.fn(),
       info: jest.fn(),
       warn: jest.fn(),
-      error: jest.fn((message: string) => {
-        errorLogs.push(message);
-      }),
+      error: jest.fn(),
     } as unknown as Logger;
 
     // The pipeline always throws here, which is what routes grading onto the
@@ -92,7 +88,7 @@ describe("EvidenceBasedGradingService — criterion failures never become scores
       logger,
     );
 
-    return { service, errorLogs };
+    return { service };
   }
 
   const grade = (service: EvidenceBasedGradingService) =>

--- a/apps/api/src/api/llm/features/grading/services/evidence-based-grading.service.spec.ts
+++ b/apps/api/src/api/llm/features/grading/services/evidence-based-grading.service.spec.ts
@@ -1,0 +1,185 @@
+import { Logger } from "winston";
+import { CanonicalSubmission } from "src/api/attempt/services/structured-content.models";
+import { IPromptProcessor } from "src/api/llm/core/interfaces/prompt-processor.interface";
+import { LearnerFacingGradingError } from "../errors/learner-facing-grading.error";
+import { RubricCriterion } from "../types/criterion-evidence.types";
+import { CriterionEvidencePipelineService } from "./criterion-evidence-pipeline.service";
+import { EvidenceBasedGradingService } from "./evidence-based-grading.service";
+import { EvidenceChunkingService } from "./evidence-chunking.service";
+import { HighlightingGeneratorService } from "./highlighting-generator.service";
+import { ImageDescriptionService } from "./image-description.service";
+
+/**
+ * These cover the legacy per-criterion fallback, which runs whenever the
+ * evidence pipeline throws. It used to answer a failed criterion with zero
+ * points and a `does_not_meet` decision, so an unreadable file or a provider
+ * outage was recorded as work the learner had failed to do.
+ */
+describe("EvidenceBasedGradingService — criterion failures never become scores", () => {
+  const criterion: RubricCriterion = {
+    id: "criterion_0",
+    rubricQuestion: "Explain the concept",
+    description: "",
+    criteria: [
+      { description: "Not met", points: 0 },
+      { description: "Met", points: 4 },
+    ],
+    maxPoints: 4,
+  };
+
+  const submission: CanonicalSubmission = {
+    submissionId: "sub-1",
+    metadata: {
+      wordCount: 10,
+      pageCount: 1,
+      blockCount: 1,
+      sourceType: "txt",
+      checksum: "abc123",
+      extractedAt: "2026-08-07T00:00:00.000Z",
+    },
+    pages: [
+      {
+        pageNumber: 1,
+        blocks: [
+          {
+            blockId: "b1",
+            page: 1,
+            type: "paragraph",
+            text: "The learner wrote a real answer here.",
+          },
+        ],
+      },
+    ],
+  } as unknown as CanonicalSubmission;
+
+  function buildService(promptProcessor: IPromptProcessor): {
+    service: EvidenceBasedGradingService;
+    errorLogs: string[];
+  } {
+    const errorLogs: string[] = [];
+    const logger = {
+      child: () => logger,
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn((message: string) => {
+        errorLogs.push(message);
+      }),
+    } as unknown as Logger;
+
+    // The pipeline always throws here, which is what routes grading onto the
+    // legacy per-criterion path these tests are about.
+    const evidencePipeline = {
+      gradeWithEvidence: jest
+        .fn()
+        .mockRejectedValue(new Error("pipeline unavailable")),
+    } as unknown as CriterionEvidencePipelineService;
+
+    const service = new EvidenceBasedGradingService(
+      promptProcessor,
+      {
+        describeImages: jest.fn().mockResolvedValue(undefined),
+      } as unknown as ImageDescriptionService,
+      {
+        generateHighlightsFromEvidence: jest
+          .fn()
+          .mockReturnValue({ pages: {}, blockHighlights: {} }),
+      } as unknown as HighlightingGeneratorService,
+      {
+        extractFromSubmission: jest.fn().mockReturnValue([]),
+      } as unknown as EvidenceChunkingService,
+      evidencePipeline,
+      logger,
+    );
+
+    return { service, errorLogs };
+  }
+
+  const grade = (service: EvidenceBasedGradingService) =>
+    service.gradeSubmission(submission, [criterion], "Question?", 1, "en");
+
+  it("fails the job instead of scoring zero when a criterion cannot be graded", async () => {
+    const promptProcessor = {
+      processPromptForFeature: jest
+        .fn()
+        .mockRejectedValue(
+          new Error("400 Invalid body: failed to parse JSON value."),
+        ),
+    } as unknown as IPromptProcessor;
+
+    const { service } = buildService(promptProcessor);
+
+    // The regression: this used to resolve with pointsAwarded 0 rather than reject.
+    await expect(grade(service)).rejects.toThrow(
+      "400 Invalid body: failed to parse JSON value.",
+    );
+  });
+
+  it("retries a transient failure and keeps the recovered grade", async () => {
+    const processPromptForFeature = jest
+      .fn()
+      .mockRejectedValueOnce(new Error("503 upstream unavailable"))
+      .mockResolvedValue(
+        JSON.stringify({
+          evidence: [
+            {
+              blockId: "b1",
+              quote: "The learner wrote a real answer here.",
+              page: 1,
+            },
+          ],
+          decision: "meets",
+          pointsAwarded: 4,
+          rationale: "The submission addresses the criterion in full.",
+          explanation:
+            "The cited sentence directly answers what the criterion asks for.",
+        }),
+      );
+
+    const { service } = buildService({
+      processPromptForFeature,
+    } as unknown as IPromptProcessor);
+
+    const result = await grade(service);
+
+    expect(processPromptForFeature).toHaveBeenCalledTimes(2);
+    expect(result.totalPoints).toBe(4);
+    expect(result.criteriaResults[0].pointsAwarded).toBe(4);
+  });
+
+  it("stops retrying a learner-facing error rather than burning attempts", async () => {
+    class UnreadableFileError extends LearnerFacingGradingError {
+      constructor() {
+        super("no gradable text");
+        Object.setPrototypeOf(this, UnreadableFileError.prototype);
+      }
+      get learnerMessage(): string {
+        return "We couldn't read your file.";
+      }
+    }
+
+    const processPromptForFeature = jest
+      .fn()
+      .mockRejectedValue(new UnreadableFileError());
+
+    const { service } = buildService({
+      processPromptForFeature,
+    } as unknown as IPromptProcessor);
+
+    await expect(grade(service)).rejects.toBeInstanceOf(UnreadableFileError);
+    expect(processPromptForFeature).toHaveBeenCalledTimes(1);
+  });
+
+  it("gives up after a bounded number of attempts", async () => {
+    const processPromptForFeature = jest
+      .fn()
+      .mockRejectedValue(new Error("429 rate limited"));
+
+    const { service } = buildService({
+      processPromptForFeature,
+    } as unknown as IPromptProcessor);
+
+    await expect(grade(service)).rejects.toThrow("429 rate limited");
+    expect(processPromptForFeature).toHaveBeenCalledTimes(3);
+  });
+});

--- a/apps/api/src/api/llm/features/grading/services/evidence-based-grading.service.ts
+++ b/apps/api/src/api/llm/features/grading/services/evidence-based-grading.service.ts
@@ -26,6 +26,7 @@ import { Logger } from "winston";
 import { z } from "zod";
 import { IPromptProcessor } from "../../../core/interfaces/prompt-processor.interface";
 import { PROMPT_PROCESSOR } from "../../../llm.constants";
+import { LearnerFacingGradingError } from "../errors/learner-facing-grading.error";
 import {
   CriterionGrade,
   DEFAULT_MODEL_SELECTION,
@@ -101,6 +102,16 @@ type EvidenceOutput = z.infer<typeof EvidenceOutputSchema>;
 @Injectable()
 export class EvidenceBasedGradingService {
   private readonly logger: Logger;
+
+  /**
+   * Total tries per criterion on the legacy fallback path. The evidence
+   * pipeline does its own retrying; this path had none, so a single transient
+   * provider error used to be enough to lose the criterion.
+   */
+  private static readonly CRITERION_MAX_ATTEMPTS = 3;
+
+  /** Multiplied by the attempt number for a linear backoff between tries. */
+  private static readonly CRITERION_RETRY_BASE_MS = 500;
 
   constructor(
     @Inject(PROMPT_PROCESSOR)
@@ -214,49 +225,25 @@ export class EvidenceBasedGradingService {
       );
 
       for (const criterion of criteria) {
-        try {
-          this.logger.debug(
-            `Grading criterion (legacy): ${criterion.rubricQuestion} (max ${criterion.maxPoints} points)`,
-          );
+        this.logger.debug(
+          `Grading criterion (legacy): ${criterion.rubricQuestion} (max ${criterion.maxPoints} points)`,
+        );
 
-          const result = await this.gradeOneCriterion(
-            submission,
-            criterion,
-            questionText,
-            assignmentId,
-            language,
-            judgeFeedback,
-          );
+        // Deliberately unguarded: a criterion that cannot be graded must fail
+        // the job. Scoring it zero would hand the learner a wrong grade for an
+        // infrastructure fault, indistinguishable from work that earned zero.
+        const result = await this.gradeOneCriterionWithRetry(
+          submission,
+          criterion,
+          questionText,
+          assignmentId,
+          language,
+          judgeFeedback,
+        );
 
-          criteriaResults.push(result);
-          totalPoints += result.pointsAwarded;
-          maxPossiblePoints += result.maxPoints;
-        } catch (criterionError) {
-          this.logger.error(
-            `Failed to grade criterion ${criterion.id}: ${
-              criterionError instanceof Error
-                ? criterionError.message
-                : String(criterionError)
-            }`,
-          );
-
-          criteriaResults.push({
-            criterionId: criterion.id,
-            rubricQuestion: criterion.rubricQuestion,
-            pointsAwarded: 0,
-            maxPoints: criterion.maxPoints,
-            evidence: [],
-            rationale: `Grading failed: ${
-              criterionError instanceof Error
-                ? criterionError.message
-                : "Unknown error"
-            }`,
-            decision: "does_not_meet",
-            gradedAt: new Date().toISOString(),
-          });
-
-          maxPossiblePoints += criterion.maxPoints;
-        }
+        criteriaResults.push(result);
+        totalPoints += result.pointsAwarded;
+        maxPossiblePoints += result.maxPoints;
       }
     }
 
@@ -294,6 +281,97 @@ export class EvidenceBasedGradingService {
         determinismChecksum: submission.metadata.checksum,
       },
     };
+  }
+
+  /**
+   * Grade one criterion, retrying transient faults.
+   *
+   * Every exit is either a real grade or a throw. There is no third outcome
+   * that produces a score, because the only score available to invent here is
+   * zero — and a zero the learner cannot distinguish from a judged zero is
+   * worse than a failed job they can retry.
+   *
+   * Learner-facing errors are terminal by definition (the same submission will
+   * fail the same way), so they short-circuit rather than burn attempts.
+   */
+  private async gradeOneCriterionWithRetry(
+    submission: CanonicalSubmission,
+    criterion: RubricCriterion,
+    questionText: string,
+    assignmentId: number,
+    language: string,
+    judgeFeedback?: string,
+  ): Promise<CriterionGradingResult> {
+    const maxAttempts = EvidenceBasedGradingService.CRITERION_MAX_ATTEMPTS;
+    let lastError: unknown;
+
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+      try {
+        return await this.gradeOneCriterion(
+          submission,
+          criterion,
+          questionText,
+          assignmentId,
+          language,
+          judgeFeedback,
+        );
+      } catch (criterionError) {
+        lastError = criterionError;
+
+        if (criterionError instanceof LearnerFacingGradingError) {
+          this.logger.warn(
+            `Criterion ${criterion.id} is terminal for this submission: ${criterionError.message}`,
+            {
+              submissionId: submission.submissionId,
+              assignmentId,
+              criterionId: criterion.id,
+              errorClass: criterionError.name,
+            },
+          );
+          throw criterionError;
+        }
+
+        const message =
+          criterionError instanceof Error
+            ? criterionError.message
+            : String(criterionError);
+
+        if (attempt < maxAttempts) {
+          this.logger.warn(
+            `Criterion ${criterion.id} failed (attempt ${attempt}/${maxAttempts}), retrying: ${message}`,
+            {
+              submissionId: submission.submissionId,
+              assignmentId,
+              criterionId: criterion.id,
+              attempt,
+            },
+          );
+          await this.delay(
+            EvidenceBasedGradingService.CRITERION_RETRY_BASE_MS * attempt,
+          );
+        }
+      }
+    }
+
+    this.logger.error(
+      `Criterion ${criterion.id} failed after ${maxAttempts} attempts; failing the grading job rather than scoring it zero: ${
+        lastError instanceof Error ? lastError.message : String(lastError)
+      }`,
+      {
+        submissionId: submission.submissionId,
+        assignmentId,
+        criterionId: criterion.id,
+        attempts: maxAttempts,
+      },
+    );
+
+    // Rethrow the original so the worker's error taxonomy still classifies it
+    // (retryable vs terminal); wrapping would flatten every cause into one.
+    throw lastError;
+  }
+
+  private delay(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
   }
 
   /**

--- a/apps/api/src/api/llm/features/grading/services/file-grading.service.ts
+++ b/apps/api/src/api/llm/features/grading/services/file-grading.service.ts
@@ -3064,7 +3064,9 @@ export class FileGradingService implements IFileGradingService {
       };
       modelOverridesAreFinal?: boolean;
     },
-    failLoudly = false,
+    // Defaults to throwing: the silent branch scores minimum points on any
+    // failure, which a caller must opt into knowingly rather than inherit.
+    failLoudly = true,
     includeCodeUploads = false,
   ): Promise<FileBasedQuestionResponseModel> {
     try {

--- a/apps/jobs/src/job-worker.service.ts
+++ b/apps/jobs/src/job-worker.service.ts
@@ -886,6 +886,7 @@ export class JobWorkerService implements OnModuleInit, OnModuleDestroy {
   private static readonly TERMINAL_GRADING_ERROR_NAMES = new Set([
     "OversizedSubmissionError",
     "UnsupportedImageFormatError",
+    "UnextractableSubmissionError",
   ]);
 
   // Matches the two ConflictException messages a duplicate submit produces:


### PR DESCRIPTION
## **PR Description**

### **Overview:**

A learner's `.numbers` upload was decoded as UTF-16LE mojibake by the fallback extractor, the model provider rejected the request body, and every criterion was scored 0 — a silent zero indistinguishable from real grading. This PR makes "a grading failure must never become a learner's zero" hold end to end:

- The legacy per-criterion fallback no longer swallows provider errors into `pointsAwarded: 0` with the raw error as learner-visible rationale. It retries up to 3 times with backoff, short-circuits learner-facing errors as terminal, and otherwise fails the job so the worker taxonomy classifies it.
- Unsupported iWork containers are rejected up front with export guidance; fallback output that is binary, too short, or carries unpaired surrogates (the actual production signature) is rejected as unextractable instead of reaching the model.
- Post-review hardening: a COS download failure now fails the job instead of degrading into placeholder text the grader scores as absent work; the iWork rejection requires the ZIP magic bytes so a PEM-style `.key` file or dotless filename is not refused unread; `UnextractableSubmissionError` joins the worker's terminal-name set so forwarded mode stops burning retries on a deterministic verdict; `failLoudly` defaults to throwing.

#### **Type of Issue:**

- [ ] **Feature (`feat`)**: New functionality or feature added.
- [x] **Bug Fix (`bug`)**: Issue or bug resolved.
- [ ] **Chore (`chore`)**: Maintenance, refactoring, or non-functional changes.
- [ ] **Documentation Update (`doc`)**: Documentation improvements or additions.

#### **Change Type:**

- [ ] **Major:** Significant changes that introduce new features, large refactoring, or breaking changes. Requires thorough review and testing.
- [x] **Minor:** Small to medium changes, such as adding new functionality that is backward-compatible or minor refactoring. Moderate review needed.
- [ ] **Patch:** Bug fixes, small tweaks, or documentation updates. Light review is sufficient.

## Test Coverage
- [x] Unit tests updated
- [x] Manual verification done

Evidence:
- 122 tests green across the four affected suites (`file-content-extraction.spec.ts` new + pre-existing, `evidence-based-grading.service.spec.ts`, `file-grading-routing.service.spec.ts`); `tsc --noEmit` and eslint clean in `apps/api` and `apps/jobs`.
- New tests pin the edges: paired astral surrogates still extract, the 20-char length floor at both sides of the boundary, a PEM `.key` file extracting as text, and a storage failure rejecting extraction instead of resolving to placeholder content.
- Both real production submissions were replayed against the guards during development (each rejected even when renamed past the extension allowlist; well-formed CJK still extracts).

## Impact / Risk
- Grading extraction + evidence-based grading error paths, and the jobs worker's terminal-error classification. Recognized formats are untouched — the length/binary gates apply only after extension and MIME dispatch both decline.
- Support-visible tightening: exotic binary uploads that previously "graded" as scraped fragments now come back as unextractable with export guidance. Expect tickets that describe this as a new failure; it is the fix working.
- The two learner-facing strings in `unextractable-submission.error.ts` are new product copy (grading modal + submit-time 400) — flagging for copy sign-off.
- Known residual, deliberately deferred: a binary file renamed to a recognized extension (e.g. `.txt`) still reaches the model path as mojibake; it now fails the job rather than scoring zero, but a friendlier choke-point message is a follow-up candidate.

## Rollback
`git revert 72e5182b 2b088b6e de90cc80` — no schema or config changes.

## Reviewer Focus
- `extractContentFromFiles` now rethrows every per-file failure; the three call sites (attempt grading, author reference uploads, chat) were each checked to tolerate it — worth re-verifying.
- The ZIP-magic gate on the unsupported-extension rejection (`file-content-extraction.ts`).
- Retry semantics in `gradeOneCriterionWithRetry`: 3 attempts, backoff between, terminal short-circuit, original error rethrown.