### PR TITLE
fix: stop learner reload loop from oversized attempt payloads

### DIFF
--- a/apps/api/src/api/assignment/attempt/attempt.service.spec.ts
+++ b/apps/api/src/api/assignment/attempt/attempt.service.spec.ts
@@ -775,6 +775,58 @@ describe("AttemptServiceV1 - Auto-Grade Expired Attempts", () => {
       expect(question.choices[0].feedback).toBeUndefined();
       expect(question.answer).toBeUndefined();
     });
+
+    // The response used to embed every language's translation of every
+    // question. With images inlined in question HTML that multiplied each
+    // image by the language count (assignment 2532 shipped ~4MB attempts,
+    // overflowing the client's localStorage quota). Only the requested
+    // language family may be fetched.
+    it("fetches translations only for the requested language family", async () => {
+      mockPrismaService.assignmentAttempt.findUnique.mockResolvedValue({
+        ...baseAttempt,
+        questionOrder: [7],
+        questionVariants: [
+          { questionId: 7, questionVariant: null, randomizedChoices: null },
+        ],
+      });
+      mockPrismaService.assignment.findUnique.mockResolvedValue({
+        ...baseAssignment,
+        questions: [
+          {
+            id: 7,
+            assignmentId: 42,
+            question: "Pick one",
+            type: "SINGLE_CORRECT",
+            totalPoints: 1,
+            choices: [{ choice: "A", isCorrect: true, points: 1 }],
+          },
+        ],
+      });
+      mockPrismaService.translation.findMany.mockResolvedValue([
+        {
+          questionId: 7,
+          variantId: null,
+          languageCode: "zh-CN",
+          translatedText: "选一个",
+          translatedChoices: [{ choice: "甲" }],
+        },
+      ]);
+      mockPrismaService.question.findMany.mockResolvedValue([]);
+
+      const result = await service.getAssignmentAttempt(555, "zh-CN");
+
+      expect(mockPrismaService.translation.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            languageCode: { startsWith: "zh" },
+          }),
+        }),
+      );
+      const [question] = result.questions;
+      expect(question.translations["zh-CN"]).toEqual(
+        expect.objectContaining({ translatedText: "选一个" }),
+      );
+    });
   });
 
   describe("getLearnerAssignmentAttempt - correct answer visibility", () => {

--- a/apps/api/src/api/assignment/attempt/attempt.service.ts
+++ b/apps/api/src/api/assignment/attempt/attempt.service.ts
@@ -1190,7 +1190,8 @@ export class AttemptServiceV1 implements OnModuleDestroy {
    * @param language - The language code requested (if none provided, defaults to "en")
    * @returns Structured attempt data with:
    * - Questions in their attempt-specific order
-   * - Merged question/variant data including translations for all available languages
+   * - Merged question/variant data including translations for the requested
+   *   language family only (the client refetches on language switch)
    * - Responses with score/feedback visibility rules applied
    * - Assignment configuration metadata
    *
@@ -1292,8 +1293,17 @@ export class AttemptServiceV1 implements OnModuleDestroy {
       .map((qv) => qv.questionVariant?.id)
       .filter((id) => id != undefined);
 
+    // Only the requested language family is fetched (startsWith covers
+    // regional rows like zh-CN/zh-TW for a zh request). Returning every
+    // language made the response size scale with the translation count — an
+    // assignment with images embedded in its question HTML shipped each image
+    // once per language (assignment 2532 reached ~4MB, overflowing
+    // localStorage on the client and trapping learners in a clear-and-reload
+    // loop). The client refetches the attempt when the learner switches
+    // language mid-attempt.
     const translations = await this.prisma.translation.findMany({
       where: {
+        languageCode: { startsWith: normalizedLanguage },
         OR: [
           { questionId: { in: questionIds } },
           ...(variantIds.length > 0 ? [{ variantId: { in: variantIds } }] : []),

--- a/apps/web/app/learner/(components)/Header.tsx
+++ b/apps/web/app/learner/(components)/Header.tsx
@@ -14,6 +14,7 @@ import type {
   SubmitAssignmentResponse,
 } from "@/config/types";
 import {
+  getAttempt,
   getSupportedLanguages,
   getUser,
   submitAssignment,
@@ -73,6 +74,7 @@ function LearnerHeader() {
   const [
     questions,
     setQuestion,
+    setQuestions,
     setShowSubmissionFeedback,
     activeAttemptId,
     setTotalPointsEarned,
@@ -81,6 +83,7 @@ function LearnerHeader() {
   ] = useLearnerStore((state) => [
     state.questions,
     state.setQuestion,
+    state.setQuestions,
     state.setShowSubmissionFeedback,
     state.activeAttemptId,
     state.setTotalPointsEarned,
@@ -181,6 +184,23 @@ function LearnerHeader() {
     if (!selectedLanguage) return;
     if (selectedLanguage !== userPreferedLanguage) {
       setUserPreferedLanguage(selectedLanguage);
+
+      // The attempt payload only carries the language it was fetched with, so
+      // an in-page switch pulls the new language's translations and merges
+      // them over the store (setQuestions keeps draft answers). Until the
+      // fetch lands the UI falls back to the server-translated question text.
+      if (isInQuestionPage && assignmentId && activeAttemptId) {
+        void getAttempt(
+          assignmentId,
+          activeAttemptId,
+          undefined,
+          selectedLanguage,
+        ).then((attempt) => {
+          if (attempt?.questions?.length) {
+            setQuestions(attempt.questions);
+          }
+        });
+      }
     }
 
     if (!isInQuestionPage && !isAttemptPage && !isSuccessPage) {

--- a/apps/web/app/learner/[assignmentId]/questions/LearnerLayout.tsx
+++ b/apps/web/app/learner/[assignmentId]/questions/LearnerLayout.tsx
@@ -148,6 +148,22 @@ async function LearnerLayout(props: Props) {
     return <ClientLearnerLayout assignmentId={assignmentId} role={role} />;
   }
 
+  // Authors must not fall through to the learner flow: the server accepts
+  // their attempt creation, but AttemptLoader renders learner-only content,
+  // which left authors on a silently blank page (and created stray attempts).
+  if (role === "author") {
+    log("Author attempt disallowed");
+    return (
+      <ErrorModal
+        error={
+          "You can't take the assignment as an author, please switch to learner mode or check learner side in the review page to try the assignment"
+        }
+        statusCode={403}
+        stateTimeline={stateTimeline}
+      />
+    );
+  }
+
   let listOfAttempts;
   try {
     listOfAttempts = await getAttempts(assignmentId, cookieHeader, {

--- a/apps/web/app/learner/[assignmentId]/questions/__tests__/LearnerLayout.test.tsx
+++ b/apps/web/app/learner/[assignmentId]/questions/__tests__/LearnerLayout.test.tsx
@@ -144,4 +144,22 @@ describe("LearnerLayout attempt resolution", () => {
     expect(element.type).toBe(ErrorModal);
     expect(element.props.headline).not.toBe("No more attempts available");
   });
+
+  // The server accepts attempt creation from authors, and AttemptLoader
+  // renders learner-only content — so an author who fell through to the
+  // learner flow got a silently blank page and a stray attempt. The role
+  // must be rejected up front instead.
+  it("shows the author modal before touching attempts when an author lacks authorMode", async () => {
+    getUserMock.mockResolvedValue({ role: "author" });
+
+    const element = await LearnerLayout(props);
+
+    expect(element.type).toBe(ErrorModal);
+    expect(element.props.statusCode).toBe(403);
+    expect(element.props.error).toMatch(
+      /can't take the assignment as an author/,
+    );
+    expect(getAttemptsMock).not.toHaveBeenCalled();
+    expect(createAttemptMock).not.toHaveBeenCalled();
+  });
 });

--- a/apps/web/lib/__tests__/safe-storage.test.ts
+++ b/apps/web/lib/__tests__/safe-storage.test.ts
@@ -1,0 +1,92 @@
+import { createSafeStorage } from "../safe-storage";
+
+const quotaError = () =>
+  new DOMException("quota exceeded", "QuotaExceededError");
+
+describe("createSafeStorage", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    jest.restoreAllMocks();
+  });
+
+  it("reads and writes through to localStorage", () => {
+    const storage = createSafeStorage();
+    storage.setItem("key", "value");
+    expect(storage.getItem("key")).toBe("value");
+    expect(localStorage.getItem("key")).toBe("value");
+    storage.removeItem("key");
+    expect(storage.getItem("key")).toBeNull();
+  });
+
+  describe("when a write exceeds the quota", () => {
+    it("keeps the value readable in memory instead of reloading", () => {
+      jest.spyOn(console, "error").mockImplementation(() => undefined);
+      jest.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+        throw quotaError();
+      });
+      const clearSpy = jest.spyOn(Storage.prototype, "clear");
+
+      const storage = createSafeStorage();
+      storage.setItem("big-key", "oversized value");
+
+      // The old behavior cleared localStorage and reloaded the page. When
+      // the oversized write recurs on every load that becomes an infinite
+      // reload loop, so neither may happen.
+      expect(clearSpy).not.toHaveBeenCalled();
+      expect(storage.getItem("big-key")).toBe("oversized value");
+    });
+
+    it("does not clobber other keys", () => {
+      jest.spyOn(console, "error").mockImplementation(() => undefined);
+      localStorage.setItem("other-key", "kept");
+      jest.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+        throw quotaError();
+      });
+
+      const storage = createSafeStorage();
+      storage.setItem("big-key", "oversized value");
+
+      jest.restoreAllMocks();
+      expect(localStorage.getItem("other-key")).toBe("kept");
+    });
+
+    it("prefers the newer in-memory value over a stale persisted one", () => {
+      jest.spyOn(console, "error").mockImplementation(() => undefined);
+      localStorage.setItem("key", "stale");
+      jest.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+        throw quotaError();
+      });
+
+      const storage = createSafeStorage();
+      storage.setItem("key", "fresh");
+
+      expect(storage.getItem("key")).toBe("fresh");
+    });
+
+    it("resumes persisting once a later write fits", () => {
+      jest.spyOn(console, "error").mockImplementation(() => undefined);
+      const storage = createSafeStorage();
+
+      const failing = jest
+        .spyOn(Storage.prototype, "setItem")
+        .mockImplementation(() => {
+          throw quotaError();
+        });
+      storage.setItem("key", "oversized");
+      failing.mockRestore();
+
+      storage.setItem("key", "small");
+      expect(localStorage.getItem("key")).toBe("small");
+      expect(storage.getItem("key")).toBe("small");
+    });
+  });
+
+  it("rethrows non-quota write errors", () => {
+    jest.spyOn(console, "error").mockImplementation(() => undefined);
+    jest.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new Error("security error");
+    });
+    const storage = createSafeStorage();
+    expect(() => storage.setItem("key", "value")).toThrow("security error");
+  });
+});

--- a/apps/web/lib/safe-storage.ts
+++ b/apps/web/lib/safe-storage.ts
@@ -1,7 +1,11 @@
-/* eslint-disable */
 /**
- * Safe localStorage wrapper that handles QuotaExceededError.
- * When quota is exceeded, it clears localStorage and reloads the page.
+ * Safe localStorage wrapper that tolerates QuotaExceededError.
+ *
+ * A write that exceeds the quota falls back to an in-memory map instead of
+ * clearing localStorage and reloading: when the oversized write happens on
+ * every page load, clear-and-reload turns into an infinite reload loop (the
+ * next load repeats the same write). With the fallback the session keeps
+ * working; only cross-reload persistence of the oversized key is lost.
  */
 
 export interface SafeStorage {
@@ -20,37 +24,30 @@ function isQuotaExceededError(error: unknown): boolean {
   );
 }
 
-function handleQuotaExceeded(operation: string): void {
-  console.error(
-    `QuotaExceededError during ${operation}. Clearing localStorage and reloading...`,
-  );
-
-  try {
-    localStorage.clear();
-  } catch (clearError) {
-    console.error("Failed to clear localStorage:", clearError);
-  }
-
-  setTimeout(() => {
-    window.location.reload();
-  }, 100);
-}
-
 /**
- * Creates a safe localStorage wrapper that handles QuotaExceededError
- * by clearing localStorage and reloading the page.
+ * Creates a safe localStorage wrapper that falls back to in-memory storage
+ * for writes that exceed the quota.
  */
 export function createSafeStorage(): SafeStorage {
   if (typeof window === "undefined") {
     return {
       getItem: () => null,
-      setItem: () => {},
-      removeItem: () => {},
+      setItem: () => undefined,
+      removeItem: () => undefined,
     };
   }
 
+  // Overflowed values live here for the rest of the session. Reads prefer
+  // this map so the store never observes a stale localStorage value after a
+  // fallback write.
+  const memoryFallback = new Map<string, string>();
+
   return {
     getItem: (name: string) => {
+      const fallback = memoryFallback.get(name);
+      if (fallback !== undefined) {
+        return fallback;
+      }
       try {
         return localStorage.getItem(name);
       } catch (error) {
@@ -62,9 +59,15 @@ export function createSafeStorage(): SafeStorage {
     setItem: (name: string, value: string) => {
       try {
         localStorage.setItem(name, value);
+        memoryFallback.delete(name);
       } catch (error) {
         if (isQuotaExceededError(error)) {
-          handleQuotaExceeded(`setItem for key "${name}"`);
+          console.error(
+            `QuotaExceededError writing ${value.length} chars to ` +
+              `localStorage key "${name}"; keeping the value in memory for ` +
+              `this session instead.`,
+          );
+          memoryFallback.set(name, value);
         } else {
           console.error(`Error writing to localStorage (${name}):`, error);
           throw error;
@@ -73,6 +76,7 @@ export function createSafeStorage(): SafeStorage {
     },
 
     removeItem: (name: string) => {
+      memoryFallback.delete(name);
       try {
         localStorage.removeItem(name);
       } catch (error) {

--- a/apps/web/stores/__tests__/learner.persist.test.ts
+++ b/apps/web/stores/__tests__/learner.persist.test.ts
@@ -1,0 +1,69 @@
+import type { QuestionStore } from "@/config/types";
+import { useLearnerStore } from "../learner";
+
+jest.mock("@/lib/talkToBackend", () => ({
+  getUser: jest.fn(),
+}));
+
+const fatQuestion = (): Partial<QuestionStore> => ({
+  id: 7,
+  type: "SINGLE_CORRECT",
+  totalPoints: 1,
+  question: '<p>Pick one</p><img src="data:image/png;base64,AAAA">',
+  choices: [
+    { choice: "A", isCorrect: true, points: 1 },
+    { choice: "B", isCorrect: false, points: 0 },
+  ],
+  translations: {
+    es: { translatedText: "elige", translatedChoices: [] },
+    fr: { translatedText: "choisis", translatedChoices: [] },
+  },
+  status: "edited",
+  learnerTextResponse: "draft text",
+  learnerChoices: ["1"],
+  selectedLanguage: "es",
+});
+
+const readPersistedLearnerState = (): {
+  questions: Record<string, unknown>[];
+} => {
+  for (let index = 0; index < localStorage.length; index++) {
+    const key = localStorage.key(index);
+    if (key && /^learner-(?!overview)/.test(key)) {
+      const parsed = JSON.parse(localStorage.getItem(key) ?? "{}") as {
+        state: { questions: Record<string, unknown>[] };
+      };
+      return parsed.state;
+    }
+  }
+  throw new Error("no persisted learner state found");
+};
+
+describe("useLearnerStore persistence", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  // Server content persisted per question once multiplied localStorage usage
+  // past the quota (question HTML can embed images), which trapped learners
+  // in a clear-and-reload loop. Only learner-authored draft state may be
+  // written; content is re-fetched and merged over it on every load.
+  it("persists learner drafts but not server question content", () => {
+    useLearnerStore
+      .getState()
+      .setQuestions([fatQuestion() as unknown as QuestionStore]);
+
+    const persisted = readPersistedLearnerState();
+    const [question] = persisted.questions;
+
+    expect(question.id).toBe(7);
+    expect(question.status).toBe("edited");
+    expect(question.learnerTextResponse).toBe("draft text");
+    expect(question.learnerChoices).toEqual(["1"]);
+    expect(question.selectedLanguage).toBe("es");
+
+    expect(question.question).toBeUndefined();
+    expect(question.translations).toBeUndefined();
+    expect(question.choices).toBeUndefined();
+  });
+});

--- a/apps/web/stores/learner.ts
+++ b/apps/web/stores/learner.ts
@@ -527,6 +527,28 @@ export const useLearnerOverviewStore = createWithEqualityFn<
   shallow,
 );
 
+/**
+ * Only learner-authored state may be persisted. Server content (question
+ * HTML, translations, choices) can carry embedded images and once multiplied
+ * across languages has overflowed the localStorage quota, which trapped
+ * learners in a clear-and-reload loop. Content is re-fetched on every load
+ * and merged over these drafts by setQuestions.
+ */
+const persistQuestionDraft = (question: QuestionStore) => ({
+  id: question.id,
+  status: question.status,
+  learnerResponse: question.learnerResponse,
+  learnerTextResponse: question.learnerTextResponse,
+  learnerUrlResponse: question.learnerUrlResponse,
+  learnerChoices: question.learnerChoices,
+  learnerAnswerChoice: question.learnerAnswerChoice,
+  learnerFileResponse: question.learnerFileResponse,
+  learnerPresentationResponse: question.learnerPresentationResponse,
+  presentationResponse: question.presentationResponse,
+  translationOn: question.translationOn,
+  selectedLanguage: question.selectedLanguage,
+});
+
 export const useLearnerStore = createWithEqualityFn<
   LearnerState & LearnerActions
 >()(
@@ -1005,7 +1027,7 @@ export const useLearnerStore = createWithEqualityFn<
       name: `learner-${ASSIGNMENT_ID}`,
       storage: createJSONStorage(() => createSafeStorage()),
       partialize: (state) => ({
-        questions: state.questions,
+        questions: state.questions.map(persistQuestionDraft),
         activeAttemptId: state.activeAttemptId,
         userPreferedLanguage: state.userPreferedLanguage,
       }),


### PR DESCRIPTION
The learner attempt response embedded every language's translation of every question, so question HTML with inline base64 images scaled by the language count — assignment 2532 shipped ~4MB attempts. Persisting those questions to localStorage overflowed the quota (Safari caps at ~5MB of UTF-16), and the quota handler cleared storage and reloaded, repeating the same oversized write on the next load: an infinite reload loop.

- getAssignmentAttempt fetches translations for the requested language family only (startsWith covers regional rows like zh-CN); the learner header refetches the attempt when the language is switched mid-attempt, which the all-languages map previously made unnecessary.
- The learner store persists draft answers only; server question content is re-fetched on every load and no longer written to localStorage.
- safe-storage falls back to in-memory storage on QuotaExceededError instead of clearing localStorage and reloading.
- Authors opening /learner/:id without authorMode=true get the 403 modal before any attempt is created; they previously fell through to the learner flow, created a stray attempt, and rendered a silently blank page.
