### PR TITLE
fix(learner): stop post-submit bounce for non-English learners and 40…

### DIFF
--- a/apps/api/src/api/attempt/services/grading-progress.service.spec.ts
+++ b/apps/api/src/api/attempt/services/grading-progress.service.spec.ts
@@ -129,3 +129,49 @@ describe("GradingProgressService.markComplete", () => {
     expect(mockPrisma.gradingProgress.findUnique).not.toHaveBeenCalled();
   });
 });
+
+describe("GradingProgressService.markFailed", () => {
+  let service: GradingProgressService;
+
+  const mockPrisma = {
+    gradingProgress: {
+      update: jest.fn(),
+      updateMany: jest.fn(),
+      findUnique: jest.fn(),
+      upsert: jest.fn(),
+    },
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        GradingProgressService,
+        { provide: PrismaService, useValue: mockPrisma },
+        {
+          provide: AdminEmailService,
+          useValue: { sendGradingCompletionEmail: jest.fn() },
+        },
+      ],
+    }).compile();
+
+    service = module.get<GradingProgressService>(GradingProgressService);
+    jest.clearAllMocks();
+    mockPrisma.gradingProgress.updateMany.mockResolvedValue({ count: 0 });
+  });
+
+  it("never downgrades a COMPLETED row to FAILED", async () => {
+    // A duplicate submit throws ConflictException after the first submit has
+    // already graded the attempt; the catch path calls markFailed and used to
+    // overwrite the COMPLETED row, showing "Grading Failed" on a graded attempt.
+    await service.markFailed(77, "Attempt 77 has already been submitted.");
+
+    expect(mockPrisma.gradingProgress.update).not.toHaveBeenCalled();
+    expect(mockPrisma.gradingProgress.updateMany).toHaveBeenCalledWith({
+      where: { attemptId: 77, status: { not: GradingStatus.COMPLETED } },
+      data: expect.objectContaining({
+        status: GradingStatus.FAILED,
+        error: "Attempt 77 has already been submitted.",
+      }),
+    });
+  });
+});

--- a/apps/api/src/api/attempt/services/grading-progress.service.ts
+++ b/apps/api/src/api/attempt/services/grading-progress.service.ts
@@ -323,14 +323,22 @@ export class GradingProgressService {
   async markFailed(attemptId: number, error: string): Promise<void> {
     try {
       if (attemptId > 0) {
-        await this.prisma.gradingProgress.update({
-          where: { attemptId },
+        // Never downgrade a finished grade: a duplicate submit (409) reaches
+        // this path after the first submit already completed, and overwriting
+        // the row showed "Grading Failed" on a graded attempt.
+        const { count } = await this.prisma.gradingProgress.updateMany({
+          where: { attemptId, status: { not: GradingStatus.COMPLETED } },
           data: {
             status: GradingStatus.FAILED,
             error,
             completedAt: new Date(),
           },
         });
+        if (count === 0) {
+          this.logger.warn(
+            `markFailed: attempt ${attemptId} has no non-completed progress row; left as-is (reason: ${error})`,
+          );
+        }
       }
     } catch (error_) {
       this.logger.error(

--- a/apps/api/src/api/llm/features/grading/services/grading-cache.service.spec.ts
+++ b/apps/api/src/api/llm/features/grading/services/grading-cache.service.spec.ts
@@ -231,6 +231,37 @@ describe("GradingCacheService — Redis L1 cache (Change 8)", () => {
       expect(fakeRedis.data.has("mark:grading-cache:canonical-new")).toBe(true);
     });
 
+    it("scrubs NUL bytes before writing so Postgres does not reject the row", async () => {
+      // Prod: a learner response containing U+0000 made gradingCache.create
+      // throw 22P05 and failed the whole attempt.
+      const result = makeResult({
+        cacheKey: "canonical-nul",
+        overallFeedback: "fine\u0000work",
+        criteria: [
+          { name: "c1", feedback: "met\u0000" },
+        ] as unknown as ICachedGradingResult["criteria"],
+        metadata: {
+          learnerResponse: "Project Brief\u0000 created",
+        } as unknown as ICachedGradingResult["metadata"],
+      });
+      mockPrisma.gradingCache.create.mockResolvedValue(undefined);
+
+      await service.cacheGradingIfAbsent(result);
+
+      const written = mockPrisma.gradingCache.create.mock.calls[0][0].data;
+      expect(JSON.stringify(written)).not.toContain("\\u0000");
+      expect(written.overallFeedback).toBe("finework");
+    });
+
+    it("returns the graded result instead of failing grading when the cache write fails", async () => {
+      const result = makeResult({ cacheKey: "canonical-db-down" });
+      mockPrisma.gradingCache.create.mockRejectedValue(
+        new Error("connection refused"),
+      );
+
+      await expect(service.cacheGradingIfAbsent(result)).resolves.toBe(result);
+    });
+
     it("returns the existing result when another worker wins insertion", async () => {
       const attempted = makeResult({
         cacheKey: "canonical-race",

--- a/apps/api/src/api/llm/features/grading/services/grading-cache.service.ts
+++ b/apps/api/src/api/llm/features/grading/services/grading-cache.service.ts
@@ -9,6 +9,7 @@ import {
 import { PrismaService } from "src/database/prisma.service";
 import { Prisma } from "@prisma/client";
 import { createRedisConnection } from "src/job-queue/redis.connection";
+import { sanitizeUnicodeForJson } from "src/helpers/sanitize-unicode";
 
 const REDIS_TTL_SECONDS = 7 * 24 * 60 * 60; // 7 days
 
@@ -322,6 +323,18 @@ export class GradingCacheService
     }
 
     try {
+      // Postgres rejects NUL (U+0000) and lone surrogates in TEXT/jsonb; a
+      // learner response carrying one used to fail the whole attempt here.
+      const { value: clean, replaced } = sanitizeUnicodeForJson({
+        criteria: result.criteria,
+        overallFeedback: result.overallFeedback,
+        metadata: result.metadata,
+      });
+      if (replaced > 0) {
+        this.logger.warn(
+          `Scrubbed ${replaced} unsafe character(s) from grading cache entry for question ${result.questionId}`,
+        );
+      }
       await this.prisma.gradingCache.create({
         data: {
           cacheKey: result.cacheKey,
@@ -330,11 +343,11 @@ export class GradingCacheService
           answerHash: result.answerHash,
           totalScore: result.totalScore,
           maxScore: result.maxScore,
-          criteria: result.criteria as Prisma.InputJsonValue,
-          overallFeedback: result.overallFeedback,
+          criteria: clean.criteria as Prisma.InputJsonValue,
+          overallFeedback: clean.overallFeedback,
           cachedAt: result.cachedAt,
           hitCount: result.hitCount,
-          metadata: result.metadata as Prisma.InputJsonValue,
+          metadata: clean.metadata as Prisma.InputJsonValue,
         },
       });
       await this.redisSet(result);
@@ -347,7 +360,13 @@ export class GradingCacheService
         const canonical = await this.getCachedGrading(result.cacheKey);
         if (canonical) return canonical;
       }
-      throw error;
+      // The cache is an optimisation: a failed write must not fail the grade.
+      this.logger.error(
+        `Grading cache write failed for question ${result.questionId}; returning uncached result: ${
+          error instanceof Error ? error.message : "Unknown error"
+        }`,
+      );
+      return result;
     }
   }
 

--- a/apps/web/app/learner/(components)/Header.tsx
+++ b/apps/web/app/learner/(components)/Header.tsx
@@ -45,7 +45,10 @@ import Button from "../../../components/Button";
 import GradingProgressModal, {
   type ProgressState,
 } from "./GradingProgressModal";
-import { isGradingStreamLostError } from "@/lib/learner";
+import {
+  isAttemptAlreadySubmittedError,
+  isGradingStreamLostError,
+} from "@/lib/learner";
 
 const TRANSLATION_PREVIEW_DISABLED_TOOLTIP =
   "Translations are only available after publishing this assignment. Publish to preview translated content.";
@@ -442,6 +445,14 @@ function LearnerHeader() {
     } catch (error) {
       setSubmitting(false);
       submitInFlightRef.current = false;
+
+      if (isAttemptAlreadySubmittedError(error)) {
+        // The attempt was already graded (this was a retried PATCH after a
+        // timeout or lost stream). Show those results instead of an error.
+        setShowGradingModal(false);
+        router.push(`/learner/${assignmentId}/successPage/${error.attemptId}`);
+        return;
+      }
 
       if (isGradingStreamLostError(error)) {
         // The submission itself succeeded — only our view of it died. Leave

--- a/apps/web/app/learner/(components)/__tests__/Header.test.tsx
+++ b/apps/web/app/learner/(components)/__tests__/Header.test.tsx
@@ -17,6 +17,7 @@ import LearnerHeader from "../Header";
 const mockUseParams = jest.fn();
 const mockPush = jest.fn();
 const mockReplace = jest.fn();
+const mockSearchParams = jest.fn(() => new URLSearchParams());
 jest.mock("next/navigation", () => ({
   useParams: () => mockUseParams(),
   usePathname: () => "/learner/3428/questions",
@@ -25,7 +26,7 @@ jest.mock("next/navigation", () => ({
     replace: mockReplace,
     prefetch: jest.fn(),
   }),
-  useSearchParams: () => ({ get: () => null, toString: () => "" }),
+  useSearchParams: () => mockSearchParams(),
 }));
 
 // --- backend: submitAssignment is the call whose first arg must be the URL id ---
@@ -136,6 +137,7 @@ describe("LearnerHeader submit path", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     localStorage.clear();
+    mockSearchParams.mockImplementation(() => new URLSearchParams());
   });
 
   it("submits with the assignmentId from the URL, not the (null) store value", async () => {
@@ -258,5 +260,81 @@ describe("LearnerHeader submit path", () => {
     } finally {
       jest.useRealTimers();
     }
+  });
+});
+
+describe("LearnerHeader post-submit language reset", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    localStorage.clear();
+  });
+
+  it("does not re-navigate the questions route after submit when the UI language is not English", async () => {
+    // Prod signature (Sep 2026): for learners on ?uiLang=<non-en>, the reset
+    // after submit turned the store language into "en", the uiLang URL sync
+    // dropped the param with router.replace(<questions path>), and the server
+    // layout for that route created a fresh attempt — bouncing the learner
+    // off their results. English learners have no uiLang param, so nothing
+    // fired for them.
+    mockUseParams.mockReturnValue({ assignmentId: "3428" });
+    mockSearchParams.mockImplementation(() => new URLSearchParams("uiLang=it"));
+    seedLearnerState(null);
+    useLearnerStore.setState({ userPreferedLanguage: "it" });
+    mockSubmitAssignment.mockResolvedValue({
+      id: 999,
+      grade: 0.9,
+      totalPointsEarned: 9,
+      totalPossiblePoints: 10,
+      passed: true,
+      showSubmissionFeedback: true,
+      feedbacksForQuestions: [],
+    });
+
+    jest.useFakeTimers();
+    try {
+      render(<LearnerHeader />);
+      await act(async () => {
+        window.dispatchEvent(new Event("triggerAssignmentSubmission"));
+      });
+      await act(async () => {
+        jest.advanceTimersByTime(1500);
+      });
+
+      expect(mockPush).toHaveBeenCalledWith("/learner/3428/successPage/999");
+      const questionsRouteNavigations = mockReplace.mock.calls.filter(([url]) =>
+        String(url).includes("/questions"),
+      );
+      expect(questionsRouteNavigations).toEqual([]);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+});
+
+describe("LearnerHeader duplicate-submit conflict", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    localStorage.clear();
+    mockSearchParams.mockImplementation(() => new URLSearchParams());
+  });
+
+  it("sends the learner to their results when the API reports the attempt was already submitted", async () => {
+    // A retried PATCH (proxy timeout, lost stream) lands on an attempt that is
+    // already graded. The learner must land on those results, not be told
+    // grading is down and that nothing was submitted.
+    const { AttemptAlreadySubmittedError } =
+      jest.requireActual("@/lib/learner");
+    mockUseParams.mockReturnValue({ assignmentId: "3428" });
+    seedLearnerState(null);
+    mockSubmitAssignment.mockRejectedValue(
+      new AttemptAlreadySubmittedError(999),
+    );
+
+    render(<LearnerHeader />);
+    await triggerSubmit();
+
+    expect(mockPush).toHaveBeenCalledWith("/learner/3428/successPage/999");
+    expect(toast.error).not.toHaveBeenCalled();
+    expect(screen.queryByTestId("grading-modal")).not.toBeInTheDocument();
   });
 });

--- a/apps/web/lib/__tests__/learner.submit-conflict.test.ts
+++ b/apps/web/lib/__tests__/learner.submit-conflict.test.ts
@@ -1,0 +1,70 @@
+jest.mock("../api-client", () => {
+  class MockAPIError extends Error {
+    constructor(
+      message: string,
+      public status: number,
+      public statusText: string,
+      public body?: unknown,
+    ) {
+      super(message);
+      this.name = "APIError";
+    }
+  }
+  return {
+    apiClient: { patch: jest.fn(), post: jest.fn(), get: jest.fn() },
+    APIError: MockAPIError,
+  };
+});
+
+import { apiClient, APIError } from "../api-client";
+import {
+  isAiTemporarilyDisabled,
+  isAttemptAlreadySubmittedError,
+  submitAssignment,
+} from "../learner";
+
+const conflict = (body: unknown) =>
+  new APIError("Conflict", 409, "Conflict", body);
+
+const alreadySubmittedBody = {
+  statusCode: 409,
+  message: "Attempt 999 has already been submitted.",
+  error: "Conflict",
+};
+
+describe("submit 409 handling", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("does not treat a plain 409 (duplicate submit) as the AI kill-switch", () => {
+    // Prod, Aug–Sep 2026: every "grading temporarily out of service" report
+    // was a duplicate PATCH on an attempt that was already graded.
+    expect(isAiTemporarilyDisabled(conflict(alreadySubmittedBody))).toBe(false);
+  });
+
+  it("still recognises the kill-switch by its body code", () => {
+    expect(
+      isAiTemporarilyDisabled(
+        conflict({
+          statusCode: 409,
+          code: "AI_TEMPORARILY_DISABLED",
+          message: "AI grading is temporarily unavailable.",
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("rejects with an already-submitted error carrying the attempt id", async () => {
+    (apiClient.patch as jest.Mock).mockRejectedValue(
+      conflict(alreadySubmittedBody),
+    );
+
+    const err: unknown = await submitAssignment(3428, 999, []).catch(
+      (error: unknown) => error,
+    );
+
+    expect(isAttemptAlreadySubmittedError(err)).toBe(true);
+    expect((err as { attemptId?: number }).attemptId).toBe(999);
+  });
+});

--- a/apps/web/lib/learner.ts
+++ b/apps/web/lib/learner.ts
@@ -113,15 +113,36 @@ function getErrorCode(err: unknown): string | undefined {
 }
 
 /**
- * Recognises the AI kill-switch response. Matches on the body `code` first (the
- * stable signal) and falls back to HTTP 409 — the status the backend now uses
- * because gateways/meshes mangle 503s into generic 500s. Accepts `unknown` and
- * duck-types so it survives the Next server-module-identity `instanceof` gotcha.
+ * Recognises the AI kill-switch response by its body `code`. Accepts `unknown`
+ * and duck-types so it survives the Next server-module-identity `instanceof`
+ * gotcha.
  */
 export function isAiTemporarilyDisabled(err: unknown): boolean {
+  // Body code only. The backend uses 409 for the kill-switch, but 409 is also
+  // what a duplicate submit gets ("already been submitted"); matching on the
+  // status alone told graded learners that grading was down.
+  return getErrorCode(err) === "AI_TEMPORARILY_DISABLED";
+}
+
+/**
+ * The API rejected a submit because the attempt is already submitted (a
+ * retried PATCH after a proxy timeout or a lost grading stream). The attempt
+ * is graded; the caller should show its results rather than an error.
+ */
+export class AttemptAlreadySubmittedError extends Error {
+  constructor(public readonly attemptId: number) {
+    super(`Attempt ${attemptId} has already been submitted.`);
+    this.name = "AttemptAlreadySubmittedError";
+  }
+}
+
+/** Duck-typed on `name` so it survives the Next server-module-identity gotcha. */
+export function isAttemptAlreadySubmittedError(
+  err: unknown,
+): err is AttemptAlreadySubmittedError {
   return (
-    getErrorCode(err) === "AI_TEMPORARILY_DISABLED" ||
-    getErrorStatus(err) === 409
+    (err as { name?: string } | undefined)?.name ===
+    "AttemptAlreadySubmittedError"
   );
 }
 
@@ -534,9 +555,17 @@ export async function submitAssignment(
     } catch (apiError) {
       let errorMessage = "Submission failed";
 
-      // Check the kill-switch first and duck-typed (not gated on
-      // `instanceof APIError`, which is unreliable across Next's module
-      // boundary) so the out-of-service message always wins for a 409.
+      // A 409 that is not the kill-switch is the API's "already submitted"
+      // conflict: the attempt is graded. Hand it to the caller to navigate.
+      if (
+        getErrorStatus(apiError) === 409 &&
+        !isAiTemporarilyDisabled(apiError)
+      ) {
+        throw new AttemptAlreadySubmittedError(attemptId);
+      }
+
+      // Duck-typed (not gated on `instanceof APIError`, which is unreliable
+      // across Next's module boundary).
       if (isAiTemporarilyDisabled(apiError)) {
         // AI grading kill-switch engaged: the attempt was not submitted and
         // no grading was performed, so the learner's progress is preserved.

--- a/apps/web/stores/__tests__/learner.language.test.ts
+++ b/apps/web/stores/__tests__/learner.language.test.ts
@@ -1,0 +1,30 @@
+import { useLearnerStore } from "../learner";
+
+jest.mock("@/lib/talkToBackend", () => ({
+  getUser: jest.fn(),
+}));
+
+describe("useLearnerStore.setUserPreferedLanguage", () => {
+  beforeEach(() => {
+    useLearnerStore.setState({ userPreferedLanguage: null });
+  });
+
+  it("normalises a regional tag to the supported base language", () => {
+    useLearnerStore.getState().setUserPreferedLanguage("it-IT");
+    expect(useLearnerStore.getState().userPreferedLanguage).toBe("it");
+  });
+
+  it("falls back to English for an unsupported language", () => {
+    useLearnerStore.getState().setUserPreferedLanguage("xx");
+    expect(useLearnerStore.getState().userPreferedLanguage).toBe("en");
+  });
+
+  it("clears the preference when given null instead of coercing it to English", () => {
+    // The post-submit reset passes null. Turning that into "en" makes the
+    // Header's uiLang URL sync see "en" vs the URL's uiLang=it and re-navigate
+    // the questions route, whose server layout mints a fresh attempt.
+    useLearnerStore.getState().setUserPreferedLanguage("it");
+    useLearnerStore.getState().setUserPreferedLanguage(null);
+    expect(useLearnerStore.getState().userPreferedLanguage).toBeNull();
+  });
+});

--- a/apps/web/stores/learner.ts
+++ b/apps/web/stores/learner.ts
@@ -341,7 +341,7 @@ export type LearnerState = {
   totalPointsPossible: number;
   translationOn: boolean;
   globalLanguage: string;
-  userPreferedLanguage: string;
+  userPreferedLanguage: string | null;
   isUploadingFiles: boolean;
 };
 
@@ -436,7 +436,7 @@ export type LearnerActions = {
     translatedChoices: string[],
   ) => void;
   setGlobalLanguage: (language: string) => void;
-  setUserPreferedLanguage: (language: string) => void;
+  setUserPreferedLanguage: (language: string | null) => void;
   getUserPreferedLanguageFromLTI: () => Promise<string>;
   clearLearnerAnswers: () => void;
   setIsUploadingFiles: (isUploading: boolean) => void;
@@ -765,6 +765,13 @@ export const useLearnerStore = createWithEqualityFn<
         },
         setGlobalLanguage: (language) => set({ globalLanguage: language }),
         setUserPreferedLanguage: (languageCode) => {
+          // A null reset (post-submit) must stay null. Intl.Locale(null)
+          // throws, and the catch below used to turn that into "en" — which
+          // the Header's uiLang URL sync then treated as a language change.
+          if (languageCode === null || languageCode === undefined) {
+            set({ userPreferedLanguage: null });
+            return;
+          }
           try {
             const parsedLocale = new Intl.Locale(languageCode);
             const baseLang = parsedLocale.language;


### PR DESCRIPTION
The post-submit reset called setUserPreferedLanguage(null); Intl.Locale(null) threw and the catch stored "en". The Header's uiLang URL sync then saw "en" against ?uiLang=<lang>, dropped the param and router.replace'd the still-current questions route, whose server layout creates a new attempt whenever none is in progress. Every non-English learner (80-95% by language, 0% for en) lost the results page and was left on a fresh unsubmitted attempt; about a third redid a quiz they had passed. Null now stays null.

A retried submit PATCH gets 409 "already been submitted". The web kill-switch check matched any 409, so learners were told grading was down and nothing was submitted, and markFailed overwrote the COMPLETED GradingProgress row with FAILED. The kill-switch now matches its body code only, submitAssignment surfaces AttemptAlreadySubmittedError and the Header navigates to that attempt's results, and markFailed never downgrades a COMPLETED row.

Grading cache inserts scrub NUL and lone surrogates and a failed insert returns the graded result instead of failing the attempt.