### PR TITLE
fix: admin dashboard 403 when the browser holds a non-admin session

### DIFF
--- a/apps/api/src/api/admin/controllers/admin-dashboard.controller.spec.ts
+++ b/apps/api/src/api/admin/controllers/admin-dashboard.controller.spec.ts
@@ -4,7 +4,10 @@ import { WINSTON_MODULE_PROVIDER } from "nest-winston";
 
 import { AdminGuard } from "../../../auth/guards/admin.guard";
 import type { UserSessionRequest } from "../../../auth/interfaces/user.session.interface";
-import { RolesGlobalGuard } from "../../../auth/role/roles.global.guard";
+import {
+  ROLES_KEY,
+  RolesGlobalGuard,
+} from "../../../auth/role/roles.global.guard";
 import { ScheduledTasksService } from "../../scheduled-tasks/services/scheduled-tasks.service";
 import { AdminService } from "../admin.service";
 import { AdminDashboardController } from "./admin-dashboard.controller";
@@ -331,5 +334,40 @@ describe("AdminDashboardController", () => {
       ).rejects.toThrow(new BadRequestException("Page must be at least 1"));
       expect(mockAdminService.getAssignmentAnalytics).not.toHaveBeenCalled();
     });
+  });
+  describe("guard metadata", () => {
+    // Regression: RolesGlobalGuard is registered globally, so Nest runs it
+    // before this controller's AdminGuard. Any @Roles metadata here is decided
+    // against the forwarded cookie session, which for an admin browsing with a
+    // learner launch cookie is role "learner" -> 403 before AdminGuard can
+    // establish the admin role. AdminGuard alone is both correct and narrower.
+    const handlerNames = [
+      "getDashboardStats",
+      "executeQuickAction",
+      "getAssignmentAnalytics",
+      "getDetailedAssignmentInsights",
+      "manualDraftCleanup",
+    ] as const;
+
+    it("declares AdminGuard at the controller level", () => {
+      const guards: unknown[] =
+        Reflect.getMetadata("__guards__", AdminDashboardController) ?? [];
+      expect(guards).toContain(AdminGuard);
+    });
+
+    it.each(handlerNames)(
+      "does not put @Roles metadata on %s",
+      (handlerName) => {
+        const handler = (
+          AdminDashboardController.prototype as unknown as Record<
+            string,
+            (...args: unknown[]) => unknown
+          >
+        )[handlerName];
+
+        expect(handler).toBeDefined();
+        expect(Reflect.getMetadata(ROLES_KEY, handler)).toBeUndefined();
+      },
+    );
   });
 });

--- a/apps/api/src/api/admin/controllers/admin-dashboard.controller.ts
+++ b/apps/api/src/api/admin/controllers/admin-dashboard.controller.ts
@@ -24,7 +24,6 @@ import {
   UserRole,
   UserSessionRequest,
 } from "src/auth/interfaces/user.session.interface";
-import { Roles } from "src/auth/role/roles.global.guard";
 import { ScheduledTasksService } from "../../scheduled-tasks/services/scheduled-tasks.service";
 import { AdminService } from "../admin.service";
 import { DashboardStatsQueryDto } from "./dto/dashboard-stats-query.dto";
@@ -107,6 +106,13 @@ const ANALYTICS_SORT_FIELDS = ["name", "updatedAt", "published"] as const;
 type AnalyticsSortField = (typeof ANALYTICS_SORT_FIELDS)[number];
 
 @ApiTags("Admin Dashboard")
+// AdminGuard covers the whole controller and is the single source of truth for
+// access here. Deliberately no @Roles on any handler: RolesGlobalGuard is a
+// global guard, so it runs BEFORE AdminGuard and would decide on the forwarded
+// cookie session — an admin browsing with a learner/author launch cookie would
+// be rejected before AdminGuard could establish the admin role. AdminGuard is
+// strictly narrower than @Roles(AUTHOR, ADMIN) anyway, so dropping the metadata
+// never widens access.
 @UseGuards(AdminGuard)
 @ApiBearerAuth()
 @Injectable()
@@ -152,7 +158,6 @@ export class AdminDashboardController {
   }
 
   @Get("stats")
-  @Roles(UserRole.AUTHOR, UserRole.ADMIN)
   @ApiOperation({
     summary: "Get admin dashboard statistics",
   })
@@ -177,7 +182,6 @@ export class AdminDashboardController {
     });
   }
   @Get("quick-actions/:action")
-  @Roles(UserRole.AUTHOR, UserRole.ADMIN)
   @ApiOperation({
     summary: "Execute predefined quick actions for dashboard insights",
   })
@@ -207,7 +211,6 @@ export class AdminDashboardController {
    * Get assignment analytics with detailed insights
    */
   @Get("analytics")
-  @Roles(UserRole.AUTHOR, UserRole.ADMIN)
   @UseGuards(AdminGuard)
   @ApiOperation({
     summary:
@@ -289,7 +292,6 @@ export class AdminDashboardController {
    * Get detailed insights for a specific assignment
    */
   @Get("assignments/:id/insights")
-  @Roles(UserRole.AUTHOR, UserRole.ADMIN)
   @UseGuards(AdminGuard)
   @ApiOperation({
     summary: "Get detailed insights for a specific assignment",
@@ -321,7 +323,6 @@ export class AdminDashboardController {
    * Manual cleanup of old drafts
    */
   @Post("cleanup/drafts")
-  @Roles(UserRole.ADMIN)
   @UseGuards(AdminGuard)
   @ApiOperation({
     summary: "Manually trigger cleanup of old drafts (Admin only)",


### PR DESCRIPTION
RolesGlobalGuard is registered as a global guard, so Nest runs it before AdminDashboardController's AdminGuard. On the handlers carrying @Roles it therefore decided access from the forwarded cookie session rather than the admin session: an admin browsing with a learner (or any non-author) launch cookie was rejected with 403 before AdminGuard could establish the admin role. Endpoints on the same controller without @Roles were unaffected, which is why queue-status and reports/feedback worked while stats, analytics and insights returned 403 for the same admin token.

Drop the @Roles metadata and let the class-level AdminGuard be the single source of truth, matching queue-status.controller.ts. AdminGuard is strictly narrower than @Roles(AUTHOR, ADMIN) -- it requires a verified admin session whose email is on the allow-list -- so this does not widen access. The author-facing insights endpoint is a separate, ownership-scoped route and is untouched.

Adds guard-metadata tests so a future @Roles on this controller fails.
