### PR TITLE
feat: stop mirroring reports to GitHub issues

### DIFF
--- a/apps/api/src/api/report/controllers/report.controller.ts
+++ b/apps/api/src/api/report/controllers/report.controller.ts
@@ -153,7 +153,7 @@ export class ReportsController {
     },
     @UploadedFile() screenshot: Express.Multer.File,
     @Req() request: UserSessionRequest,
-  ): Promise<{ message: string; issueNumber?: number; reportId?: number }> {
+  ): Promise<{ message: string; reportId?: number }> {
     const resolvedUserEmail = dto.userEmail || request.userSession?.userId;
     const reportDto = {
       issueType: dto.issueType,

--- a/apps/api/src/api/report/helpers/issue-template.spec.ts
+++ b/apps/api/src/api/report/helpers/issue-template.spec.ts
@@ -1,76 +1,21 @@
 import {
-  buildChatIssueBody,
-  buildChatIssueTitle,
   buildSnSupportTicketTitle,
-  CHAT_ISSUE_FOOTER,
   defaultSeverityForIssueType,
   stripSectionLabelMarkdown,
 } from "./issue-template";
 
 const baseInput = {
   issueType: "technical",
-  role: "learner",
-  severity: "error",
-  userEmail: "learner@example.com",
   assignmentId: 771,
   attemptId: 12_345,
-  reportedAt: new Date("2026-05-14T10:33:26.841Z"),
-  isProduction: true,
   description: "Question 4 rejects my file upload with a client error 400.",
 };
 
-describe("buildChatIssueTitle", () => {
-  it("renders a single-line title with environment, role, severity and ids", () => {
-    const title = buildChatIssueTitle(baseInput);
-
-    expect(title).not.toContain("\n");
-    expect(title).toContain("[MARK CHAT]");
-    expect(title).toContain("[PROD]");
-    expect(title).toContain("[learner]");
-    expect(title).toContain("ERROR");
-    expect(title).toContain("Assignment 771");
-    expect(title).toContain("Attempt 12345");
-  });
-
-  it("omits the attempt segment when attemptId is missing", () => {
-    const title = buildChatIssueTitle({ ...baseInput, attemptId: undefined });
-
-    expect(title).not.toContain("Attempt");
-    expect(title).not.toContain("undefined");
-  });
-
-  it("collapses whitespace in the description summary", () => {
-    const title = buildChatIssueTitle({
-      ...baseInput,
-      description: "line one\nline two\t\tspaced",
-    });
-
-    expect(title).not.toContain("\n");
-    expect(title).toContain("line one line two spaced");
-  });
-
-  it("marks non-production reports as DEV", () => {
-    const title = buildChatIssueTitle({ ...baseInput, isProduction: false });
-
-    expect(title).toContain("[DEV]");
-  });
-
-  it("summarizes a form-templated description without markdown markers", () => {
-    const title = buildChatIssueTitle({
-      ...baseInput,
-      description:
-        "**Steps to reproduce:**\nOpen quiz\n\n**Actual result:**\nSpinner never stops",
-    });
-
-    expect(title).toContain("Spinner never stops");
-    expect(title).not.toContain("**");
-  });
-});
-
 describe("buildSnSupportTicketTitle", () => {
-  it("renders type and ids without the bracket prefixes", () => {
+  it("renders type and ids without any bracket prefixes", () => {
     const title = buildSnSupportTicketTitle(baseInput);
 
+    expect(title).not.toContain("\n");
     expect(title).toContain("Assignment 771 - Attempt 12345");
     expect(title).not.toContain("[");
     expect(title).not.toContain("MARK CHAT");
@@ -85,6 +30,16 @@ describe("buildSnSupportTicketTitle", () => {
 
     expect(title).toContain("Assignment 771:");
     expect(title).not.toContain("Attempt");
+  });
+
+  it("collapses whitespace in the description summary", () => {
+    const title = buildSnSupportTicketTitle({
+      ...baseInput,
+      description: "line one\nline two\t\tspaced",
+    });
+
+    expect(title).not.toContain("\n");
+    expect(title).toContain("line one line two spaced");
   });
 
   it("summarizes a form-templated description from the Actual result section", () => {
@@ -125,39 +80,6 @@ describe("stripSectionLabelMarkdown", () => {
   });
 });
 
-describe("buildChatIssueBody", () => {
-  it("renders the standard Mark Chat issue template", () => {
-    const body = buildChatIssueBody(baseInput);
-
-    expect(body).toContain("## Issue Report from Mark Chat");
-    expect(body).toContain("**Issue Type:** technical");
-    expect(body).toContain("**Reported By:** learner");
-    expect(body).toContain("**User Email:** learner@example.com");
-    expect(body).toContain("**Assignment ID:** 771");
-    expect(body).toContain("**Attempt ID:** 12345");
-    expect(body).toContain("**Time Reported:** 2026-05-14T10:33:26.841Z");
-    expect(body).toContain("**Severity:** error");
-    expect(body).toContain("**Environment:** Production");
-    expect(body).toContain("### Description");
-    expect(body).toContain(baseInput.description);
-  });
-
-  it("falls back to placeholders for missing optional fields", () => {
-    const body = buildChatIssueBody({
-      ...baseInput,
-      userEmail: undefined,
-      assignmentId: undefined,
-      attemptId: undefined,
-      isProduction: false,
-    });
-
-    expect(body).toContain("**User Email:** Unknown");
-    expect(body).toContain("**Assignment ID:** N/A");
-    expect(body).toContain("**Attempt ID:** N/A");
-    expect(body).toContain("**Environment:** Development");
-  });
-});
-
 describe("defaultSeverityForIssueType", () => {
   it.each([
     ["bug", "error"],
@@ -170,13 +92,5 @@ describe("defaultSeverityForIssueType", () => {
     ["OTHER", "info"],
   ])("maps %s to %s", (issueType, expected) => {
     expect(defaultSeverityForIssueType(issueType)).toBe(expected);
-  });
-});
-
-describe("CHAT_ISSUE_FOOTER", () => {
-  it("carries the automated-report attribution line", () => {
-    expect(CHAT_ISSUE_FOOTER).toContain(
-      "This issue was automatically reported through the Mark Chat feature.",
-    );
   });
 });

--- a/apps/api/src/api/report/helpers/issue-template.ts
+++ b/apps/api/src/api/report/helpers/issue-template.ts
@@ -1,16 +1,9 @@
-export interface ChatIssueTemplateInput {
+export interface SnTicketTitleInput {
   issueType: string;
-  role: string;
-  severity: string;
-  userEmail?: string | null;
   assignmentId?: number | null;
   attemptId?: number | null;
-  reportedAt: Date;
-  isProduction: boolean;
   description: string;
 }
-
-export const CHAT_ISSUE_FOOTER = `\n---\n*This issue was automatically reported through the Mark Chat feature.*`;
 
 const TITLE_SUMMARY_MAX_CHARS = 50;
 
@@ -18,7 +11,7 @@ const TITLE_SUMMARY_MAX_CHARS = 50;
 // description already templated into "**Label:**\ncontent" sections.
 const SECTION_LABEL_PATTERN = /\*\*([^\n*]+):\*\*/g;
 const ACTUAL_RESULT_PATTERN =
-  /\*\*Actual result:\*\*\s*([\s\S]*?)(?=\n\s*\*\*[^\n*]+:\*\*|$)/i;
+  /\*\*actual result:\*\*\s*([\S\s]*?)(?=\n\s*\*\*[^\n*]+:\*\*|$)/i;
 
 /**
  * One-line summary of a report description for use in a title. For templated
@@ -75,24 +68,9 @@ export function defaultSeverityForIssueType(
   }
 }
 
-export function buildChatIssueTitle(input: ChatIssueTemplateInput): string {
-  const environment = input.isProduction ? "PROD" : "DEV";
-  const normalizedDescription = summarizeDescription(input.description);
-  const summary = normalizedDescription.slice(0, TITLE_SUMMARY_MAX_CHARS);
-  const ellipsis =
-    normalizedDescription.length > TITLE_SUMMARY_MAX_CHARS ? "..." : "";
-  const attemptSegment = input.attemptId ? ` - Attempt ${input.attemptId}` : "";
-
-  return `[MARK CHAT] [${environment}] [${input.role}] ${input.severity.toUpperCase()} ${capitalizeIssueType(
-    input.issueType,
-  )} Assignment ${input.assignmentId || "N/A"}${attemptSegment}: ${summary}${ellipsis}`;
-}
-
 // SN Support tickets carry environment, role, and severity as structured
-// fields, so the title stays human-readable without the bracket prefixes.
-export function buildSnSupportTicketTitle(
-  input: ChatIssueTemplateInput,
-): string {
+// fields, so the title stays human-readable without any bracket prefixes.
+export function buildSnSupportTicketTitle(input: SnTicketTitleInput): string {
   const normalizedDescription = summarizeDescription(input.description);
   const summary = normalizedDescription.slice(0, TITLE_SUMMARY_MAX_CHARS);
   const ellipsis =
@@ -102,22 +80,4 @@ export function buildSnSupportTicketTitle(
   return `${capitalizeIssueType(input.issueType)}: Assignment ${
     input.assignmentId || "N/A"
   }${attemptSegment}: ${summary}${ellipsis}`;
-}
-
-export function buildChatIssueBody(input: ChatIssueTemplateInput): string {
-  return `
-## Issue Report from Mark Chat
-
-**Issue Type:** ${input.issueType}
-**Reported By:** ${input.role || "Unknown"}
-**User Email:** ${input.userEmail || "Unknown"}
-**Assignment ID:** ${input.assignmentId || "N/A"}
-**Attempt ID:** ${input.attemptId || "N/A"}
-**Time Reported:** ${input.reportedAt.toISOString()}
-**Severity:** ${input.severity}
-**Environment:** ${input.isProduction ? "Production" : "Development"}
-
-### Description
-${input.description}
-`;
 }

--- a/apps/api/src/api/report/services/report.service.spec.ts
+++ b/apps/api/src/api/report/services/report.service.spec.ts
@@ -123,43 +123,39 @@ describe("ReportsService.reportIssue", () => {
   };
 
   const makeForReportIssue = (snSupportService: unknown) => {
-    const forwardPrisma = {
+    const prisma = {
       report: {
         findMany: jest.fn().mockResolvedValue([]),
+        findUnique: jest.fn().mockResolvedValue(null),
         create: jest.fn().mockResolvedValue({ id: 7 }),
       },
     };
     const floService = { sendError: jest.fn().mockResolvedValue(undefined) };
     const service = new ReportsService(
       floService as never,
-      forwardPrisma as never,
+      prisma as never,
       undefined as never,
       undefined as never,
       snSupportService as never,
     );
-    jest
-      .spyOn(
-        service as unknown as {
-          createGithubIssue: () => Promise<{ number: number }>;
-        },
-        "createGithubIssue",
-      )
-      .mockResolvedValue({ number: 123 });
-    return service;
+    return { service, prisma, floService };
   };
 
-  it("forwards the report to SN Support with Mark context", async () => {
+  it("creates the SN Support ticket with Mark context and no GitHub issue", async () => {
     const snSupportService = {
       isConfigured: jest.fn().mockReturnValue(true),
       createTicket: jest.fn().mockResolvedValue({ ticketKey: "SUPPORT-1" }),
     };
 
-    const result = await makeForReportIssue(snSupportService).reportIssue(
-      reportDto,
-      session,
-    );
+    const { service, prisma } = makeForReportIssue(snSupportService);
+    const result = await service.reportIssue(reportDto, session);
 
-    expect(result.issueNumber).toBe(123);
+    expect(result.reportId).toBe(7);
+    expect(result.message).toContain("SUPPORT-1");
+    // The DB row is the record now — no GitHub issue number anywhere.
+    expect(
+      prisma.report.create.mock.calls[0][0].data.issueNumber,
+    ).toBeUndefined();
     expect(snSupportService.createTicket).toHaveBeenCalledWith({
       title: expect.stringContaining("Assignment 42 - Attempt 84"),
       description: expect.stringContaining("The assignment submission fails"),
@@ -187,7 +183,7 @@ describe("ReportsService.reportIssue", () => {
 
     // The flag-button modal pre-composes the description into markdown
     // sections and lets the reporter pick a severity.
-    await makeForReportIssue(snSupportService).reportIssue(
+    await makeForReportIssue(snSupportService).service.reportIssue(
       {
         ...reportDto,
         issueType: "other",
@@ -207,48 +203,49 @@ describe("ReportsService.reportIssue", () => {
     expect(sent.description).not.toContain("**");
   });
 
-  it("still files the GitHub issue when SN Support is down", async () => {
+  it("still records the report when SN Support is down", async () => {
     const snSupportService = {
       isConfigured: jest.fn().mockReturnValue(true),
       createTicket: jest.fn().mockRejectedValue(new Error("sn down")),
     };
 
-    const result = await makeForReportIssue(snSupportService).reportIssue(
-      reportDto,
-      session,
-    );
+    const { service, prisma } = makeForReportIssue(snSupportService);
+    const result = await service.reportIssue(reportDto, session);
 
     expect(snSupportService.createTicket).toHaveBeenCalled();
-    expect(result.issueNumber).toBe(123);
+    expect(prisma.report.create).toHaveBeenCalled();
+    expect(result.reportId).toBe(7);
+    expect(result.message).not.toContain("SUPPORT");
   });
 
-  it("skips the SN forward when the reporter email is unknown", async () => {
+  it("records anonymous reports as DB rows without an SN ticket", async () => {
     const snSupportService = {
       isConfigured: jest.fn().mockReturnValue(true),
       createTicket: jest.fn(),
     };
 
-    const result = await makeForReportIssue(snSupportService).reportIssue(
-      reportDto,
-      { assignmentId: 42, attemptId: 84 },
-    );
+    const { service, prisma } = makeForReportIssue(snSupportService);
+    const result = await service.reportIssue(reportDto, {
+      assignmentId: 42,
+      attemptId: 84,
+    });
 
     expect(snSupportService.createTicket).not.toHaveBeenCalled();
-    expect(result.issueNumber).toBe(123);
+    expect(prisma.report.create).toHaveBeenCalled();
+    expect(result.reportId).toBe(7);
   });
 
-  it("skips the SN forward when the integration is not configured", async () => {
+  it("records the report when the SN integration is not configured", async () => {
     const snSupportService = {
       isConfigured: jest.fn().mockReturnValue(false),
       createTicket: jest.fn(),
     };
 
-    const result = await makeForReportIssue(snSupportService).reportIssue(
-      reportDto,
-      session,
-    );
+    const { service, prisma } = makeForReportIssue(snSupportService);
+    const result = await service.reportIssue(reportDto, session);
 
     expect(snSupportService.createTicket).not.toHaveBeenCalled();
-    expect(result.issueNumber).toBe(123);
+    expect(prisma.report.create).toHaveBeenCalled();
+    expect(result.reportId).toBe(7);
   });
 });

--- a/apps/api/src/api/report/services/report.service.ts
+++ b/apps/api/src/api/report/services/report.service.ts
@@ -23,10 +23,7 @@ import {
 import { AdminEmailService } from "src/auth/services/admin-email.service";
 import { PrismaService } from "src/database/prisma.service";
 import {
-  buildChatIssueBody,
-  buildChatIssueTitle,
   buildSnSupportTicketTitle,
-  CHAT_ISSUE_FOOTER,
   defaultSeverityForIssueType,
   stripSectionLabelMarkdown,
 } from "../helpers/issue-template";
@@ -594,178 +591,6 @@ export class ReportsService {
       },
     };
   }
-  private async createGithubIssue(
-    title: string,
-    body: string,
-    labels: string[] = [],
-  ): Promise<{ number: number; [key: string]: any }> {
-    const githubOwner = process.env.GITHUB_OWNER;
-    const githubRepo = process.env.GITHUB_REPO;
-
-    const token = await this.getInstallationToken();
-    if (!githubOwner || !githubRepo || !token) {
-      const missingConfig = [];
-      if (!githubOwner) missingConfig.push("GITHUB_OWNER");
-      if (!githubRepo) missingConfig.push("GITHUB_REPO");
-      if (!token) missingConfig.push("installation token");
-      this.logger.error("createGitHubIssue: required config missing", {
-        missing: missingConfig,
-        title_length: title?.length,
-        body_length: body?.length,
-        labels,
-      });
-      throw new InternalServerErrorException(
-        `GitHub repository configuration or token missing: ${missingConfig.join(
-          ", ",
-        )}`,
-      );
-    }
-
-    try {
-      const url = `https://api.github.com/repos/${githubOwner}/${githubRepo}/issues`;
-      const payload = { title, body, labels };
-      const response = await axios.post(url, payload, {
-        headers: {
-          Authorization: `Bearer ${token}`,
-          Accept: "application/vnd.github+json",
-          "X-GitHub-Api-Version": "2022-11-28",
-        },
-      });
-
-      return response.data as { number: number; [key: string]: any };
-    } catch (error) {
-      if (axios.isAxiosError(error)) {
-        const errorMessage: string =
-          error.response?.data?.message || error.message;
-        const status = error.response?.status;
-
-        this.logger.error(
-          `createGitHubIssue: GitHub API call failed (${status})`,
-          {
-            status,
-            errorMessage,
-            response_data: error.response?.data,
-            url: error.config?.url,
-          },
-        );
-        throw new InternalServerErrorException(
-          `Failed to create GitHub issue (${status}): ${errorMessage}`,
-        );
-      } else {
-        const errorMessage =
-          error instanceof Error ? error.message : "Unknown error";
-        this.logger.error("createGitHubIssue: non-axios error", {
-          errorMessage,
-          stack: error instanceof Error ? error.stack : undefined,
-        });
-        throw new InternalServerErrorException(
-          `Failed to create GitHub issue: ${errorMessage}`,
-        );
-      }
-    }
-  }
-
-  private async checkGitHubIssueStatus(issueNumber: number): Promise<{
-    state: string;
-    status: ReportStatus;
-    statusMessage: string;
-    closureReason?: string;
-  }> {
-    const { githubOwner, githubRepo, token } = await this.getGithubConfig(
-      "checkGitHubIssueStatus",
-      { issueNumber },
-    );
-
-    try {
-      const response = await axios.get(
-        `https://api.github.com/repos/${githubOwner}/${githubRepo}/issues/${issueNumber}`,
-        {
-          headers: {
-            Authorization: `Bearer ${token}`,
-            Accept: "application/vnd.github+json",
-            "X-GitHub-Api-Version": "2022-11-28",
-          },
-        },
-      );
-
-      const issue = response.data as {
-        state: string;
-        labels: Array<{ name: string }>;
-        closed_at: string | null;
-      };
-
-      let status: ReportStatus = ReportStatus.OPEN;
-      let statusMessage =
-        "Your issue is currently open, developers didn't pick it up yet";
-      let closureReason: string | undefined;
-
-      if (issue.state === "closed") {
-        const isDuplicate = issue.labels.some((label) =>
-          label.name.toLowerCase().includes("duplicate"),
-        );
-
-        const isWontFix = issue.labels.some(
-          (label) =>
-            label.name.toLowerCase().includes("wontfix") ||
-            label.name.toLowerCase().includes("won't fix") ||
-            label.name.toLowerCase().includes("not planned"),
-        );
-
-        const isInvalid = issue.labels.some(
-          (label) =>
-            label.name.toLowerCase().includes("invalid") ||
-            label.name.toLowerCase().includes("not reproducible"),
-        );
-
-        if (isDuplicate) {
-          status = ReportStatus.CLOSED;
-          closureReason = "duplicate";
-          statusMessage =
-            "This issue was closed as a duplicate of another issue.";
-        } else if (isWontFix) {
-          status = ReportStatus.CLOSED;
-          closureReason = "wontfix";
-          statusMessage =
-            "This issue was closed as it won't be implemented or fixed.";
-        } else if (isInvalid) {
-          status = ReportStatus.CLOSED;
-          closureReason = "invalid";
-          statusMessage =
-            "This issue was closed as it was deemed invalid or not reproducible.";
-        } else {
-          status = ReportStatus.RESOLVED;
-          closureReason = "fixed";
-          statusMessage = "This issue has been resolved.";
-        }
-      } else {
-        const inProgressLabel = issue.labels.find(
-          (label: { name: string }) =>
-            label.name === "in progress" ||
-            label.name === "in-progress" ||
-            label.name === "working",
-        );
-
-        if (inProgressLabel) {
-          status = ReportStatus.IN_PROGRESS;
-          statusMessage = "Our team is actively working on this issue.";
-        }
-      }
-
-      return {
-        state: issue.state,
-        status,
-        statusMessage,
-        closureReason,
-      };
-    } catch {
-      return {
-        state: "unknown",
-        status: ReportStatus.OPEN,
-        statusMessage: "Unable to retrieve current status.",
-      };
-    }
-  }
-
   private mapIssueTypeToReportType(issueType: string): ReportType {
     switch (issueType.toLowerCase()) {
       case "bug":
@@ -1005,7 +830,6 @@ export class ReportsService {
     screenshot?: Express.Multer.File,
   ): Promise<{
     message: string;
-    issueNumber?: number;
     reportId?: number;
     similarReports?: Array<{
       id: number;
@@ -1030,7 +854,6 @@ export class ReportsService {
       throw new InternalServerErrorException("issueType is required");
     }
 
-    const isProduction = process.env.NODE_ENV === "production";
     const role = userSession?.role || "Author";
     const issueSeverity: "info" | "warning" | "error" | "critical" =
       severity || defaultSeverityForIssueType(issueType);
@@ -1090,19 +913,12 @@ export class ReportsService {
     const potentialDuplicate = similarReports.find((r) => r.similarity > 0.85);
     const highSimilarityReport = similarReports.find((r) => r.similarity > 0.7);
 
-    const issueTemplateInput = {
+    const ticketTitle = buildSnSupportTicketTitle({
       issueType,
-      role,
-      severity: issueSeverity,
-      userEmail: safeUserEmail,
       assignmentId,
       attemptId,
-      reportedAt: new Date(),
-      isProduction,
       description,
-    };
-    const issueTitle = buildChatIssueTitle(issueTemplateInput);
-    let issueBody = buildChatIssueBody(issueTemplateInput);
+    });
 
     const finalScreenshotUrl =
       screenshotUrl || additionalDetails?.screenshotUrl;
@@ -1119,24 +935,12 @@ export class ReportsService {
         fullScreenshotUrl = screenshotUrl
           ? `${cosEndpoint}/${debugBucket}/${screenshotUrl}`
           : `${cosEndpoint}/${debugBucket}/${finalScreenshotUrl}`;
-
-        issueBody += `
-### Screenshot
-![Screenshot](${fullScreenshotUrl})
-
-*Screenshot uploaded to IBM Cloud Object Storage: \`${finalScreenshotUrl}\`*
-`;
-      } else {
-        issueBody += `
-### Screenshot
-Screenshot Key: \`${finalScreenshotUrl}\`
-`;
       }
     }
 
-    // Forward to SN Support in addition to the GitHub issue. Best-effort
-    // during the transition: an SN outage or validation error must never
-    // block the report itself. The v2 API requires a reporter email.
+    // SN Support is the support queue for new reports. The v2 API requires a
+    // reporter email, so anonymous reports exist only as DB rows below.
+    let snTicketKey: string | undefined;
     if (this.snSupportService.isConfigured() && safeUserEmail !== "Unknown") {
       const supportDescription = [
         stripSectionLabelMarkdown(description),
@@ -1150,7 +954,7 @@ Screenshot Key: \`${finalScreenshotUrl}\`
 
       try {
         const snTicket = await this.snSupportService.createTicket({
-          title: buildSnSupportTicketTitle(issueTemplateInput),
+          title: ticketTitle,
           description: supportDescription,
           reporterEmail: safeUserEmail,
           severity: issueSeverity,
@@ -1181,266 +985,113 @@ Screenshot Key: \`${finalScreenshotUrl}\`
               : undefined,
           screenshotUrl: fullScreenshotUrl,
         });
-        this.logger.log("Forwarded report to SN Support", {
+        snTicketKey = snTicket.ticketKey;
+        this.logger.log("Created SN Support ticket for report", {
           ticket_key: snTicket.ticketKey,
           assignment_id: assignmentId,
           attempt_id: attemptId,
         });
       } catch (error) {
-        this.logger.warn("SN Support ticket creation failed; continuing", {
+        // The report survives as a DB row (and in the admin dashboard), so
+        // the submission itself is not failed — but nobody is watching that
+        // queue, so this needs attention.
+        this.logger.error("SN Support ticket creation failed", {
           error: error instanceof Error ? error.message : String(error),
+          stack: error instanceof Error ? error.stack : undefined,
           assignment_id: assignmentId,
           attempt_id: attemptId,
         });
       }
     } else {
-      this.logger.debug("Skipping SN Support forward", {
+      // Without a ticket the report reaches no support queue — DB row only.
+      this.logger.warn("Report not forwarded to SN Support", {
         configured: this.snSupportService.isConfigured(),
         has_reporter_email: safeUserEmail !== "Unknown",
+        assignment_id: assignmentId,
+        attempt_id: attemptId,
       });
     }
 
-    if (similarReports.length > 0) {
-      issueBody += `\n\n### Similar Issues\n`;
-      for (const report of similarReports.slice(0, 3)) {
-        const similarityPercentage = Math.round(report.similarity * 100);
-        issueBody += `- Issue #${
-          report.issueNumber || report.id
-        } (${similarityPercentage}% similar)\n`;
+    // Duplicates inherit the parent's resolution so reporters aren't told a
+    // fixed issue is still open.
+    let reportStatus: ReportStatus = ReportStatus.OPEN;
+    let statusMessage = "Your issue has been reported and is being reviewed.";
+    let closureReason: string | null = null;
+    const isDuplicate = Boolean(potentialDuplicate);
+
+    if (potentialDuplicate) {
+      const parentReport = await this.prisma.report.findUnique({
+        where: { id: potentialDuplicate.id },
+        select: { status: true, closureReason: true },
+      });
+
+      if (
+        parentReport &&
+        (parentReport.status === ReportStatus.RESOLVED ||
+          parentReport.status === ReportStatus.CLOSED)
+      ) {
+        reportStatus = parentReport.status;
+        closureReason = parentReport.closureReason ?? null;
+        statusMessage =
+          parentReport.closureReason === "wontfix"
+            ? "This issue was closed as it won't be implemented or fixed."
+            : parentReport.closureReason === "invalid"
+              ? "This issue was closed as it was deemed invalid or not reproducible."
+              : parentReport.closureReason === "duplicate"
+                ? "This issue was closed as a duplicate of another issue."
+                : "This issue was resolved.";
       }
     }
 
-    issueBody += CHAT_ISSUE_FOOTER;
+    const reportData: {
+      duplicateOfReportId: number | null;
+      reporterId: string;
+      assignmentId: number | null;
+      attemptId: number | null;
+      issueType: ReportType;
+      description: string;
+      author: boolean;
+      status: ReportStatus;
+      statusMessage: string;
+      relatedToReportId?: number | null;
+      similarityScore?: number | null;
+      closureReason?: string | null;
+    } = {
+      reporterId: userSession?.userId || "anonymous",
+      assignmentId: typeof assignmentId === "number" ? assignmentId : null,
+      attemptId: typeof attemptId === "number" ? attemptId : null,
+      issueType: mappedIssueType,
+      description: description,
+      author: role?.toLowerCase() === "author",
+      status: reportStatus,
+      statusMessage: statusMessage,
+      duplicateOfReportId: null,
+      relatedToReportId: null,
+      similarityScore: null,
+      closureReason,
+    };
 
     if (potentialDuplicate) {
-      issueBody += `\n\n⚠️ **Potential Duplicate** ⚠️\nThis issue appears to be a duplicate of Issue #${
-        potentialDuplicate.issueNumber || potentialDuplicate.id
-      } (${Math.round(potentialDuplicate.similarity * 100)}% similar)`;
+      reportData.duplicateOfReportId = potentialDuplicate.id;
+      reportData.similarityScore = potentialDuplicate.similarity;
+    } else if (highSimilarityReport) {
+      reportData.relatedToReportId = highSimilarityReport.id;
+      reportData.similarityScore = highSimilarityReport.similarity;
     }
 
     try {
-      let issue: { number: number; [key: string]: any } | undefined;
-      let parentIssueNumber: number | undefined;
-      let isDuplicate = false;
-
-      if (potentialDuplicate?.issueNumber) {
-        isDuplicate = true;
-        parentIssueNumber = potentialDuplicate.issueNumber;
-
-        const { githubOwner, githubRepo, token } = await this.getGithubConfig(
-          "submitReport (duplicate path)",
-          { parent_issue_number: parentIssueNumber },
-        );
-
-        let commentBody = `
-## Duplicate Report Detected
-
-Another user has reported a nearly identical issue:
-
-**Similarity Score:** ${Math.round(potentialDuplicate.similarity * 100)}%
-**Reported By:** ${role || "Unknown"}
-**User Email:** ${safeUserEmail}
-**Assignment ID:** ${assignmentId || "N/A"}
-**Attempt ID:** ${attemptId || "N/A"}
-**Time Reported:** ${new Date().toISOString()}
-
-### Description from new report
-${description}
-`;
-
-        const screenshotUrl = additionalDetails?.screenshotUrl;
-        if (screenshotUrl && typeof screenshotUrl === "string") {
-          const debugBucket = process.env.IBM_COS_DEBUG_BUCKET;
-          if (debugBucket && screenshotUrl.includes(debugBucket)) {
-            const cosEndpoint = process.env.IBM_COS_ENDPOINT;
-            const fullScreenshotUrl = `${cosEndpoint}/${debugBucket}/${screenshotUrl}`;
-
-            commentBody += `
-### Screenshot from duplicate report
-![Screenshot](${fullScreenshotUrl})
-`;
-          } else {
-            commentBody += `
-### Screenshot from duplicate report
-Screenshot Key: \`${screenshotUrl}\`
-`;
-          }
-        }
-
-        await axios.post(
-          `https://api.github.com/repos/${githubOwner}/${githubRepo}/issues/${parentIssueNumber}/comments`,
-          { body: commentBody },
-          {
-            headers: {
-              Authorization: `Bearer ${token}`,
-              Accept: "application/vnd.github+json",
-              "X-GitHub-Api-Version": "2022-11-28",
-            },
-          },
-        );
-
-        const issueResponse = await axios.get(
-          `https://api.github.com/repos/${githubOwner}/${githubRepo}/issues/${parentIssueNumber}`,
-          {
-            headers: {
-              Authorization: `Bearer ${token}`,
-              Accept: "application/vnd.github+json",
-              "X-GitHub-Api-Version": "2022-11-28",
-            },
-          },
-        );
-
-        issue = issueResponse.data as {
-          number: number;
-          state: string;
-          labels: Array<{ name: string }>;
-          closed_at?: string | null;
-        };
-
-        if (issue.state === "closed") {
-          await this.checkGitHubIssueStatus(parentIssueNumber);
-        }
-      } else if (highSimilarityReport?.issueNumber) {
-        const labels = ["chat-report", "related-issue"];
-        if (issueType === "technical" || issueType === "bug")
-          labels.push("bug");
-        if (issueType === "content") labels.push("content");
-        if (issueType === "grading") labels.push("grading");
-        if (role) labels.push(role);
-
-        issueBody += `\n\n### Related Issue\nThis appears to be related to Issue #${
-          highSimilarityReport.issueNumber
-        } (${Math.round(highSimilarityReport.similarity * 100)}% similar)`;
-
-        issue = await this.createGithubIssue(issueTitle, issueBody, labels);
-
-        const githubOwner = process.env.GITHUB_OWNER;
-        const githubRepo = process.env.GITHUB_REPO;
-        const token = await this.getInstallationToken();
-
-        if (githubOwner && githubRepo && token) {
-          const relationComment = `
-## Related Issue Created
-
-A new related issue has been created: #${issue.number}
-
-**Similarity Score:** ${Math.round(highSimilarityReport.similarity * 100)}%
-**Issue Type:** ${issueType}
-`;
-
-          await axios.post(
-            `https://api.github.com/repos/${githubOwner}/${githubRepo}/issues/${highSimilarityReport.issueNumber}/comments`,
-            { body: relationComment },
-            {
-              headers: {
-                Authorization: `Bearer ${token}`,
-                Accept: "application/vnd.github+json",
-                "X-GitHub-Api-Version": "2022-11-28",
-              },
-            },
-          );
-        }
-      } else {
-        const labels = ["chat-report"];
-        if (issueType === "technical" || issueType === "bug")
-          labels.push("bug");
-        if (issueType === "content") labels.push("content");
-        if (issueType === "grading") labels.push("grading");
-        if (role) labels.push(role);
-
-        issue = await this.createGithubIssue(issueTitle, issueBody, labels);
-      }
-
-      let reportStatus: ReportStatus = ReportStatus.OPEN;
-      let statusMessage = "Your issue has been reported and is being reviewed.";
-
-      if (isDuplicate && potentialDuplicate) {
-        const parentReport = await this.prisma.report.findUnique({
-          where: { id: potentialDuplicate.id },
-          select: { status: true, statusMessage: true, closureReason: true },
-        });
-
-        if (
-          parentReport &&
-          (parentReport.status === ReportStatus.RESOLVED ||
-            parentReport.status === ReportStatus.CLOSED)
-        ) {
-          reportStatus = parentReport.status;
-          statusMessage =
-            parentReport.closureReason === "wontfix"
-              ? "This issue was closed as it won't be implemented or fixed."
-              : parentReport.closureReason === "invalid"
-                ? "This issue was closed as it was deemed invalid or not reproducible."
-                : parentReport.closureReason === "duplicate"
-                  ? "This issue was closed as a duplicate of another issue."
-                  : "This issue was resolved.";
-        }
-      }
-
-      const reportData: {
-        duplicateOfReportId: number | null;
-        reporterId: string;
-        assignmentId: number | null;
-        attemptId: number | null;
-        issueType: ReportType;
-        description: string;
-        author: boolean;
-        status: ReportStatus;
-        issueNumber?: number;
-        statusMessage: string;
-        relatedToReportId?: number | null;
-        similarityScore?: number | null;
-        closureReason?: string | null;
-      } = {
-        reporterId: userSession?.userId || "anonymous",
-        assignmentId: typeof assignmentId === "number" ? assignmentId : null,
-        attemptId: typeof attemptId === "number" ? attemptId : null,
-        issueType: mappedIssueType,
-        description: description,
-        author: role?.toLowerCase() === "author",
-        status: reportStatus,
-        issueNumber: issue.number,
-        statusMessage: statusMessage,
-        duplicateOfReportId: null,
-        relatedToReportId: null,
-        similarityScore: null,
-        closureReason: null,
-      };
-
-      if (potentialDuplicate) {
-        reportData.duplicateOfReportId = potentialDuplicate.id;
-        reportData.similarityScore = potentialDuplicate.similarity;
-
-        if (
-          reportStatus === ReportStatus.CLOSED ||
-          reportStatus === ReportStatus.RESOLVED
-        ) {
-          const parentReport = await this.prisma.report.findUnique({
-            where: { id: potentialDuplicate.id },
-            select: { closureReason: true },
-          });
-
-          if (parentReport?.closureReason) {
-            reportData.closureReason = parentReport.closureReason;
-          }
-        }
-      } else if (highSimilarityReport) {
-        reportData.relatedToReportId = highSimilarityReport.id;
-        reportData.similarityScore = highSimilarityReport.similarity;
-      }
-
       const report = await this.prisma.report.create({ data: reportData });
 
       // Fire-and-forget: Flo is best-effort telemetry. Never block the
       // request on its NATS publish — the underlying ts-nats client opens a
       // fresh connection per call and has no built-in deadline.
       void this.floService
-        .sendError(issueTitle, description, {
+        .sendError(ticketTitle, description, {
           severity: issueSeverity,
           tags: ["mark", "chat", "report", role || "user", issueType],
           assignmentId,
           attemptId,
-          github_issue: issue.number,
+          sn_ticket: snTicketKey,
           report_id: report.id,
           is_duplicate: isDuplicate,
         })
@@ -1452,10 +1103,13 @@ A new related issue has been created: #${issue.number}
           );
         });
 
-      let message = `Thank you for your report. Issue #${issue.number} has been created and our team will review it soon. You can check the status of this issue anytime by asking me about your reported issues.`;
+      const ticketSegment = snTicketKey
+        ? `Support ticket ${snTicketKey} has been created and our team will review it soon.`
+        : `Our team will review it soon.`;
+      let message = `Thank you for your report. ${ticketSegment} You can check the status anytime by asking about your reported issues.`;
 
       if (isDuplicate) {
-        message = `Thank you for your report. We found that this is likely a duplicate of an existing issue (#${parentIssueNumber}). Your report has been linked to the existing issue and will be handled together. You can check the status anytime by asking about your reported issues.`;
+        message = `Thank you for your report. This looks like a duplicate of a previously reported issue, so your report has been linked to it and they will be handled together. You can check the status anytime by asking about your reported issues.`;
 
         if (
           reportStatus === ReportStatus.RESOLVED ||
@@ -1466,11 +1120,9 @@ A new related issue has been created: #${issue.number}
           }.`;
         }
       } else if (highSimilarityReport) {
-        message = `Thank you for your report. Issue #${issue.number} has been created and linked to a similar existing issue (#${highSimilarityReport.issueNumber}). Our team will review both issues together. You can check the status anytime by asking about your reported issues.`;
+        message = `Thank you for your report. ${ticketSegment} It has been linked to a similar existing report and our team will review them together. You can check the status anytime by asking about your reported issues.`;
       } else if (similarReports.length > 0) {
-        message = `Thank you for your report. Issue #${
-          issue.number
-        } has been created and our team will review it soon. We found ${
+        message = `Thank you for your report. ${ticketSegment} We found ${
           similarReports.length
         } similar ${
           similarReports.length === 1 ? "issue" : "issues"
@@ -1479,7 +1131,6 @@ A new related issue has been created: #${issue.number}
 
       return {
         message,
-        issueNumber: issue?.number,
         reportId: report.id,
         similarReports:
           similarReports.length > 0
@@ -1493,66 +1144,14 @@ A new related issue has been created: #${issue.number}
             : undefined,
         isDuplicate,
       };
-    } catch {
-      try {
-        const reportData: {
-          duplicateOfReportId: number | null;
-          reporterId: string;
-          assignmentId: number | null;
-          attemptId: number | null;
-          issueType: ReportType;
-          description: string;
-          author: boolean;
-          status: ReportStatus;
-          issueNumber?: number;
-          statusMessage: string;
-          relatedToReportId?: number | null;
-          similarityScore?: number | null;
-        } = {
-          reporterId: userSession?.userId || "anonymous",
-          assignmentId: assignmentId,
-          attemptId: attemptId,
-          issueType: mappedIssueType,
-          description: `${description}\n\nNote: GitHub issue creation failed.`,
-          author: role?.toLowerCase() === "author",
-          status: ReportStatus.OPEN,
-          statusMessage:
-            "Your issue has been reported but there was a problem creating a GitHub issue.",
-          issueNumber: null,
-          duplicateOfReportId: null,
-          relatedToReportId: null,
-          similarityScore: null,
-        };
-
-        if (potentialDuplicate) {
-          reportData.duplicateOfReportId = potentialDuplicate.id;
-          reportData.similarityScore = potentialDuplicate.similarity;
-        } else if (highSimilarityReport) {
-          reportData.relatedToReportId = highSimilarityReport.id;
-          reportData.similarityScore = highSimilarityReport.similarity;
-        }
-
-        const report = await this.prisma.report.create({ data: reportData });
-
-        return {
-          message:
-            "Your report has been saved. However, we encountered an issue with our tracking system. Your feedback is still important to us - we'll follow up as soon as possible.",
-          reportId: report.id,
-          similarReports:
-            similarReports.length > 0
-              ? similarReports.slice(0, 3).map((r) => ({
-                  id: r.id,
-                  issueNumber: r.issueNumber,
-                  similarity: r.similarity,
-                  description: r.description,
-                  status: r.status.toString(),
-                }))
-              : undefined,
-          isDuplicate: potentialDuplicate !== undefined,
-        };
-      } catch {
-        // If we fail to create a report, fall through to generic error response
-      }
+    } catch (error) {
+      this.logger.error("submitReport: failed to persist report", {
+        error: error instanceof Error ? error.message : String(error),
+        stack: error instanceof Error ? error.stack : undefined,
+        assignment_id: assignmentId,
+        attempt_id: attemptId,
+        sn_ticket: snTicketKey,
+      });
 
       return {
         message:
@@ -1794,72 +1393,43 @@ A new related issue has been created: #${issue.number}
       throw new NotFoundException(`Report with ID ${reportId} not found`);
     }
 
-    const githubOwner = process.env.GITHUB_OWNER;
-    const githubRepo = process.env.GITHUB_REPO;
-    const token = await this.getInstallationToken();
+    // Reports created after the SN Support cutover have no GitHub issue;
+    // their comment is delivered by email below. GitHub-era reports keep
+    // getting the issue comment so the mark-support thread stays complete.
+    if (report.issueNumber) {
+      const githubOwner = process.env.GITHUB_OWNER;
+      const githubRepo = process.env.GITHUB_REPO;
+      const token = await this.getInstallationToken();
 
-    if (!githubOwner || !githubRepo || !token) {
-      this.logger.error("addReportComment: GitHub config or token missing", {
-        report_id: report.id,
-        issue_number: report.issueNumber,
-        owner_set: !!githubOwner,
-        repo_set: !!githubRepo,
-        token_set: !!token,
-      });
-      throw new InternalServerErrorException(
-        "GitHub repository configuration or token missing",
-      );
-    }
+      if (!githubOwner || !githubRepo || !token) {
+        this.logger.error("addReportComment: GitHub config or token missing", {
+          report_id: report.id,
+          issue_number: report.issueNumber,
+          owner_set: !!githubOwner,
+          repo_set: !!githubRepo,
+          token_set: !!token,
+        });
+        throw new InternalServerErrorException(
+          "GitHub repository configuration or token missing",
+        );
+      }
 
-    // Orphan reports (issueNumber === null) exist when GitHub issue creation
-    // failed during report submission. Backfill the issue here so commenting
-    // recovers them instead of 500ing forever.
-    if (!report.issueNumber) {
-      const labels = ["chat-report", report.issueType.toLowerCase()];
-      const backfillDescription = report.description ?? "(no description)";
-      const backfillTemplateInput = {
-        issueType: report.issueType,
-        role: report.author ? "author" : "learner",
-        severity: defaultSeverityForIssueType(report.issueType),
-        userEmail: report.reporterId,
-        assignmentId: report.assignmentId,
-        attemptId: report.attemptId,
-        reportedAt: report.createdAt ?? new Date(),
-        isProduction: process.env.NODE_ENV === "production",
-        description: backfillDescription,
-      };
-
-      const issue = await this.createGithubIssue(
-        buildChatIssueTitle(backfillTemplateInput),
-        buildChatIssueBody(backfillTemplateInput) + CHAT_ISSUE_FOOTER,
-        labels,
-      );
-      report.issueNumber = issue.number;
-      await this.prisma.report.update({
-        where: { id: report.id },
-        data: { issueNumber: issue.number },
-      });
-      this.logger.log(
-        "addReportComment: backfilled GitHub issue for orphan report",
-        { report_id: report.id, issue_number: issue.number },
-      );
-    }
-
-    await axios.post(
-      `https://api.github.com/repos/${githubOwner}/${githubRepo}/issues/${report.issueNumber}/comments`,
-      {
-        body: `**${userSession.role ?? "user"} (${
-          userSession.userId
-        })**\n\n${comment}`,
-      },
-      {
-        headers: {
-          Authorization: `Bearer ${token}`,
-          Accept: "application/vnd.github+json",
-          "X-GitHub-Api-Version": "2022-11-28",
+      await axios.post(
+        `https://api.github.com/repos/${githubOwner}/${githubRepo}/issues/${report.issueNumber}/comments`,
+        {
+          body: `**${userSession.role ?? "user"} (${
+            userSession.userId
+          })**\n\n${comment}`,
         },
-      },
-    );
+        {
+          headers: {
+            Authorization: `Bearer ${token}`,
+            Accept: "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+          },
+        },
+      );
+    }
 
     const reporterEmail = report.reporterId;
     const developerEmail = this.getDeveloperNotificationEmail();
@@ -2792,51 +2362,22 @@ A new related issue has been created: #${issue.number}
     userId?: string,
     assignmentId?: number,
   ): Promise<{ message: string; reportId?: number }> {
-    try {
-      // Fire-and-forget: see floService.sendError comment in reportIssue.
-      void this.floService
-        .sendFeedback(title, description, {
-          rating,
-          userEmail,
-          portalName: portalName || "Mark AI Assistant",
-        })
-        .catch((error) => {
-          this.logger.warn(
-            `Flo sendFeedback dispatch failed: ${(error as Error).message}`,
-          );
-        });
+    // Fire-and-forget: see floService.sendError comment in reportIssue.
+    void this.floService
+      .sendFeedback(title, description, {
+        rating,
+        userEmail,
+        portalName: portalName || "Mark AI Assistant",
+      })
+      .catch((error) => {
+        this.logger.warn(
+          `Flo sendFeedback dispatch failed: ${(error as Error).message}`,
+        );
+      });
 
-      const issueTitle = `[MARK CHAT] User Feedback: ${title}`;
-      const issueBody = `
-## User Feedback Report
-**Feedback Type:** ${title}
-**Rating:** ${rating}
-**Reported By:** ${userEmail || "Anonymous"}
-**Time Reported:** ${new Date().toISOString()}
-### Description
-${description}
----
-*This feedback was automatically reported through the Mark Chat feature.*
-`;
-
-      const labels = ["feedback"];
-      if (title === "bug") labels.push("bug");
-      if (title === "content") labels.push("content");
-      if (title === "grading") labels.push("grading");
-      if (title === "technical") labels.push("technical");
-      if (title === "critical") labels.push("critical");
-      if (title === "feature") labels.push("feature");
-      if (title === "other") labels.push("other");
-
-      const issue = await this.createGithubIssue(issueTitle, issueBody, labels);
-
-      let report: {
-        id: number;
-        status: ReportStatus;
-        statusMessage: string;
-      } | null;
-
-      if (assignmentId) {
+    let report: { id: number } | null = null;
+    if (assignmentId) {
+      try {
         report = await this.prisma.report.create({
           data: {
             reporterId: userId || "anonymous",
@@ -2845,54 +2386,32 @@ ${description}
             description: `Rating: ${rating}\n\n${description}`,
             author: false,
             status: ReportStatus.OPEN,
-            issueNumber: issue.number,
             statusMessage:
               "Your feedback has been received and is being reviewed.",
           },
         });
+      } catch (error) {
+        this.logger.error("sendUserFeedback: failed to persist feedback", {
+          error: error instanceof Error ? error.message : String(error),
+          stack: error instanceof Error ? error.stack : undefined,
+          assignment_id: assignmentId,
+        });
+
+        return {
+          message:
+            "We encountered an issue while submitting your feedback. Please try again later.",
+        };
       }
-
-      return {
-        message: `Thank you for your feedback! Issue #${
-          issue.number
-        } has been created and our team will review it soon.${
-          report
-            ? " You can check the status of this feedback anytime by asking me about your reported issues."
-            : ""
-        }`,
-        reportId: report?.id,
-      };
-    } catch {
-      if (assignmentId && userId) {
-        try {
-          const report = await this.prisma.report.create({
-            data: {
-              reporterId: userId,
-              assignmentId,
-              issueType: ReportType.FEEDBACK,
-              description: `Rating: ${rating}\n\n${description}\n\nNote: GitHub issue creation failed.`,
-              author: false,
-              status: ReportStatus.OPEN,
-              statusMessage:
-                "Your feedback has been received, but there was a problem creating a GitHub issue.",
-            },
-          });
-
-          return {
-            message:
-              "Your feedback has been saved. Thank you for helping us improve!",
-            reportId: report.id,
-          };
-        } catch {
-          // fall through to generic error
-        }
-      }
-
-      return {
-        message:
-          "We encountered an issue while submitting your feedback. Please try again later.",
-      };
     }
+
+    return {
+      message: `Thank you for your feedback! Our team will review it soon.${
+        report
+          ? " You can check the status of this feedback anytime by asking me about your reported issues."
+          : ""
+      }`,
+      reportId: report?.id,
+    };
   }
 
   async sendBugRenewalEmail(dto: BugRenewalEmailDto): Promise<{


### PR DESCRIPTION
SN Support is proven in prod, so new reports and chat feedback no longer create GitHub issues. The SN ticket plus the DB report row are the record: duplicate and related-report linking now runs purely on the DB (including inheriting a resolved parent's status), the reporter-facing messages reference the SN ticket key instead of an issue number, and Flo telemetry carries sn_ticket instead of github_issue. An SN outage or an anonymous reporter (the v2 API requires an email) degrades to the DB row alone, logged at error/warn respectively since no support queue sees those reports.

Machinery for GitHub-era reports stays: the webhook, renewal emails, status sync, and admin comments still work for any report that has an issueNumber. Admin comments on SN-era reports skip GitHub (previously an orphan report was backfilled into a new GitHub issue, which would have quietly resurrected the mirror) and are delivered by the existing reporter email leg instead. createGithubIssue and checkGitHubIssueStatus are now unreferenced and removed, along with the GitHub title/body builders.
