### PR TITLE
fix: surface learner notebook code to the evidence grader

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": null,
     "lines": null
   },
-  "generated_at": "2026-08-12T15:40:30Z",
+  "generated_at": "2026-08-19T15:18:48Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -238,7 +238,7 @@
       {
         "hashed_secret": "2c0580ffd7d80319531cf629f5e90f747b1386f1",
         "is_verified": false,
-        "line_number": 3291,
+        "line_number": 3297,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/apps/api/src/api/attempt/services/__tests__/file-content-extraction.spec.ts
+++ b/apps/api/src/api/attempt/services/__tests__/file-content-extraction.spec.ts
@@ -1579,3 +1579,116 @@ describe("FileContentExtractionService.extractArchiveContent source files", () =
     expect(manifest.truncated).toBe(false);
   });
 });
+
+// ─── Jupyter notebook output hygiene ────────────────────────────────────────
+//
+// Notebook outputs are grading evidence, but oversized or duplicated output
+// payloads crowd the learner's actual code out of every downstream budget
+// (the 12K pinned whole-file block, the 30K validation render budget). A
+// 135KB pandas HTML table repr must never reach the prompt when its
+// text/plain sibling already carries the same information.
+
+describe("FileContentExtractionService.extractJupyterNotebook output handling", () => {
+  let service: FileContentExtractionService;
+
+  beforeEach(() => {
+    service = createService();
+  });
+
+  function notebookBuffer(cells: unknown[]): Buffer {
+    return Buffer.from(
+      JSON.stringify({ nbformat: 4, nbformat_minor: 5, metadata: {}, cells }),
+    );
+  }
+
+  function codeCell(source: string, outputs: unknown[] = []): unknown {
+    return { cell_type: "code", source: [source], metadata: {}, outputs };
+  }
+
+  async function extractNotebook(cells: unknown[]): Promise<string> {
+    const result = await (service as any).extractJupyterNotebook(
+      notebookBuffer(cells),
+      "test.ipynb",
+    );
+    return result.extractedText as string;
+  }
+
+  it("inlines only the highest-preference text payload per output", async () => {
+    const text = await extractNotebook([
+      codeCell("df.head()", [
+        {
+          output_type: "execute_result",
+          execution_count: 1,
+          data: {
+            "text/plain": ["   col_a  col_b\n0      1      2"],
+            "text/html": [
+              '<div><table class="dataframe"><tr><td>1</td></tr></table></div>',
+            ],
+          },
+        },
+      ]),
+    ]);
+
+    expect(text).toContain("col_a  col_b");
+    expect(text).not.toContain("<table");
+  });
+
+  it("keeps image placeholders alongside the text payload", async () => {
+    const text = await extractNotebook([
+      codeCell("plt.plot(x, y)", [
+        {
+          output_type: "display_data",
+          data: {
+            "text/plain": ["<Figure size 640x480 with 1 Axes>"],
+            "image/png": ["iVBORw0KGgoAAAANSUhEUg" + "A".repeat(500)],
+          },
+        },
+      ]),
+    ]);
+
+    expect(text).toContain("<Figure size 640x480 with 1 Axes>");
+    expect(text).toContain("[image/png]: <image data present>");
+    expect(text).not.toContain("iVBORw0KGgo");
+  });
+
+  it("caps an oversized rich-output text payload", async () => {
+    const huge = "x".repeat(50_000);
+    const text = await extractNotebook([
+      codeCell("print(huge)", [
+        { output_type: "execute_result", data: { "text/plain": [huge] } },
+      ]),
+    ]);
+
+    expect(text).toContain("[output truncated");
+    expect(text.length).toBeLessThan(10_000);
+  });
+
+  it("caps an oversized stream output", async () => {
+    const verbose = "Fitting 5 folds for each of 288 candidates\n".repeat(3000);
+    const text = await extractNotebook([
+      codeCell("grid.fit(X, y)", [
+        { output_type: "stream", name: "stdout", text: [verbose] },
+      ]),
+    ]);
+
+    expect(text).toContain("Fitting 5 folds");
+    expect(text).toContain("[output truncated");
+    expect(text.length).toBeLessThan(10_000);
+  });
+
+  it("never inlines non-preferred mime payloads", async () => {
+    const text = await extractNotebook([
+      codeCell("show_gif()", [
+        {
+          output_type: "display_data",
+          data: {
+            "image/webp": "UklGRh4AAABXRUJQVlA4TBEAAAAv" + "B".repeat(400),
+          },
+        },
+      ]),
+    ]);
+
+    expect(text).toContain("[image/webp]: <image data present>");
+    expect(text).not.toContain("UklGRh4");
+  });
+});

--- a/apps/api/src/api/attempt/services/file-content-extraction.ts
+++ b/apps/api/src/api/attempt/services/file-content-extraction.ts
@@ -115,6 +115,11 @@ export class FileContentExtractionService {
   private readonly ARCHIVE_ENTRY_MAX_BYTES = 100_000;
   private readonly ARCHIVE_TEXT_ENTRY_MAX_CHARS = 1000;
   private readonly ARCHIVE_TOTAL_CONTENT_BUDGET = 2_000_000;
+  // A single notebook output (GridSearch verbose logs, a full-frame DataFrame
+  // repr) can run to hundreds of KB and crowd the learner's code out of every
+  // downstream evidence budget. The head of an output is what shows whether
+  // the cell ran and what it produced.
+  private readonly NOTEBOOK_OUTPUT_TEXT_MAX_CHARS = 2000;
 
   private readonly mimeTypeMap: Record<string, string[]> = {
     "text/plain": ["txt", "log", "md", "markdown", "rst", "asc", "text"],
@@ -1531,7 +1536,9 @@ export class FileContentExtractionService {
                 const text = Array.isArray(output.text)
                   ? output.text.join("")
                   : output.text || "";
-                extractedText += `[${output.name || "stdout"}]:\n${text}`;
+                extractedText += `[${
+                  output.name || "stdout"
+                }]:\n${this.capNotebookOutputText(text)}`;
                 break;
               }
 
@@ -1638,51 +1645,53 @@ export class FileContentExtractionService {
   private extractJupyterOutputData(data: Record<string, unknown>): string {
     let result = "";
 
-    const mimePreference = [
+    // Alternate representations of the same result (text/plain + text/html +
+    // text/latex) carry the same information; inlining more than the first is
+    // pure prompt bloat — a pandas HTML repr of a text/plain table can run to
+    // 100KB+ on its own.
+    const textMimePreference = [
       "text/plain",
       "text/markdown",
       "text/html",
       "text/latex",
       "application/json",
       "application/javascript",
-      "image/png",
-      "image/jpeg",
-      "image/svg+xml",
     ];
 
-    for (const mime of mimePreference) {
-      if (data[mime]) {
-        const content = data[mime];
-
-        if (
-          mime.startsWith("text/") ||
-          mime === "application/json" ||
-          mime === "application/javascript"
-        ) {
-          const text = Array.isArray(content)
-            ? content.join("")
-            : String(content);
-          result += `[${mime}]:\n${text}\n`;
-        } else if (mime.startsWith("image/")) {
-          result += `[${mime}]: <image data present>\n`;
-        } else {
-          result += `[${mime}]: <binary data present>\n`;
-        }
+    let textEmitted = false;
+    for (const mime of textMimePreference) {
+      const content = data[mime];
+      if (!content) continue;
+      if (
+        !textEmitted &&
+        (typeof content === "string" || Array.isArray(content))
+      ) {
+        const text = Array.isArray(content)
+          ? content.join("")
+          : String(content);
+        result += `[${mime}]:\n${this.capNotebookOutputText(text)}\n`;
+        textEmitted = true;
       }
     }
 
+    // Image payloads are base64; only their presence is evidence. Anything
+    // outside the known text mimes is never inlined — vendor mimes
+    // (image/webp, application/vnd.plotly.v1+json, ...) also arrive as
+    // base64 or oversized JSON strings.
     for (const [mime, content] of Object.entries(data)) {
-      if (!mimePreference.includes(mime)) {
-        if (typeof content === "string" || Array.isArray(content)) {
-          const text = Array.isArray(content) ? content.join("") : content;
-          result += `[${mime}]:\n${text}\n`;
-        } else {
-          result += `[${mime}]: <data present>\n`;
-        }
-      }
+      if (!content || textMimePreference.includes(mime)) continue;
+      result += mime.startsWith("image/")
+        ? `[${mime}]: <image data present>\n`
+        : `[${mime}]: <data present>\n`;
     }
 
     return result;
+  }
+
+  private capNotebookOutputText(text: string): string {
+    if (text.length <= this.NOTEBOOK_OUTPUT_TEXT_MAX_CHARS) return text;
+    const omitted = text.length - this.NOTEBOOK_OUTPUT_TEXT_MAX_CHARS;
+    return `${text.slice(0, this.NOTEBOOK_OUTPUT_TEXT_MAX_CHARS)}\n... [output truncated: ${omitted} more characters]`;
   }
 
   private extractPresentationMetadata(parsed: any): string {

--- a/apps/api/src/api/llm/features/grading/services/__tests__/file-grading-routing.service.spec.ts
+++ b/apps/api/src/api/llm/features/grading/services/__tests__/file-grading-routing.service.spec.ts
@@ -668,7 +668,7 @@ describe("FileGradingService.buildCodeEvidenceBlocks", () => {
 
 // ─── notebook (.ipynb) cell-aware chunking ─────────────────────────────────
 
-describe("FileGradingService - notebook extractions chunk by cell", () => {
+describe("FileGradingService - notebook extractions chunk by task section", () => {
   let service: any;
 
   beforeEach(() => {
@@ -716,18 +716,23 @@ describe("FileGradingService - notebook extractions chunk by cell", () => {
     );
   }
 
-  it("builds a pinned whole-notebook block plus per-cell segments", () => {
+  it("builds a pinned whole-notebook block plus task-section segments", () => {
     const blocks = notebookBlocks();
     expect(blocks[0].pinnedEvidence).toBe(true);
     expect(blocks[0].text).toContain("=== CELL 2 [CODE] [1] ===");
 
+    // The markdown task cell and the code cells answering it share one
+    // segment: retrieval matches rubric wording against the markdown, so the
+    // code must travel in the same chunk to ever reach the grader.
     const segments = blocks.slice(1).map((b: any) => b.text);
-    const cell2 = segments.find((s: string) => s.includes("=== CELL 2 [CODE]"));
-    expect(cell2).toBeDefined();
-    expect(cell2).toContain(
+    const section = segments.find((s: string) =>
+      s.includes("=== CELL 1 [MARKDOWN]"),
+    );
+    expect(section).toBeDefined();
+    expect(section).toContain(
       "monthly = sales.groupby('month')['revenue'].sum()",
     );
-    expect(cell2).not.toContain("=== CELL 3");
+    expect(section).toContain("=== CELL 3");
   });
 
   it("preserves tab indentation inside notebook code cells", () => {
@@ -735,13 +740,15 @@ describe("FileGradingService - notebook extractions chunk by cell", () => {
     expect(blocks[0].text).toContain("\tprint(month, revenue)");
   });
 
-  it("keeps a cell's output attached to its cell segment", () => {
+  it("keeps a cell's output attached to its section segment", () => {
     const segments = notebookBlocks()
       .slice(1)
       .map((b: any) => b.text);
-    const cell2 = segments.find((s: string) => s.includes("=== CELL 2 [CODE]"));
-    expect(cell2).toContain("--- OUTPUT ---");
-    expect(cell2).toContain("2025-01 131072");
+    const section = segments.find((s: string) =>
+      s.includes("=== CELL 2 [CODE]"),
+    );
+    expect(section).toContain("--- OUTPUT ---");
+    expect(section).toContain("2025-01 131072");
   });
 });
 

--- a/apps/api/src/api/llm/features/grading/services/criterion-evidence-retrieval.service.spec.ts
+++ b/apps/api/src/api/llm/features/grading/services/criterion-evidence-retrieval.service.spec.ts
@@ -535,4 +535,69 @@ describe("CriterionEvidenceRetrievalService", () => {
     expect(cellEvidence?.quote).toBe(cellText);
     expect(proseEvidence?.quote?.length).toBe(220);
   });
+
+  /**
+   * The validator prompt is designed to pick the best six chunks FROM a wider
+   * candidate pool ("Keep only the most relevant 6 chunks. Where more than
+   * six qualify..."). Slicing the pool to six before the validator ever sees
+   * it silently delegates the final relevance judgement to lexical scoring —
+   * which ranks rubric-parroting template text above the learner's actual
+   * code (observed in production as "submission shows only the solution
+   * template" false zeros on notebook uploads). The full reranked pool must
+   * reach the validator; only the validator's verdict is capped at six.
+   */
+  it("surfaces the full reranked candidate pool to the validator, not only the lexical top six", async () => {
+    const core = "notebook python code bar chart";
+    const chunks = Array.from({ length: 9 }, (_, i) =>
+      makeChunk(
+        `ch${i + 1}`,
+        `${core} variant-${i + 1} ${"filler ".repeat(i * 3)}`,
+      ),
+    );
+
+    const criterion: RubricCriterion = {
+      id: "bar-chart",
+      rubricQuestion:
+        "Does the notebook include Python code to create a bar chart?",
+      description: "The notebook must include Python code for a bar chart.",
+      criteria: [
+        { description: "Correct bar chart code", points: 2 },
+        { description: "Partial bar chart code", points: 1 },
+        { description: "No bar chart code", points: 0 },
+      ],
+      maxPoints: 2,
+    };
+
+    const promptProcessor = {
+      processStructuredPrompt: jest.fn().mockResolvedValue({
+        evidence: [{ chunkId: "ch9", relevance: "supports" }],
+      }),
+    };
+    const service = new CriterionEvidenceRetrievalService(
+      promptProcessor as any,
+      {
+        getModelKeyWithFallback: jest.fn().mockResolvedValue("gpt-4o-mini"),
+      } as any,
+    );
+    const index = new ChunkIndex(chunks);
+
+    const response = await service.retrieveEvidence(
+      {
+        criterion,
+        question: "Grade this notebook submission",
+        chunks,
+        assignmentId: 7,
+      },
+      index,
+    );
+
+    const promptArg = promptProcessor.processStructuredPrompt.mock.calls[0][0];
+    const validationPrompt = await promptArg.format({});
+    for (const chunk of chunks) {
+      expect(validationPrompt).toContain(chunk.chunkId);
+    }
+    expect(response.evidence).toEqual([
+      expect.objectContaining({ chunkId: "ch9" }),
+    ]);
+  });
 });

--- a/apps/api/src/api/llm/features/grading/services/criterion-evidence-retrieval.service.ts
+++ b/apps/api/src/api/llm/features/grading/services/criterion-evidence-retrieval.service.ts
@@ -156,6 +156,13 @@ export class CriterionEvidenceRetrievalService {
 
     if (candidates.length > 0) {
       const maxSearchScore = Math.max(...candidates.map((c) => c.score), 1);
+      // The full filtered pool (up to maxCandidates from the search above)
+      // goes forward: the LLM validator is the judge of which candidates are
+      // evidence, and its prompt is written to pick the best maxEvidence from
+      // a wider pool. Slicing to maxEvidence here would hand that judgement
+      // to lexical scoring, which ranks rubric-parroting prose above the code
+      // that actually answers it. Non-validated paths cap at maxEvidence in
+      // mapRerankedCandidatesToEvidence.
       reranked = candidates
         .map((candidate) => {
           const relevance = this.computeRelevanceScore(
@@ -171,8 +178,7 @@ export class CriterionEvidenceRetrievalService {
           };
         })
         .filter((candidate) => candidate.relevance >= this.config.minRelevance)
-        .sort((a, b) => b.combined - a.combined)
-        .slice(0, maxEvidence);
+        .sort((a, b) => b.combined - a.combined);
     }
 
     if (reranked.length === 0) {
@@ -193,7 +199,7 @@ export class CriterionEvidenceRetrievalService {
       const aboveThreshold = scored
         .filter((item) => item.relevance >= this.config.minRelevance)
         .sort((a, b) => b.combined - a.combined)
-        .slice(0, maxEvidence);
+        .slice(0, this.config.maxCandidates);
 
       // Lexical relevance scoring misses genuinely relevant content with no
       // keyword overlap (e.g. numeric spreadsheet cells vs. prose rubric

--- a/apps/api/src/api/llm/features/grading/services/file-grading.service.notebook-sections.spec.ts
+++ b/apps/api/src/api/llm/features/grading/services/file-grading.service.notebook-sections.spec.ts
@@ -1,0 +1,164 @@
+/* eslint-disable */
+import { Logger } from "@nestjs/common";
+
+import { CODE_SEGMENT_MAX_CHARS } from "./source-code.utils";
+import { FileGradingService } from "./file-grading.service";
+
+/**
+ * Notebook evidence segmentation.
+ *
+ * A rubric criterion's wording matches the markdown task cell ("Create a bar
+ * chart to compare..."), but the work that satisfies it lives in the code
+ * cells that follow. Evidence retrieval selects whole chunks, so a task's
+ * description and its answer code must share a chunk — otherwise lexical
+ * retrieval hands the grader the rubric-parroting template cell and the
+ * learner's code never reaches the prompt (observed in production as
+ * "submission shows only the solution template" false zeros).
+ */
+
+function makeService(): FileGradingService {
+  const service = Object.create(FileGradingService.prototype);
+  (service as any).logger = {
+    debug: jest.fn(),
+    log: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  } as unknown as Logger;
+  return service as FileGradingService;
+}
+
+function mdCell(n: number, text: string): string {
+  return `=== CELL ${n} [MARKDOWN] ===\n${text}`;
+}
+
+function codeCell(n: number, text: string): string {
+  return `=== CELL ${n} [CODE] [${n}] ===\n${text}`;
+}
+
+const HEADER = "=== JUPYTER NOTEBOOK: test.ipynb ===\nFormat: v4.5";
+
+describe("FileGradingService notebook section segmentation", () => {
+  let service: FileGradingService;
+
+  beforeEach(() => {
+    service = makeService();
+  });
+
+  function split(text: string): string[] {
+    return (service as any).splitCodeIntoSegments(text);
+  }
+
+  it("attaches a task's code cells to the preceding markdown run", () => {
+    const text = [
+      HEADER,
+      mdCell(
+        1,
+        "TASK 1.3: Create a bar chart to compare Vehicle-Wise Sales During Recession and Non-Recession Periods.\nHint: use the groupby method on the Vehicle_Type column and plot the result.\nTemplate: # df_grouped = df.groupby(...)... " +
+          "x".repeat(120),
+      ),
+      codeCell(
+        2,
+        "df_grouped = df.groupby(['Recession', 'Vehicle_Type'])['Automobile_Sales'].mean().reset_index()\nsns.barplot(x='Recession', y='Automobile_Sales', hue='Vehicle_Type', data=df_grouped)\nplt.title('Vehicle-Wise Sales')\nplt.show()" +
+          "\n# " +
+          "y".repeat(120),
+      ),
+      mdCell(
+        3,
+        "TASK 1.4: Create a pie chart to display advertising expenditure during recession periods.\nHint: use plt.pie with the two expenditure totals. " +
+          "z".repeat(120),
+      ),
+      codeCell(
+        4,
+        "totals = [rec_exp, non_rec_exp]\nplt.pie(totals, labels=['Recession', 'Non-Recession'])\nplt.show()" +
+          "\n# " +
+          "w".repeat(120),
+      ),
+    ].join("\n");
+
+    const segments = split(text);
+
+    const barChartSegment = segments.find((s) => s.includes("TASK 1.3"));
+    expect(barChartSegment).toBeDefined();
+    expect(barChartSegment).toContain("sns.barplot");
+
+    const pieSegment = segments.find((s) => s.includes("TASK 1.4"));
+    expect(pieSegment).toBeDefined();
+    expect(pieSegment).toContain("plt.pie");
+  });
+
+  it("starts a new section at each markdown run so tasks stay separate", () => {
+    const text = [
+      HEADER,
+      mdCell(1, "TASK A: first task description " + "a".repeat(200)),
+      codeCell(2, "first_task_code()\n# " + "b".repeat(200)),
+      mdCell(3, "TASK B: second task description " + "c".repeat(200)),
+      codeCell(4, "second_task_code()\n# " + "d".repeat(200)),
+    ].join("\n");
+
+    const segments = split(text);
+
+    const first = segments.find((s) => s.includes("TASK A"));
+    expect(first).toBeDefined();
+    expect(first).not.toContain("second_task_code");
+
+    const second = segments.find((s) => s.includes("TASK B"));
+    expect(second).toBeDefined();
+    expect(second).not.toContain("first_task_code");
+  });
+
+  it("groups consecutive markdown cells (heading + hint) with the answer code", () => {
+    const text = [
+      HEADER,
+      mdCell(
+        1,
+        "TASK 2.1: Compare GDP variations during recession periods. " +
+          "e".repeat(160),
+      ),
+      mdCell(
+        2,
+        "Hint: use pandas groupby on the GDP column and add_subplot. " +
+          "f".repeat(160),
+      ),
+      codeCell(
+        3,
+        "gdp = df.groupby('Year')['GDP'].mean()\nfig.add_subplot(1, 2, 1)\n# " +
+          "g".repeat(160),
+      ),
+    ].join("\n");
+
+    const segments = split(text);
+
+    const section = segments.find((s) => s.includes("TASK 2.1"));
+    expect(section).toBeDefined();
+    expect(section).toContain("Hint: use pandas groupby");
+    expect(section).toContain("fig.add_subplot");
+  });
+
+  it("keeps every segment within CODE_SEGMENT_MAX_CHARS and loses no content", () => {
+    const bigCode = "data_row = [1, 2, 3]\n".repeat(400); // ~8.4K chars
+    const text = [
+      HEADER,
+      mdCell(1, "TASK 3: Load and describe the dataset. " + "h".repeat(200)),
+      codeCell(2, bigCode + "unique_final_marker = True"),
+    ].join("\n");
+
+    const segments = split(text);
+
+    for (const segment of segments) {
+      expect(segment.length).toBeLessThanOrEqual(CODE_SEGMENT_MAX_CHARS);
+    }
+    const joined = segments.join("\n");
+    expect(joined).toContain("TASK 3");
+    expect(joined).toContain("unique_final_marker = True");
+  });
+
+  it("leaves non-notebook source code on the definition-split path", () => {
+    const text =
+      "def first_function():\n    return 1\n\n\ndef second_function():\n    return 2\n";
+
+    const segments = split(text);
+
+    expect(segments.join("\n")).toContain("first_function");
+    expect(segments.join("\n")).toContain("second_function");
+  });
+});

--- a/apps/api/src/api/llm/features/grading/services/file-grading.service.ts
+++ b/apps/api/src/api/llm/features/grading/services/file-grading.service.ts
@@ -1770,18 +1770,59 @@ export class FileGradingService implements IFileGradingService {
   }
 
   // Jupyter notebook extractions carry "=== CELL N [TYPE] ===" section
-  // headers (see FileContentExtractionService.extractJupyterNotebook). Each
-  // cell — with its header and any outputs — becomes one segment. Returns
-  // null when the text is not a notebook extraction.
+  // headers (see FileContentExtractionService.extractJupyterNotebook).
+  // Returns null when the text is not a notebook extraction.
+  //
+  // Cells are grouped into task sections rather than kept one-per-segment: a
+  // rubric criterion's wording matches the markdown task cell, but the work
+  // that satisfies it lives in the code cells that follow. Evidence retrieval
+  // selects whole chunks, so a task's description and its answer code must
+  // share a chunk — a lone markdown cell that parrots the rubric otherwise
+  // outranks the learner's code everywhere and the grader never sees the code.
   private splitNotebookIntoCellSegments(code: string): string[] | null {
     const cellHeader = /^=== CELL \d+ \[/m;
     if (!cellHeader.test(code)) return null;
 
-    const segments = code
+    const cells = code
       .split(/\n(?==== CELL \d+ \[)/)
       .map((segment) => segment.trimEnd())
       .filter((segment) => segment.trim());
-    return segments.length > 0 ? segments : null;
+    if (cells.length === 0) return null;
+
+    // A section starts at each markdown run (a markdown cell whose
+    // predecessor is not markdown) and carries every following cell until the
+    // next run. Sections are bounded by CODE_SEGMENT_MAX_CHARS so they
+    // survive capCodeSegments un-split; a cell that would overflow starts its
+    // own section (the pre-grouping behaviour) rather than shearing the
+    // section mid-cell.
+    const markdownCellHeader = /^=== CELL \d+ \[MARKDOWN]/;
+
+    const sections: string[] = [];
+    let current: string[] = [];
+    let currentSize = 0;
+    let previousWasMarkdown = false;
+
+    for (const cell of cells) {
+      const markdown = markdownCellHeader.test(cell);
+      const startsNewSection =
+        markdown && !previousWasMarkdown && current.length > 0;
+      const overflows =
+        current.length > 0 &&
+        currentSize + cell.length + 1 > CODE_SEGMENT_MAX_CHARS;
+
+      if (startsNewSection || overflows) {
+        sections.push(current.join("\n"));
+        current = [];
+        currentSize = 0;
+      }
+
+      current.push(cell);
+      currentSize += cell.length + 1;
+      previousWasMarkdown = markdown;
+    }
+    if (current.length > 0) sections.push(current.join("\n"));
+
+    return sections;
   }
 
   // Fold trivially short segments (a lone import, a one-line `const`) into an


### PR DESCRIPTION
Notebook uploads were being graded against evidence that systematically excluded the learner's code. Since the stricter grading model shipped, that surfaced as false zeros with feedback claiming the submission contains only the solution template: the daily zero-rate on graded .ipynb responses jumped from a 2-5% baseline to ~15%.

Replaying a real affected submission (1.1MB notebook, 102 cells, all code present and executed) through the pipeline showed why. Three compounding defects:

1. Chunking was one chunk per notebook cell, so the markdown task cells (which parrot the rubric wording nearly verbatim) and the code cells answering them competed as separate chunks. Lexical retrieval ranked the markdown above the code for every criterion; in the replay, the learner's code did not reach the candidate pool for 8 of 9 criteria and reached the validator for none of them.

2. The reranked pool was sliced to maxEvidence (6) BEFORE the LLM validator ran, even though the validator's prompt is written to pick the best six from a wider pool. Rank 7-18 candidates were silently discarded without the validator ever seeing them.

3. Oversized notebook outputs crowded out the safety nets: a pandas text/html table repr (135KB in the replayed submission) was inlined alongside its text/plain sibling, and stream outputs were uncapped, so the pinned 12K whole-file block ended mid-HTML-table before the first learner code cell.

Fixes, in the same order:

1. Notebook cell segments are now grouped into task sections: each markdown run carries the code cells that follow it, bounded by CODE_SEGMENT_MAX_CHARS. The rubric-matching markdown chunk now contains the code that answers it.

2. The validator receives the full reranked candidate pool (bounded by maxCandidates and the existing render budget); only its verdict and the non-validated fallback paths cap at maxEvidence.

3. Notebook outputs inline only the highest-preference text mime, capped at 2000 chars with an explicit truncation marker (streams included); image and vendor mimes emit placeholders instead of raw base64.

Replaying the same submission after the fix: extraction shrinks from 177K to 43K chars, and the learner's code reaches the validator's candidate set for 9 of 9 criteria.

The grading model change only exposed this: the previous model paid partial credit on the same code-free evidence, masking the miss. Zeroed notebook submissions graded since the rollout still need a regrade sweep once this deploys.
