### PR TITLE
fix: fail fast on Redis outages instead of stalling requests

### DIFF
--- a/apps/api/src/api/assignment/attempt/attempt.service.ts
+++ b/apps/api/src/api/assignment/attempt/attempt.service.ts
@@ -15,7 +15,10 @@ import {
 import { WINSTON_MODULE_PROVIDER } from "nest-winston";
 import { Logger } from "winston";
 import IORedis from "ioredis";
-import { createRedisConnection } from "src/job-queue/redis.connection";
+import {
+  createCacheRedisConnection,
+  isRedisReady,
+} from "src/job-queue/redis.connection";
 import {
   Assignment,
   Question,
@@ -138,7 +141,7 @@ export class AttemptServiceV1 implements OnModuleDestroy {
 
   private createRedisClient(): IORedis | undefined {
     try {
-      const client = createRedisConnection();
+      const client = createCacheRedisConnection();
       client.on("error", (error) => {
         this.logger.warn(
           `attempt.redis.error { message: ${JSON.stringify(error.message)} }`,
@@ -1102,7 +1105,7 @@ export class AttemptServiceV1 implements OnModuleDestroy {
       // If the Redis connection is unavailable on this pod, treat as
       // not-in-flight (marker = "unavailable") rather than crashing the
       // learner request.
-      const languageInflight = this.redis
+      const languageInflight = isRedisReady(this.redis)
         ? await isLanguageInFlight(
             this.redis,
             assignment.id,

--- a/apps/api/src/api/assignment/v2/services/assignment.service.ts
+++ b/apps/api/src/api/assignment/v2/services/assignment.service.ts
@@ -19,7 +19,7 @@ import {
   TranslateQuestionJobPayload,
   TranslateVariantJobPayload,
 } from "src/job-queue/job-queue.types";
-import { createRedisConnection } from "src/job-queue/redis.connection";
+import { createCacheRedisConnection } from "src/job-queue/redis.connection";
 import { Logger } from "winston";
 import { getAllLanguageCodes } from "../../attempt/helper/languages";
 import { BaseAssignmentResponseDto } from "../../dto/base.assignment.response.dto";
@@ -92,12 +92,12 @@ export class AssignmentServiceV2 implements OnModuleDestroy {
     this.translationStateRedis = this.tryCreateTranslationStateRedis();
   }
 
-  // Wrap createRedisConnection() so missing REDIS_URL (or boot-time Redis
+  // Wrap createCacheRedisConnection() so missing REDIS_URL (or boot-time Redis
   // failure) degrades gracefully instead of bringing down DI. Status sites
   // become no-ops; the publish poll loop falls back to the hard timeout.
   private tryCreateTranslationStateRedis(): IORedis | undefined {
     try {
-      const client = createRedisConnection();
+      const client = createCacheRedisConnection();
       client.on("error", (error) => {
         this.logger.warn(
           `Translation status Redis error (status tracking disabled): ${error.message}`,

--- a/apps/api/src/api/assignment/v2/services/translation.service.ts
+++ b/apps/api/src/api/assignment/v2/services/translation.service.ts
@@ -15,7 +15,7 @@ import { LLM_RESOLVER_SERVICE } from "src/api/llm/llm.constants";
 import { AiFeatureComponent } from "src/api/ai-feature-flags/ai-feature-flags.constants";
 import { AiFeatureFlagsService } from "src/api/ai-feature-flags/ai-feature-flags.service";
 import { PrismaService } from "src/database/prisma.service";
-import { createRedisConnection } from "src/job-queue/redis.connection";
+import { createCacheRedisConnection } from "src/job-queue/redis.connection";
 import {
   decrementInflightLanguage,
   seedInflightLanguages,
@@ -242,12 +242,12 @@ export class TranslationService implements OnModuleDestroy {
     this.translationStateRedis = this.tryCreateTranslationStateRedis();
   }
 
-  // Wrap createRedisConnection() in try/catch so missing REDIS_URL (or any
+  // Wrap createCacheRedisConnection() in try/catch so missing REDIS_URL (or any
   // boot-time Redis failure) degrades gracefully instead of bringing down
   // DI. Status-tracking sites become no-ops; translation work still runs.
   private tryCreateTranslationStateRedis(): IORedis | undefined {
     try {
-      const client = createRedisConnection();
+      const client = createCacheRedisConnection();
       client.on("error", (error) => {
         this.logger.warn(
           `Translation status Redis error (status tracking disabled): ${error.message}`,

--- a/apps/api/src/api/attempt/services/attempt-access-cache.service.spec.ts
+++ b/apps/api/src/api/attempt/services/attempt-access-cache.service.spec.ts
@@ -1,12 +1,15 @@
 import { AttemptAccessCacheService } from "./attempt-access-cache.service";
 import { PrismaService } from "../../../database/prisma.service";
-import { createRedisConnection } from "../../../job-queue/redis.connection";
+import { createCacheRedisConnection } from "../../../job-queue/redis.connection";
 
 jest.mock("../../../job-queue/redis.connection", () => ({
-  createRedisConnection: jest.fn(),
+  createCacheRedisConnection: jest.fn(),
+  isRedisReady: jest.requireActual("../../../job-queue/redis.connection")
+    .isRedisReady,
 }));
 
 class FakeRedis {
+  public status = "ready";
   public readonly values = new Map<string, string>();
   public readonly ttls = new Map<string, number>();
   public readonly quit = jest.fn(async () => undefined);
@@ -95,7 +98,7 @@ describe("AttemptAccessCacheService", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     fakeRedis = new FakeRedis();
-    (createRedisConnection as jest.Mock).mockReturnValue(fakeRedis);
+    (createCacheRedisConnection as jest.Mock).mockReturnValue(fakeRedis);
     service = new AttemptAccessCacheService(mockPrisma, logger as never);
   });
 
@@ -289,6 +292,69 @@ describe("AttemptAccessCacheService", () => {
       expect(childLogger.warn).toHaveBeenCalledWith(
         expect.stringContaining("attempt-access-cache.invalidate.failed"),
       );
+    });
+  });
+
+  describe("when the Redis connection is not ready", () => {
+    beforeEach(() => {
+      fakeRedis.status = "reconnecting";
+      fakeRedis.get = jest.fn(async () => {
+        throw new Error("get must not be called while disconnected");
+      });
+      (mockPrisma.question.findMany as jest.Mock).mockResolvedValue([]);
+    });
+
+    it("skips the cache read entirely and builds from the database", async () => {
+      const result = await service.getQuestionDtosForAttemptAccess({
+        assignmentId: 44,
+        assignmentUpdatedAt: new Date("2026-04-26T01:00:00.000Z"),
+        assignmentVersionId: null,
+      });
+
+      expect(result).toEqual([]);
+      expect(fakeRedis.get).not.toHaveBeenCalled();
+      expect(mockPrisma.question.findMany).toHaveBeenCalled();
+    });
+
+    it("skips the cache write so nothing blocks on a dead connection", async () => {
+      (mockPrisma.question.findMany as jest.Mock).mockResolvedValue([
+        {
+          id: 101,
+          question: "Database question",
+          type: "TEXT",
+          assignmentId: 44,
+          totalPoints: 10,
+          maxWords: null,
+          maxCharacters: null,
+          choices: [],
+          scoring: { type: "CRITERIA_BASED", rubrics: [] },
+          answer: false,
+          gradingContextQuestionIds: [],
+          responseType: "TEXT",
+          isDeleted: false,
+          randomizedChoices: false,
+          videoPresentationConfig: null,
+          liveRecordingConfig: null,
+        },
+      ]);
+
+      const result = await service.getQuestionDtosForAttemptAccess({
+        assignmentId: 44,
+        assignmentUpdatedAt: new Date("2026-04-26T01:00:00.000Z"),
+        assignmentVersionId: null,
+      });
+
+      expect(result).toHaveLength(1);
+      expect(fakeRedis.values.size).toBe(0);
+    });
+
+    it("skips invalidation scans instead of hanging on them", async () => {
+      const scanSpy = jest.spyOn(fakeRedis, "scan");
+
+      await expect(
+        service.invalidateForAssignment(44),
+      ).resolves.toBeUndefined();
+      expect(scanSpy).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/api/src/api/attempt/services/attempt-access-cache.service.ts
+++ b/apps/api/src/api/attempt/services/attempt-access-cache.service.ts
@@ -9,7 +9,10 @@ import {
   VideoPresentationConfig,
 } from "src/api/assignment/dto/update.questions.request.dto";
 import { PrismaService } from "src/database/prisma.service";
-import { createRedisConnection } from "src/job-queue/redis.connection";
+import {
+  createCacheRedisConnection,
+  isRedisReady,
+} from "src/job-queue/redis.connection";
 import { EnhancedAttemptQuestionDto } from "../common/utils/attempt-questions-mapper.util";
 import { ScoringType } from "src/api/assignment/question/dto/create.update.question.request.dto";
 
@@ -107,7 +110,7 @@ export class AttemptAccessCacheService implements OnModuleDestroy {
   }
 
   async invalidateForAssignment(assignmentId: number): Promise<void> {
-    if (!this.redis) {
+    if (!isRedisReady(this.redis)) {
       this.logger.debug(
         `attempt-access-cache.invalidate.skip { assignmentId: ${assignmentId}, reason: "no-redis" }`,
       );
@@ -158,7 +161,7 @@ export class AttemptAccessCacheService implements OnModuleDestroy {
 
   private createRedisClient(): IORedis | undefined {
     try {
-      const client = createRedisConnection();
+      const client = createCacheRedisConnection();
       client.on("error", (error) => {
         this.logger.warn(
           `AttemptAccessCache Redis error (falling back to PostgreSQL): ${error.message}`,
@@ -188,7 +191,7 @@ export class AttemptAccessCacheService implements OnModuleDestroy {
   private async redisGet(
     cacheKey: string,
   ): Promise<EnhancedAttemptQuestionDto[] | null> {
-    if (!this.redis) {
+    if (!isRedisReady(this.redis)) {
       return null;
     }
 
@@ -208,7 +211,7 @@ export class AttemptAccessCacheService implements OnModuleDestroy {
     cacheKey: string,
     value: EnhancedAttemptQuestionDto[],
   ): Promise<void> {
-    if (!this.redis) {
+    if (!isRedisReady(this.redis)) {
       return;
     }
 

--- a/apps/api/src/api/llm/features/grading/services/grading-cache.service.spec.ts
+++ b/apps/api/src/api/llm/features/grading/services/grading-cache.service.spec.ts
@@ -3,11 +3,13 @@ import { Test, TestingModule } from "@nestjs/testing";
 import { GradingCacheService } from "./grading-cache.service";
 import { PrismaService } from "src/database/prisma.service";
 import { ICachedGradingResult } from "../interfaces/grading-cache.interface";
-import { createRedisConnection } from "src/job-queue/redis.connection";
+import { createCacheRedisConnection } from "src/job-queue/redis.connection";
 import { Prisma } from "@prisma/client";
 
 jest.mock("src/job-queue/redis.connection", () => ({
-  createRedisConnection: jest.fn(),
+  createCacheRedisConnection: jest.fn(),
+  isRedisReady: jest.requireActual("src/job-queue/redis.connection")
+    .isRedisReady,
 }));
 
 const makeResult = (
@@ -27,6 +29,7 @@ const makeResult = (
 });
 
 class FakeRedis {
+  public status = "ready";
   public readonly data = new Map<string, string>();
   public readonly ttls = new Map<string, number>();
 
@@ -101,7 +104,7 @@ describe("GradingCacheService — Redis L1 cache (Change 8)", () => {
   beforeEach(async () => {
     jest.clearAllMocks();
     fakeRedis = new FakeRedis();
-    (createRedisConnection as jest.Mock).mockReturnValue(fakeRedis);
+    (createCacheRedisConnection as jest.Mock).mockReturnValue(fakeRedis);
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -314,8 +317,8 @@ describe("GradingCacheService — Redis L1 cache (Change 8)", () => {
   // ─── Graceful Redis fallback ───────────────────────────────────────────────
 
   describe("Redis unavailable fallback", () => {
-    it("operates in PostgreSQL-only mode when createRedisConnection throws", async () => {
-      (createRedisConnection as jest.Mock).mockImplementation(() => {
+    it("operates in PostgreSQL-only mode when createCacheRedisConnection throws", async () => {
+      (createCacheRedisConnection as jest.Mock).mockImplementation(() => {
         throw new Error("Cannot connect to Redis");
       });
 

--- a/apps/api/src/api/llm/features/grading/services/grading-cache.service.ts
+++ b/apps/api/src/api/llm/features/grading/services/grading-cache.service.ts
@@ -8,7 +8,10 @@ import {
 } from "../interfaces/grading-cache.interface";
 import { PrismaService } from "src/database/prisma.service";
 import { Prisma } from "@prisma/client";
-import { createRedisConnection } from "src/job-queue/redis.connection";
+import {
+  createCacheRedisConnection,
+  isRedisReady,
+} from "src/job-queue/redis.connection";
 
 const REDIS_TTL_SECONDS = 7 * 24 * 60 * 60; // 7 days
 
@@ -52,7 +55,7 @@ export class GradingCacheService
 
   private createRedisClient(): IORedis | undefined {
     try {
-      const client = createRedisConnection();
+      const client = createCacheRedisConnection();
       client.on("error", (error) => {
         this.logger.warn(
           `GradingCache Redis error (falling back to PostgreSQL): ${error.message}`,
@@ -74,7 +77,7 @@ export class GradingCacheService
   private async redisGet(
     cacheKey: string,
   ): Promise<ICachedGradingResult | null> {
-    if (!this.redis) return null;
+    if (!isRedisReady(this.redis)) return null;
     try {
       const raw = await this.redis.get(this.redisKey(cacheKey));
       if (!raw) return null;
@@ -85,7 +88,7 @@ export class GradingCacheService
   }
 
   private async redisSet(result: ICachedGradingResult): Promise<void> {
-    if (!this.redis) return;
+    if (!isRedisReady(this.redis)) return;
     try {
       await this.redis.set(
         this.redisKey(result.cacheKey),
@@ -99,7 +102,7 @@ export class GradingCacheService
   }
 
   private async redisDel(cacheKey: string): Promise<void> {
-    if (!this.redis) return;
+    if (!isRedisReady(this.redis)) return;
     try {
       await this.redis.del(this.redisKey(cacheKey));
     } catch {
@@ -114,7 +117,7 @@ export class GradingCacheService
    * fall back to a full-prefix scan limited to 1000 keys per call.
    */
   private async redisInvalidateQuestion(questionId: number): Promise<void> {
-    if (!this.redis) return;
+    if (!isRedisReady(this.redis)) return;
     try {
       const pattern = `mark:grading-cache:*`;
       let cursor = "0";

--- a/apps/api/src/job-queue/redis.connection.spec.ts
+++ b/apps/api/src/job-queue/redis.connection.spec.ts
@@ -1,0 +1,74 @@
+import IORedis from "ioredis";
+import {
+  createCacheRedisConnection,
+  createRedisConnection,
+  isRedisReady,
+} from "./redis.connection";
+
+jest.mock("ioredis", () => {
+  return jest.fn().mockImplementation((url: string, options: unknown) => ({
+    url,
+    options,
+    status: "wait",
+  }));
+});
+
+const MockedIORedis = IORedis as unknown as jest.Mock;
+
+describe("redis.connection", () => {
+  const originalRedisUrl = process.env.REDIS_URL;
+
+  beforeEach(() => {
+    process.env.REDIS_URL = "redis://localhost:6379";
+    MockedIORedis.mockClear();
+  });
+
+  afterAll(() => {
+    process.env.REDIS_URL = originalRedisUrl;
+  });
+
+  describe("createRedisConnection", () => {
+    it("keeps the BullMQ-required retry behavior (commands wait for reconnect)", () => {
+      createRedisConnection();
+      const options = MockedIORedis.mock.calls[0][1];
+      expect(options.maxRetriesPerRequest).toBeNull();
+    });
+  });
+
+  describe("createCacheRedisConnection", () => {
+    it("fails fast instead of queueing commands while disconnected", () => {
+      createCacheRedisConnection();
+      const options = MockedIORedis.mock.calls[0][1];
+      expect(options.enableOfflineQueue).toBe(false);
+      expect(options.maxRetriesPerRequest).toBe(1);
+    });
+
+    it("bounds connect and command latency", () => {
+      createCacheRedisConnection();
+      const options = MockedIORedis.mock.calls[0][1];
+      expect(options.connectTimeout).toBe(2000);
+      expect(options.commandTimeout).toBe(500);
+    });
+
+    it("throws when REDIS_URL is unset", () => {
+      delete process.env.REDIS_URL;
+      expect(() => createCacheRedisConnection()).toThrow(/REDIS_URL/);
+    });
+  });
+
+  describe("isRedisReady", () => {
+    it("is false for an absent client", () => {
+      expect(isRedisReady(undefined)).toBe(false);
+    });
+
+    it("is false while connecting or reconnecting", () => {
+      expect(isRedisReady({ status: "connecting" } as IORedis)).toBe(false);
+      expect(isRedisReady({ status: "reconnecting" } as IORedis)).toBe(false);
+      expect(isRedisReady({ status: "end" } as IORedis)).toBe(false);
+    });
+
+    it("is true only for a ready connection", () => {
+      expect(isRedisReady({ status: "ready" } as IORedis)).toBe(true);
+    });
+  });
+});

--- a/apps/api/src/job-queue/redis.connection.ts
+++ b/apps/api/src/job-queue/redis.connection.ts
@@ -9,9 +9,30 @@ export function getRedisUrl(): string {
   return redisUrl;
 }
 
+// BullMQ requires maxRetriesPerRequest: null — its blocking connections queue
+// commands until Redis returns. Only queue producers/workers may use this;
+// request-path code must use createCacheRedisConnection, or a Redis outage
+// stalls every HTTP request on the offline queue instead of failing over.
 export function createRedisConnection(): IORedis {
   return new IORedis(getRedisUrl(), {
     maxRetriesPerRequest: null,
     enableReadyCheck: false,
   });
+}
+
+// Request-path connection: commands reject immediately while disconnected
+// (no offline queue) and are latency-bounded while connected, so callers hit
+// their PostgreSQL fallbacks in milliseconds instead of hanging until the
+// upstream 30s proxy timeout.
+export function createCacheRedisConnection(): IORedis {
+  return new IORedis(getRedisUrl(), {
+    maxRetriesPerRequest: 1,
+    enableOfflineQueue: false,
+    connectTimeout: 2000,
+    commandTimeout: 500,
+  });
+}
+
+export function isRedisReady(client: IORedis | undefined): client is IORedis {
+  return client?.status === "ready";
 }


### PR DESCRIPTION
Request-path cache clients shared the BullMQ connection factory, whose maxRetriesPerRequest: null queues every command until Redis returns. When Redis went down, cache reads hung indefinitely instead of rejecting, so the PostgreSQL fallbacks never ran and learner requests stalled until the upstream 30s proxy timeout (surfaced as bogus 404 dialogs during the 2026-08-26 outage).

Split the factories: BullMQ keeps its required retry-forever connection; cache clients (attempt access, grading cache, translation state in both v2 services and v1 attempt service) now use a fail-fast connection (enableOfflineQueue: false, maxRetriesPerRequest: 1, connectTimeout 2s, commandTimeout 500ms) plus an isRedisReady guard on hot read paths, so a Redis outage degrades to direct-PostgreSQL latency in milliseconds.