### PR TITLE
Fix CM quiz author sessions and shared-link recovery

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -3,6 +3,8 @@
 ###############################################################################
 
 # ────── Front-end ──────
+AWB_URL=               # Recovery target; set https://author.staging.skills.network in staging
+AWB_MARK_PROVIDER_ID=  # Optional AWB provider ID for this Mark instance; defaults to AWB public Mark provider
 PORT=                  # e.g. 3010
 
 # ────── Back-end API ──────

--- a/apps/api-gateway/src/api/api.service.ts
+++ b/apps/api-gateway/src/api/api.service.ts
@@ -129,6 +129,7 @@ export class ApiService {
         // overrides the client's `cookie` header in normalizeOutgoingHeaders.
         const dedupedCookieHeader = dedupeAuthenticationCookieHeader(
           request.headers?.cookie,
+          request.headers,
         );
         if (dedupedCookieHeader !== undefined) {
           extraHeaders.cookie = dedupedCookieHeader;

--- a/apps/api-gateway/src/auth/jwt/cookie-based/author.session.spec.ts
+++ b/apps/api-gateway/src/auth/jwt/cookie-based/author.session.spec.ts
@@ -1,0 +1,200 @@
+import { Request } from "express";
+import { sign } from "jsonwebtoken";
+import { JwtConfigService } from "../jwt.config.service";
+import { JwtCookieStrategy } from "./jwt.cookie.strategy";
+import {
+  dedupeAuthenticationCookieHeader,
+  selectAuthenticationCookie,
+} from "./jwt.cookie.extractor";
+
+const secret = "local-session-test-secret";
+const token = (claims: Record<string, unknown> = {}, key = secret) =>
+  sign(
+    {
+      userID: "author@example.test",
+      role: "author",
+      assignmentID: 4892,
+      groupID: "shared-group",
+      gradingCallbackRequired: false,
+      ...claims,
+    },
+    key,
+    { expiresIn: "1h" },
+  );
+
+function authenticate(
+  cookie: string,
+  headers: Request["headers"] = {},
+  url = "/api/v1/user-session",
+) {
+  const config = { jwtConstants: { secret } } as JwtConfigService;
+  const strategy = new JwtCookieStrategy(config);
+  const response = {
+    cookie: jest.fn<
+      void,
+      [
+        string,
+        string,
+        { httpOnly: boolean; sameSite: string; path: string; maxAge: number },
+      ]
+    >(),
+    clearCookie: jest.fn(),
+  };
+  const request = {
+    headers: { cookie, ...headers },
+    originalUrl: url,
+    cookies: Object.fromEntries(
+      cookie.split("; ").map((pair) => {
+        const index = pair.indexOf("=");
+        return [pair.slice(0, index), pair.slice(index + 1)];
+      }),
+    ),
+    res: response,
+  } as unknown as Request;
+  const result = new Promise<unknown>((resolve, reject) => {
+    strategy.success = resolve;
+    strategy.fail = () => reject(new Error("Unauthorized"));
+    strategy.error = reject;
+    strategy.authenticate(request, {});
+  });
+  return { result, response };
+}
+const context = { "x-mark-author-assignment": "4892" };
+
+describe("verified author sessions", () => {
+  it("preserves the signed author token during a learner preview and forwards the same token", async () => {
+    const author = token();
+    const learner = token({ role: "learner" });
+    const cookie = `authentication=${learner}; mark_author_4892=${author}`;
+    const { result } = authenticate(cookie, context);
+    await expect(result).resolves.toMatchObject({
+      role: "author",
+      assignmentId: 4892,
+    });
+    expect(dedupeAuthenticationCookieHeader(cookie, context)).toBe(
+      `authentication=${author}`,
+    );
+    expect(selectAuthenticationCookie({ headers: { cookie } }).token).toBe(
+      learner,
+    );
+  });
+
+  it.each([
+    ["invalid signature", () => token({}, "wrong-secret")],
+    ["expired author", () => token({ exp: 1, iat: 0 })],
+  ])(
+    "rejects %s before setting an author cookie",
+    async (_name, makeInvalid) => {
+      // Explicit expiration uses sign without expiresIn.
+      const invalid =
+        _name === "expired author"
+          ? sign(
+              {
+                userID: "author@example.test",
+                role: "author",
+                assignmentID: 4892,
+                exp: 1,
+              },
+              secret,
+            )
+          : makeInvalid();
+      const { result, response } = authenticate(
+        `authentication=${token({ role: "learner" })}; mark_author_4892=${invalid}`,
+        context,
+      );
+      await expect(result).rejects.toThrow();
+      expect(response.cookie).not.toHaveBeenCalled();
+    },
+  );
+
+  it("does not revive an author cookie after the current session expired", async () => {
+    const expired = sign(
+      { userID: "author@example.test", role: "learner", exp: 1 },
+      secret,
+    );
+    await expect(
+      authenticate(
+        `authentication=${expired}; mark_author_4892=${token()}`,
+        context,
+      ).result,
+    ).rejects.toThrow();
+  });
+
+  it("does not trust a forged current-session identity", async () => {
+    await expect(
+      authenticate(
+        `authentication=${token({ role: "learner" }, "wrong-secret")}; mark_author_4892=${token()}`,
+        context,
+      ).result,
+    ).rejects.toThrow();
+  });
+
+  it("does not revive an author cookie after signing out", async () => {
+    await expect(
+      authenticate(`mark_author_4892=${token()}`, context).result,
+    ).rejects.toThrow();
+  });
+
+  it("does not borrow the previous account's author session", async () => {
+    await expect(
+      authenticate(
+        `authentication=${token({ userID: "other@example.test", role: "learner" })}; mark_author_4892=${token()}`,
+        context,
+      ).result,
+    ).rejects.toThrow();
+  });
+
+  it("rejects saves from an editor opened by another account", async () => {
+    await expect(
+      authenticate(
+        `authentication=${token({ userID: "other@example.test" })}`,
+        {
+          ...context,
+          "x-mark-author-user": "author@example.test",
+        },
+      ).result,
+    ).rejects.toThrow();
+  });
+
+  it("rejects another quiz even without browser context headers", async () => {
+    await expect(
+      authenticate(
+        `authentication=${token()}`,
+        {},
+        "/api/v2/assignments/4941/questions",
+      ).result,
+    ).rejects.toThrow();
+  });
+
+  it("selects concurrent quiz sessions independently", async () => {
+    const cookie = `authentication=${token({ assignmentID: 4941 })}; mark_author_4892=${token()}`;
+    await expect(authenticate(cookie, context).result).resolves.toMatchObject({
+      assignmentId: 4892,
+    });
+    await expect(
+      authenticate(cookie, { "x-mark-author-assignment": "4941" }).result,
+    ).resolves.toMatchObject({ assignmentId: 4941 });
+  });
+
+  it("persists a verified author token with bounded lifetime and HttpOnly", async () => {
+    const author = token();
+    const { result, response } = authenticate(
+      `authentication=${author}`,
+      context,
+    );
+    await result;
+    expect(response.cookie).toHaveBeenCalledWith(
+      "mark_author_4892",
+      author,
+      expect.objectContaining({
+        httpOnly: true,
+        sameSite: "lax",
+        path: "/",
+        maxAge: expect.any(Number) as number,
+      }),
+    );
+    expect(response.cookie.mock.calls[0][2].maxAge).toBeLessThanOrEqual(
+      3_600_000,
+    );
+  });
+});

--- a/apps/api-gateway/src/auth/jwt/cookie-based/jwt.cookie.extractor.ts
+++ b/apps/api-gateway/src/auth/jwt/cookie-based/jwt.cookie.extractor.ts
@@ -1,6 +1,51 @@
 import { Request } from "express";
 
 const COOKIE_NAME = "authentication";
+export const AUTHOR_COOKIE_PREFIX = "mark_author_";
+
+/** A routing hint only: the selected token is still signature/expiry checked. */
+export function authorAssignmentContext(
+  headers: Request["headers"],
+): number | undefined {
+  const explicit = headers["x-mark-author-assignment"];
+  if (typeof explicit === "string" && /^[1-9]\d*$/.test(explicit)) {
+    const id = Number(explicit);
+    return Number.isSafeInteger(id) ? id : undefined;
+  }
+  if (typeof headers.referer !== "string") return undefined;
+  try {
+    const match = new URL(headers.referer).pathname.match(
+      /^\/author\/([1-9]\d*)(?:\/|$)/,
+    );
+    const id = match ? Number(match[1]) : undefined;
+    return Number.isSafeInteger(id) ? id : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export function unverifiedSession(token: string | undefined): {
+  userID?: string;
+  role?: string;
+  assignmentID?: number;
+  iat?: number;
+} {
+  try {
+    const value: unknown = JSON.parse(
+      Buffer.from(token?.split(".")[1] ?? "", "base64url").toString("utf8"),
+    );
+    return value && typeof value === "object"
+      ? (value as {
+          userID?: string;
+          role?: string;
+          assignmentID?: number;
+          iat?: number;
+        })
+      : {};
+  } catch {
+    return {};
+  }
+}
 
 export interface AuthCookieSelection {
   /** The chosen cookie value, or undefined when none is present. */
@@ -33,6 +78,36 @@ export function selectAuthenticationCookie(
   },
 ): AuthCookieSelection {
   const rawHeader = request.headers?.cookie;
+  const context = authorAssignmentContext(request.headers ?? {});
+  if (context !== undefined) {
+    const legacy = selectAuthenticationCookie({
+      headers: { cookie: rawHeader },
+      cookies: request.cookies,
+    });
+    const scoped = parseCookiePairs(rawHeader)
+      .filter((pair) => pair.name === `${AUTHOR_COOKIE_PREFIX}${context}`)
+      .map((pair) => tryDecodeUriComponent(pair.rawValue));
+    const legacyClaims = unverifiedSession(legacy.token);
+    if (scoped.length > 0) {
+      const newest = scoped[pickNewestIatIndex(scoped)];
+      // Switching accounts must not revive the previous user's author session.
+      if (
+        !legacy.token ||
+        legacyClaims.userID !== unverifiedSession(newest).userID
+      )
+        return legacy;
+      if (
+        legacy.token &&
+        legacyClaims.role === "author" &&
+        legacyClaims.assignmentID === context
+      )
+        scoped.push(legacy.token);
+      return {
+        token: scoped[pickNewestIatIndex(scoped)],
+        candidateCount: scoped.length,
+      };
+    }
+  }
   const candidates = parseCookiePairs(rawHeader)
     .filter((pair) => pair.name === COOKIE_NAME)
     .map((pair) => tryDecodeUriComponent(pair.rawValue));
@@ -63,20 +138,27 @@ export function selectAuthenticationCookie(
  */
 export function dedupeAuthenticationCookieHeader(
   rawHeader?: string,
+  headers: Request["headers"] = {},
 ): string | undefined {
   const pairs = parseCookiePairs(rawHeader);
   const authPairs = pairs.filter((pair) => pair.name === COOKIE_NAME);
-  if (authPairs.length <= 1) {
+  const hasAuthorCookies = pairs.some((pair) =>
+    pair.name.startsWith(AUTHOR_COOKIE_PREFIX),
+  );
+  if (authPairs.length <= 1 && !hasAuthorCookies) {
     return undefined;
   }
 
-  const winnerIndex = pickNewestIatIndex(
-    authPairs.map((pair) => tryDecodeUriComponent(pair.rawValue)),
-  );
-  const winner = authPairs[winnerIndex];
+  const { token } = selectAuthenticationCookie({
+    headers: { ...headers, cookie: rawHeader },
+  });
 
-  const kept = pairs.filter((pair) => pair.name !== COOKIE_NAME);
-  kept.push(winner);
+  const kept = pairs.filter(
+    (pair) =>
+      pair.name !== COOKIE_NAME && !pair.name.startsWith(AUTHOR_COOKIE_PREFIX),
+  );
+  if (token)
+    kept.push({ name: COOKIE_NAME, rawValue: encodeURIComponent(token) });
   return kept.map((pair) => `${pair.name}=${pair.rawValue}`).join("; ");
 }
 

--- a/apps/api-gateway/src/auth/jwt/cookie-based/jwt.cookie.strategy.spec.ts
+++ b/apps/api-gateway/src/auth/jwt/cookie-based/jwt.cookie.strategy.spec.ts
@@ -32,7 +32,7 @@ describe("JwtCookieStrategy", () => {
         exp: 1_234_567_890 + 3600,
       };
 
-      const result = strategy.validate(payload);
+      const result = strategy.validate({ headers: {} } as any, payload);
 
       expect(result).toEqual({
         userId: "user123",
@@ -58,7 +58,7 @@ describe("JwtCookieStrategy", () => {
         exp: 1_234_567_890 + 3600,
       } as any;
 
-      const result = strategy.validate(payload);
+      const result = strategy.validate({ headers: {} } as any, payload);
 
       expect(result.userId).toBe("user123");
       expect(result.role).toBe(UserRole.AUTHOR);
@@ -79,7 +79,7 @@ describe("JwtCookieStrategy", () => {
         exp: 1_234_567_890 + 3600,
       } as any;
 
-      const result = strategy.validate(payload);
+      const result = strategy.validate({ headers: {} } as any, payload);
 
       expect(result.userId).toBe("user123");
       expect(result.role).toBe(UserRole.ADMIN);
@@ -98,7 +98,7 @@ describe("JwtCookieStrategy", () => {
           exp: 1_234_567_890 + 3600,
         };
 
-        const result = strategy.validate(payload);
+        const result = strategy.validate({ headers: {} } as any, payload);
         expect(result.role).toBe(role);
       }
     });
@@ -117,7 +117,7 @@ describe("JwtCookieStrategy", () => {
           exp: 1_234_567_890 + 3600,
         };
 
-        const result = strategy.validate(payload);
+        const result = strategy.validate({ headers: {} } as any, payload);
         expect(result.launch_presentation_locale).toBe(locale);
       }
     });
@@ -134,7 +134,7 @@ describe("JwtCookieStrategy", () => {
           exp: 1_234_567_890 + 3600,
         };
 
-        const result = strategy.validate(payload);
+        const result = strategy.validate({ headers: {} } as any, payload);
         expect(result.gradingCallbackRequired).toBe(value);
       }
     });
@@ -158,7 +158,7 @@ describe("JwtCookieStrategy", () => {
           exp: 1_234_567_890 + 3600,
         };
 
-        const result = strategy.validate(payload);
+        const result = strategy.validate({ headers: {} } as any, payload);
         expect(result.returnUrl).toBe(url);
       }
     });

--- a/apps/api-gateway/src/auth/jwt/cookie-based/jwt.cookie.strategy.ts
+++ b/apps/api-gateway/src/auth/jwt/cookie-based/jwt.cookie.strategy.ts
@@ -1,13 +1,19 @@
-import { Injectable, Logger } from "@nestjs/common";
+import { Injectable, Logger, UnauthorizedException } from "@nestjs/common";
 import { PassportStrategy } from "@nestjs/passport";
 import { Request } from "express";
+import { verify } from "jsonwebtoken";
 import { ExtractJwt, Strategy } from "passport-jwt";
 import {
   UserSession,
   UserSessionPayload,
 } from "../../interfaces/user.session.interface";
 import { JwtConfigService } from "../jwt.config.service";
-import { selectAuthenticationCookie } from "./jwt.cookie.extractor";
+import {
+  AUTHOR_COOKIE_PREFIX,
+  authorAssignmentContext,
+  selectAuthenticationCookie,
+  unverifiedSession,
+} from "./jwt.cookie.extractor";
 
 interface IRequestWithCookies extends Request {
   cookies: {
@@ -48,11 +54,94 @@ export class JwtCookieStrategy extends PassportStrategy(
       ]),
       ignoreExpiration: false,
       secretOrKey: configService.jwtConstants.secret,
+      passReqToCallback: true,
     });
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  validate(payload: IJwtPayload): UserSession {
+  validate(request: IRequestWithCookies, payload: IJwtPayload): UserSession {
+    const context = authorAssignmentContext(request.headers ?? {});
+    const routeId = request.originalUrl?.match(
+      /\/assignments\/([1-9]\d*)(?:[/?]|$)/,
+    )?.[1];
+    if (
+      (payload.role === "author" &&
+        routeId &&
+        Number(routeId) !== payload.assignmentID) ||
+      (context !== undefined &&
+        (payload.role !== "author" || payload.assignmentID !== context))
+    ) {
+      logger.warn("Author session does not match requested workspace");
+      throw new UnauthorizedException("Relaunch this quiz as an author");
+    }
+    const editorUser = request.headers?.["x-mark-author-user"];
+    if (
+      context !== undefined &&
+      editorUser !== undefined &&
+      editorUser !== payload.userID
+    ) {
+      logger.warn("Author session account changed");
+      throw new UnauthorizedException(
+        "Return to the account that opened this editor",
+      );
+    }
+    // A scoped cookie must not revive an expired, tampered, or signed-out
+    // browser session. Passport verifies the selected author token; verify the
+    // current launch separately before using it as the account-switch boundary.
+    const selected = selectAuthenticationCookie(request).token;
+    const current = selectAuthenticationCookie({
+      headers: { cookie: request.headers?.cookie },
+      cookies: request.cookies,
+    }).token;
+    if (selected && selected !== current) {
+      try {
+        if (!current) throw new Error("Missing current session");
+        const claims = verify(current, this.configService.jwtConstants.secret);
+        if (typeof claims === "string" || claims.userID !== payload.userID)
+          throw new Error("Account changed");
+      } catch {
+        logger.warn("Author recovery requires a valid current session");
+        throw new UnauthorizedException("Relaunch this quiz as an author");
+      }
+    }
+    // Only persist tokens after passport has verified their signature and expiry.
+    // A bounded set keeps previews and other quiz tabs from overwriting authors.
+    if (
+      payload.role === "author" &&
+      Number.isSafeInteger(payload.assignmentID) &&
+      payload.assignmentID > 0 &&
+      request.res
+    ) {
+      const { token } = selectAuthenticationCookie(request);
+      const name = `${AUTHOR_COOKIE_PREFIX}${payload.assignmentID}`;
+      if (token && request.cookies?.[name] !== token) {
+        const secure = process.env.NODE_ENV === "production";
+        const options = {
+          httpOnly: true,
+          secure,
+          sameSite: "lax" as const,
+          path: "/",
+        };
+        const others = Object.entries(request.cookies ?? {})
+          .filter(
+            ([key]) => key.startsWith(AUTHOR_COOKIE_PREFIX) && key !== name,
+          )
+          .sort(
+            (a, b) =>
+              (unverifiedSession(b[1]).iat ?? 0) -
+              (unverifiedSession(a[1]).iat ?? 0),
+          );
+        for (const [key] of others.slice(3))
+          request.res.clearCookie(key, options);
+        request.res.cookie(name, token, {
+          ...options,
+          maxAge: Math.max(
+            0,
+            Math.min(payload.exp * 1000 - Date.now(), 6 * 60 * 60 * 1000),
+          ),
+        });
+      }
+    }
     return {
       userId: payload.userID,
       role: payload.role,

--- a/apps/api/src/api/assignment/guards/assignment.access.control.guard.spec.ts
+++ b/apps/api/src/api/assignment/guards/assignment.access.control.guard.spec.ts
@@ -142,6 +142,37 @@ describe("AssignmentAccessControlGuard — launch-derived auto-link", () => {
     expect(childLogger.error).toHaveBeenCalled();
   });
 
+  it("denies an author targeting another quiz even when both share a group", async () => {
+    mockPrisma.$transaction = jest
+      .fn()
+      .mockResolvedValue([
+        { assignmentId: 42, groupId: "shared-group" },
+        { id: 42 },
+      ]);
+    await expect(
+      guard.canActivate(
+        createContext(
+          { role: UserRole.AUTHOR, assignmentId: 4535 },
+          { id: "42" },
+        ),
+      ),
+    ).rejects.toBeInstanceOf(ForbiddenException);
+    expect(mockPrisma.$transaction).not.toHaveBeenCalled();
+  });
+
+  it("allows a collaborator with an author launch for this quiz", async () => {
+    mockNoLink();
+    (mockPrisma.assignmentGroup.create as jest.Mock).mockResolvedValue({});
+    await expect(
+      guard.canActivate(
+        createContext(
+          { role: UserRole.AUTHOR, userId: "collaborator" },
+          { id: "4535" },
+        ),
+      ),
+    ).resolves.toBe(true);
+  });
+
   it("keeps allowing access through an existing group link without writing", async () => {
     mockPrisma.$transaction = jest.fn().mockResolvedValue([
       {

--- a/apps/api/src/api/assignment/guards/assignment.access.control.guard.ts
+++ b/apps/api/src/api/assignment/guards/assignment.access.control.guard.ts
@@ -10,6 +10,7 @@ import { Reflector } from "@nestjs/core";
 import { Prisma } from "@prisma/client";
 import { WINSTON_MODULE_PROVIDER } from "nest-winston";
 import {
+  UserRole,
   UserSession,
   UserSessionRequest,
 } from "src/auth/interfaces/user.session.interface";
@@ -47,6 +48,23 @@ export class AssignmentAccessControlGuard implements CanActivate {
         url: originalUrl,
       });
       throw new ForbiddenException("Invalid assignment ID");
+    }
+
+    // A shared LTI group is not permission to edit every quiz in that group.
+    // AWB/CM authorize collaborators before issuing a launch for this quiz.
+    if (
+      userSession.role === UserRole.AUTHOR &&
+      userSession.assignmentId !== assignmentId
+    ) {
+      this.logger.warn(
+        "assignment_access_denied: author launch targets another assignment",
+        {
+          assignment_id: assignmentId,
+          session_assignment_id: userSession.assignmentId,
+          user_id: userSession.userId,
+        },
+      );
+      throw new ForbiddenException("Access denied to this assignment");
     }
 
     const [assignmentGroup, assignment] = await this.prisma.$transaction([

--- a/apps/api/src/api/assignment/question/guards/assignment.question.access.control.guard.spec.ts
+++ b/apps/api/src/api/assignment/question/guards/assignment.question.access.control.guard.spec.ts
@@ -74,6 +74,18 @@ describe("AssignmentQuestionAccessControlGuard — hostile input", () => {
     guard = module.get(AssignmentQuestionAccessControlGuard);
   });
 
+  it("rejects a different quiz even when a shared group link exists", async () => {
+    prisma.$transaction.mockResolvedValue([
+      { id: 456 },
+      { groupId: "group-1" },
+      { id: 7 },
+    ]);
+    await expect(
+      guard.canActivate(buildContext({ assignmentId: "456", id: "7" })),
+    ).rejects.toBeInstanceOf(ForbiddenException);
+    expect(prisma.$transaction).not.toHaveBeenCalled();
+  });
+
   it("rejects missing :assignmentId with ForbiddenException BEFORE touching Prisma", async () => {
     const context = buildContext({ id: "7" }); // no assignmentId at all
 

--- a/apps/api/src/api/assignment/question/guards/assignment.question.access.control.guard.ts
+++ b/apps/api/src/api/assignment/question/guards/assignment.question.access.control.guard.ts
@@ -8,7 +8,10 @@ import {
 } from "@nestjs/common";
 import { Reflector } from "@nestjs/core";
 import { WINSTON_MODULE_PROVIDER } from "nest-winston";
-import { UserSessionRequest } from "src/auth/interfaces/user.session.interface";
+import {
+  UserRole,
+  UserSessionRequest,
+} from "src/auth/interfaces/user.session.interface";
 import { Logger } from "winston";
 import { PrismaService } from "../../../../database/prisma.service";
 import { sanitizeForLog } from "../../../../logger/sanitize";
@@ -55,6 +58,21 @@ export class AssignmentQuestionAccessControlGuard implements CanActivate {
         url: sanitizeForLog(originalUrl),
       });
       throw new ForbiddenException("Invalid assignment ID");
+    }
+
+    if (
+      userSession.role === UserRole.AUTHOR &&
+      userSession.assignmentId !== assignmentId
+    ) {
+      this.logger.warn(
+        "question_access_denied: author launch targets another assignment",
+        {
+          assignment_id: assignmentId,
+          session_assignment_id: userSession.assignmentId,
+          user_id: sanitizeForLog(userSession.userId),
+        },
+      );
+      throw new ForbiddenException("Access denied to this assignment");
     }
 
     let questionId: number | undefined;

--- a/apps/web/app/author/(components)/Header/index.tsx
+++ b/apps/web/app/author/(components)/Header/index.tsx
@@ -329,7 +329,7 @@ function AuthorHeader() {
 
       setPageState("success");
     } catch (error) {
-      setPageState("error");
+      useAuthorStore.getState().setPageError(error);
     }
   };
 
@@ -348,7 +348,7 @@ function AuthorHeader() {
         setPageState("success");
         return;
       } catch (error) {
-        setPageState("error");
+        useAuthorStore.getState().setPageError(error);
         return;
       }
     }

--- a/apps/web/app/author/(components)/SuccessPage.tsx
+++ b/apps/web/app/author/(components)/SuccessPage.tsx
@@ -43,7 +43,7 @@ function SuccessPage() {
         setPageState("success");
         return;
       } catch (error) {
-        setPageState("error");
+        useAuthorStore.getState().setPageError(error);
         return;
       }
     }

--- a/apps/web/app/author/[assignmentId]/layout.test.tsx
+++ b/apps/web/app/author/[assignmentId]/layout.test.tsx
@@ -49,11 +49,12 @@ describe("author assignment layout", () => {
     );
   });
 
-  it("does not mutate the author store during render", () => {
+  it("does not mutate the author store during render", async () => {
     renderToString(
-      <Layout>
-        <div>child</div>
-      </Layout>,
+      await Layout({
+        params: Promise.resolve({ assignmentId: "123" }),
+        children: <div>child</div>,
+      }),
     );
 
     expect(mockSetState).not.toHaveBeenCalled();
@@ -61,9 +62,10 @@ describe("author assignment layout", () => {
 
   it("updates the active assignment id after mount", async () => {
     render(
-      <Layout>
-        <div>child</div>
-      </Layout>,
+      await Layout({
+        params: Promise.resolve({ assignmentId: "123" }),
+        children: <div>child</div>,
+      }),
     );
 
     await waitFor(() => {

--- a/apps/web/app/author/[assignmentId]/layout.tsx
+++ b/apps/web/app/author/[assignmentId]/layout.tsx
@@ -1,79 +1,27 @@
-"use client";
+import type { ReactNode } from "react";
+import AuthorAccess from "@/components/AuthorAccess";
 
-import { useEffect, useState } from "react";
-import ErrorModal from "@/components/ErrorModal";
-import { useAuthorStore } from "@/stores/author";
-import { getAssignmentIdFromURL } from "@/stores/learner";
-import { getUser } from "@/lib/shared";
-import type { ComponentPropsWithoutRef, FC } from "react";
-
-type Props = ComponentPropsWithoutRef<"div">;
-
-const Layout: FC<Props> = ({ children }) => {
-  const [showRoleError, setShowRoleError] = useState(false);
-  const [pageState] = useAuthorStore((state) => [state.pageState]);
-  const assignmentId = getAssignmentIdFromURL("author");
-  const assignmentIdNumber = Number.parseInt(assignmentId, 10);
-
-  useEffect(() => {
-    if (Number.isFinite(assignmentIdNumber)) {
-      useAuthorStore.setState({ activeAssignmentId: assignmentIdNumber });
-    }
-  }, [assignmentIdNumber]);
-
-  useEffect(() => {
-    const checkRole = async () => {
-      try {
-        const user = await getUser();
-        if (!user || user.role !== "author") {
-          setShowRoleError(true);
-        }
-      } catch {
-        setShowRoleError(true);
-      }
-    };
-    void checkRole();
-  }, []);
-
-  if (pageState === "error") {
-    return (
-      <ErrorModal
-        error="Assignment error"
-        statusCode={500}
-        headline="Author workspace unavailable"
-        userSteps={[
-          { title: "Refresh the page" },
-          { title: "Return to your assignments", cta: "Go to assignments" },
-        ]}
-        primaryActionHref="/learner"
-      />
-    );
-  }
-
-  if (showRoleError) {
-    return (
-      <ErrorModal
-        statusCode={403}
-        headline="Author access required"
-        error="You tried to open the author workspace as a learner. Switch back to the learner view for this assignment."
-        userSteps={[
-          {
-            title: "Open learner view",
-            description:
-              "We'll send you to the learner version of this assignment.",
-            cta: "Go to learner view",
-          },
-          {
-            title: "If you should be an author",
-            description: "Ask your admin to grant you author permissions.",
-          },
-        ]}
-        primaryActionHref={`/learner/${assignmentId}`}
-        primaryActionLabel="Go to learner view"
-      />
-    );
-  }
-  return <div className="">{children}</div>;
-};
-
-export default Layout;
+export default async function Layout({
+  children,
+  params,
+}: {
+  children: ReactNode;
+  params: Promise<{ assignmentId: string }>;
+}) {
+  const { assignmentId } = await params;
+  const awbUrl =
+    process.env.AWB_URL ||
+    (process.env.APP_ENV === "staging"
+      ? "https://author.staging.skills.network"
+      : "https://author.skills.network");
+  return (
+    <AuthorAccess
+      key={assignmentId}
+      assignmentId={Number(assignmentId)}
+      awbUrl={awbUrl}
+      providerId={process.env.AWB_MARK_PROVIDER_ID}
+    >
+      {children}
+    </AuthorAccess>
+  );
+}

--- a/apps/web/components/AuthorAccess.tsx
+++ b/apps/web/components/AuthorAccess.tsx
@@ -1,0 +1,168 @@
+"use client";
+
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+import { getUser } from "@/lib/shared";
+import { APIError } from "@/lib/api-client";
+import { useAuthorStore } from "@/stores/author";
+import { bindAuthorSession } from "@/lib/author-session";
+import ErrorModal from "@/components/ErrorModal";
+
+type Status =
+  | "checking"
+  | "ready"
+  | "signin"
+  | "unavailable"
+  | "accountchanged";
+
+export default function AuthorAccess({
+  children,
+  assignmentId,
+  awbUrl,
+  providerId,
+}: {
+  children: ReactNode;
+  assignmentId: number;
+  awbUrl: string;
+  providerId?: string;
+}) {
+  const pageState = useAuthorStore((state) => state.pageState);
+  const mounted = useRef(true);
+  const editorUser = useRef<string | undefined>(undefined);
+  const generation = useRef(0);
+  const [status, setStatus] = useState<Status>("checking");
+  const [loaded, setLoaded] = useState(false);
+  const checking = useRef(false);
+  const checkSession = useCallback(async () => {
+    if (checking.current) return;
+    checking.current = true;
+    const startedAt = generation.current;
+    try {
+      const user = await getUser();
+      if (!mounted.current || startedAt !== generation.current) return;
+      if (user?.role === "author" && user.assignmentId === assignmentId) {
+        if (editorUser.current && editorUser.current !== user.userId) {
+          setStatus("accountchanged");
+          return;
+        }
+        editorUser.current = user.userId;
+        bindAuthorSession(assignmentId, user.userId);
+        setStatus("ready");
+        setLoaded(true);
+      } else setStatus("signin");
+    } catch (error) {
+      if (!mounted.current || startedAt !== generation.current) return;
+      setStatus(
+        error instanceof APIError && error.status === 401
+          ? "signin"
+          : "unavailable",
+      );
+    } finally {
+      checking.current = false;
+    }
+  }, [assignmentId]);
+
+  useEffect(() => {
+    mounted.current = true;
+    if (Number.isSafeInteger(assignmentId) && assignmentId > 0) {
+      useAuthorStore.setState({ activeAssignmentId: assignmentId });
+    }
+    void checkSession();
+    const onFocus = () => {
+      void checkSession();
+    };
+    const onUnauthorized = () => {
+      generation.current += 1;
+      setStatus("signin");
+    };
+    window.addEventListener("focus", onFocus);
+    window.addEventListener("mark-author-auth-required", onUnauthorized);
+    const timer = window.setInterval(onFocus, 30000);
+    return () => {
+      mounted.current = false;
+      window.removeEventListener("focus", onFocus);
+      window.removeEventListener("mark-author-auth-required", onUnauthorized);
+      window.clearInterval(timer);
+    };
+  }, [assignmentId, checkSession]);
+
+  const recovery = new URL(`/assignments/from-mark/${assignmentId}`, awbUrl);
+  if (providerId) recovery.searchParams.set("provider_id", providerId);
+
+  return (
+    <>
+      {/* Keep an opened editor mounted during reauthentication so its unsaved state survives. */}
+      {loaded && (
+        <div hidden={status !== "ready" || pageState === "error"}>
+          {children}
+        </div>
+      )}
+      {status === "ready" && pageState === "error" && (
+        <ErrorModal
+          error="Assignment error"
+          statusCode={500}
+          headline="Author workspace unavailable"
+          userSteps={[
+            { title: "Refresh the page" },
+            { title: "Return to your assignments", cta: "Go to assignments" },
+          ]}
+          primaryActionHref={awbUrl}
+        />
+      )}
+      {status !== "ready" && (
+        <section
+          role="status"
+          className="mx-auto my-16 max-w-xl rounded-xl border bg-white p-8 text-slate-900 shadow"
+        >
+          <h1 className="text-xl font-semibold">
+            {status === "checking"
+              ? "Checking author access…"
+              : status === "accountchanged"
+                ? "Your signed-in account changed"
+                : status === "unavailable"
+                  ? "Unable to check your session"
+                  : "Sign in to edit this quiz"}
+          </h1>
+          {status !== "checking" && (
+            <>
+              <p className="my-4">
+                {status === "accountchanged"
+                  ? "Sign back in with the account that opened this editor to recover your unsaved changes."
+                  : status === "unavailable"
+                    ? "The service could not be reached. Retry the session check."
+                    : "This link needs an author session. Open the quiz from Author Workbench, or use Edit Quiz in Context Manager if you created it there."}
+              </p>
+              {loaded && (
+                <p className="my-4">
+                  Keep this tab open to preserve your unsaved changes. Sign in
+                  in the new tab, then return here.
+                </p>
+              )}
+              {(status === "signin" || status === "accountchanged") && (
+                <a
+                  className="mr-4 underline"
+                  href={recovery.toString()}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Sign in through Author Workbench
+                </a>
+              )}
+              <button
+                className="rounded border px-4 py-2"
+                onClick={() => void checkSession()}
+              >
+                Check access again
+              </button>
+            </>
+          )}
+        </section>
+      )}
+    </>
+  );
+}

--- a/apps/web/components/__tests__/AuthorAccess.recovery.test.tsx
+++ b/apps/web/components/__tests__/AuthorAccess.recovery.test.tsx
@@ -1,0 +1,107 @@
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import AuthorAccess from "../AuthorAccess";
+import { getUser } from "@/lib/shared";
+import { apiClient, APIError } from "@/lib/api-client";
+import { useAuthorStore } from "@/stores/author";
+
+jest.mock("@/lib/shared", () => ({ getUser: jest.fn() }));
+jest.mock("@/lib/author", () => ({}));
+jest.mock("../ErrorModal", () => () => <div>Assignment error</div>);
+
+const author = {
+  userId: "author@example.test",
+  assignmentId: 4892,
+  role: "author" as const,
+  returnUrl: "",
+};
+const originalFetch = global.fetch;
+
+beforeEach(() => {
+  window.history.replaceState({}, "", "/author/4892/questions");
+  useAuthorStore.setState({ pageState: "success", activeAssignmentId: 4892 });
+  jest.mocked(getUser).mockResolvedValue(author);
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
+  jest.clearAllMocks();
+});
+
+function show() {
+  return render(
+    <AuthorAccess assignmentId={4892} awbUrl="https://author.example">
+      <input aria-label="Quiz title" defaultValue="Original" />
+      <button
+        onClick={() => {
+          // Same request/error path as Header.SyncAssignment.
+          void apiClient
+            .get("/api/v1/assignments/4892")
+            .catch((error: unknown) =>
+              useAuthorStore.getState().setPageError(error),
+            );
+        }}
+      >
+        Sync assignment
+      </button>
+    </AuthorAccess>,
+  );
+}
+
+it("restores the same draft after a sync 401 and successful reauthentication", async () => {
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: false,
+    status: 401,
+    statusText: "Unauthorized",
+    json: async () => ({ message: "Expired" }),
+  });
+  await act(async () => {
+    show();
+  });
+  const input = await screen.findByLabelText("Quiz title");
+  fireEvent.change(input, { target: { value: "Unsaved title" } });
+  await act(async () => {
+    fireEvent.click(screen.getByRole("button", { name: "Sync assignment" }));
+  });
+  await screen.findByRole("heading", { name: "Sign in to edit this quiz" });
+  expect(input).not.toBeVisible();
+  await act(async () => {
+    fireEvent.click(screen.getByRole("button", { name: "Check access again" }));
+  });
+  await waitFor(() => expect(input).toBeVisible());
+  expect(input).toHaveValue("Unsaved title");
+  expect(screen.queryByText("Assignment error")).not.toBeInTheDocument();
+});
+
+it("keeps genuine sync failures visible after a successful session check", async () => {
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: false,
+    status: 500,
+    statusText: "Internal Server Error",
+    json: async () => ({ message: "Failed to load" }),
+  });
+  await act(async () => {
+    show();
+  });
+  const input = await screen.findByLabelText("Quiz title");
+  await act(async () => {
+    fireEvent.click(screen.getByRole("button", { name: "Sync assignment" }));
+  });
+  expect(await screen.findByText("Assignment error")).toBeVisible();
+  await act(async () => window.dispatchEvent(new Event("focus")));
+  expect(input).not.toBeVisible();
+  expect(screen.getByText("Assignment error")).toBeVisible();
+});
+
+it("does not clear an existing workspace error when a session expires", () => {
+  useAuthorStore.setState({ pageState: "error" });
+  useAuthorStore
+    .getState()
+    .setPageError(new APIError("Expired", 401, "Unauthorized"));
+  expect(useAuthorStore.getState().pageState).toBe("error");
+});

--- a/apps/web/components/__tests__/AuthorAccess.test.tsx
+++ b/apps/web/components/__tests__/AuthorAccess.test.tsx
@@ -1,0 +1,145 @@
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import AuthorAccess from "../AuthorAccess";
+import { getUser } from "@/lib/shared";
+import { APIError } from "@/lib/api-client";
+
+jest.mock("@/lib/shared", () => ({ getUser: jest.fn() }));
+jest.mock("@/lib/api-client", () => ({
+  APIError: class extends Error {
+    constructor(
+      message: string,
+      public status: number,
+    ) {
+      super(message);
+    }
+  },
+}));
+jest.mock("@/stores/author", () => ({
+  useAuthorStore: Object.assign(() => "editing", { setState: jest.fn() }),
+}));
+jest.mock("../ErrorModal", () => () => <div>Assignment error</div>);
+
+const author = {
+  userId: "author@example.test",
+  assignmentId: 4892,
+  role: "author" as const,
+  returnUrl: "",
+};
+const getSession = jest.mocked(getUser);
+const show = () =>
+  render(
+    <AuthorAccess
+      assignmentId={4892}
+      awbUrl="https://author.example"
+      providerId="7"
+    >
+      <input aria-label="Quiz title" defaultValue="Original" />
+    </AuthorAccess>,
+  );
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+it("offers the correct AWB recovery link for a missing session, without mounting the editor", async () => {
+  getSession.mockRejectedValue(
+    new APIError("Unauthorized", 401, "Unauthorized"),
+  );
+  await act(async () => {
+    show();
+  });
+  expect(
+    await screen.findByRole("heading", { name: "Sign in to edit this quiz" }),
+  ).toBeVisible();
+  expect(
+    screen.getByRole("link", { name: "Sign in through Author Workbench" }),
+  ).toHaveAttribute(
+    "href",
+    "https://author.example/assignments/from-mark/4892?provider_id=7",
+  );
+  expect(screen.queryByLabelText("Quiz title")).not.toBeInTheDocument();
+});
+
+it.each([
+  { ...author, role: "learner" as const },
+  { ...author, assignmentId: 4941 },
+])("requires a matching author launch", async (user) => {
+  getSession.mockResolvedValue(user);
+  await act(async () => {
+    show();
+  });
+  expect(
+    await screen.findByRole("heading", { name: "Sign in to edit this quiz" }),
+  ).toBeVisible();
+  expect(screen.queryByLabelText("Quiz title")).not.toBeInTheDocument();
+});
+
+it("preserves unsaved editor state through expiry and same-account recovery", async () => {
+  getSession.mockResolvedValue(author);
+  await act(async () => {
+    show();
+  });
+  const input = await screen.findByLabelText("Quiz title");
+  fireEvent.change(input, { target: { value: "Unsaved title" } });
+  act(() => window.dispatchEvent(new Event("mark-author-auth-required")));
+  expect(input).not.toBeVisible();
+  await act(async () => {
+    fireEvent.click(screen.getByRole("button", { name: "Check access again" }));
+  });
+  await waitFor(() => expect(input).toBeVisible());
+  expect(input).toHaveValue("Unsaved title");
+});
+
+it("does not reopen another account's unsaved editor", async () => {
+  getSession
+    .mockResolvedValueOnce(author)
+    .mockResolvedValueOnce({ ...author, userId: "other@example.test" })
+    .mockResolvedValue(author);
+  await act(async () => {
+    show();
+  });
+  const input = await screen.findByLabelText("Quiz title");
+  fireEvent.change(input, { target: { value: "Private draft" } });
+  await act(async () => {
+    window.dispatchEvent(new Event("focus"));
+  });
+  expect(
+    await screen.findByRole("heading", {
+      name: "Your signed-in account changed",
+    }),
+  ).toBeVisible();
+  expect(input).not.toBeVisible();
+  await act(async () => {
+    fireEvent.click(screen.getByRole("button", { name: "Check access again" }));
+  });
+  await waitFor(() => expect(input).toBeVisible());
+  expect(input).toHaveValue("Private draft");
+});
+
+it("ignores a session check that completed after an unauthorized API response", async () => {
+  let resolveSession: (user: typeof author) => void = () => {
+    throw new Error("Not initialized");
+  };
+  getSession.mockReturnValue(
+    new Promise((resolve) => {
+      resolveSession = resolve;
+    }),
+  );
+  await act(async () => {
+    show();
+  });
+  act(() => window.dispatchEvent(new Event("mark-author-auth-required")));
+  await act(async () => {
+    resolveSession(author);
+  });
+  expect(
+    screen.getByRole("heading", { name: "Sign in to edit this quiz" }),
+  ).toBeVisible();
+  expect(screen.queryByLabelText("Quiz title")).not.toBeInTheDocument();
+});

--- a/apps/web/lib/__tests__/author-session.test.ts
+++ b/apps/web/lib/__tests__/author-session.test.ts
@@ -1,0 +1,30 @@
+import { authorSessionHeaders, bindAuthorSession } from "../author-session";
+
+beforeEach(() => window.history.replaceState({}, "", "/"));
+afterEach(() => window.history.replaceState({}, "", "/"));
+
+it("sends the editor identity and quiz context even without a referrer", () => {
+  window.history.replaceState({}, "", "/author/4892/questions");
+  bindAuthorSession(4892, "author@example.test");
+  expect(authorSessionHeaders()).toEqual({
+    "x-mark-author-assignment": "4892",
+    "x-mark-author-user": "author@example.test",
+  });
+  expect(authorSessionHeaders(false)).toEqual({
+    "x-mark-author-assignment": "4892",
+  });
+});
+
+it("does not send author context to learner previews", () => {
+  bindAuthorSession(4892, "author@example.test");
+  window.history.replaceState({}, "", "/learner/4892");
+  expect(authorSessionHeaders()).toEqual({});
+});
+
+it("does not carry an editor identity into another quiz", () => {
+  bindAuthorSession(4892, "author@example.test");
+  window.history.replaceState({}, "", "/author/4941/questions");
+  expect(authorSessionHeaders()).toEqual({
+    "x-mark-author-assignment": "4941",
+  });
+});

--- a/apps/web/lib/api-client.ts
+++ b/apps/web/lib/api-client.ts
@@ -4,6 +4,7 @@ import {
 } from "@/app/Helpers/data-transformer";
 import { API_DECODE_CONFIG } from "@/app/Helpers/transform-config";
 import { toast } from "sonner";
+import { authorSessionHeaders } from "./author-session";
 
 interface APIClientConfig {
   baseURL?: string;
@@ -139,6 +140,7 @@ export class APIClient {
       "Content-Type": "application/json",
       ...this.defaultHeaders,
       ...headers,
+      ...authorSessionHeaders(),
     };
 
     const controller = new AbortController();
@@ -156,6 +158,13 @@ export class APIClient {
       clearTimeout(timeoutId);
 
       if (!response.ok) {
+        if (
+          response.status === 401 &&
+          typeof window !== "undefined" &&
+          window.location.pathname.startsWith("/author/")
+        ) {
+          window.dispatchEvent(new Event("mark-author-auth-required"));
+        }
         let errorBody: unknown;
         try {
           errorBody = await response.json();

--- a/apps/web/lib/author-session.ts
+++ b/apps/web/lib/author-session.ts
@@ -1,0 +1,20 @@
+// Per-tab identity of the mounted editor. It survives temporary session loss.
+let editor: { assignmentId: number; userId: string } | undefined;
+
+export function bindAuthorSession(assignmentId: number, userId: string) {
+  editor = { assignmentId, userId };
+}
+
+export function authorSessionHeaders(
+  includeIdentity = true,
+): Record<string, string> {
+  if (typeof window === "undefined") return {};
+  const match = window.location.pathname.match(/^\/author\/([1-9]\d*)(?:\/|$)/);
+  if (!match || !Number.isSafeInteger(Number(match[1]))) return {};
+  return {
+    "x-mark-author-assignment": match[1],
+    ...(includeIdentity && editor?.assignmentId === Number(match[1])
+      ? { "x-mark-author-user": editor.userId }
+      : {}),
+  };
+}

--- a/apps/web/lib/shared.ts
+++ b/apps/web/lib/shared.ts
@@ -1,3 +1,4 @@
+import { authorSessionHeaders } from "./author-session";
 /* eslint-disable */
 import { absoluteUrl } from "./utils";
 import { getApiRoutes, getBaseApiPath } from "@/config/constants";
@@ -2003,13 +2004,15 @@ const V1_USER_ROUTE = absoluteUrl("/api/v1/user-session");
 
 export async function getUser(cookies?: string): Promise<User | undefined> {
   const res = await fetch(V1_USER_ROUTE, {
+    cache: "no-store",
     headers: {
+      ...authorSessionHeaders(false),
       ...(cookies ? { Cookie: cookies } : {}),
     },
   });
 
   if (res.status === 401) {
-    throw new Error("Unauthorized");
+    throw new APIError("Sign in to continue", 401, "Unauthorized");
   }
 
   if (!res.ok) {

--- a/apps/web/stores/author.ts
+++ b/apps/web/stores/author.ts
@@ -10,6 +10,7 @@ import {
   RubricType,
   Scoring,
 } from "@/config/types";
+import { APIError } from "@/lib/api-client";
 import { extractAssignmentId } from "@/lib/strings";
 import { createJSONStorage, devtools, persist } from "zustand/middleware";
 import { shallow } from "zustand/shallow";
@@ -222,6 +223,7 @@ export type AuthorActions = {
   ) => void;
   setPoints: (questionId: number, points: number) => void;
   setPageState: (state: "loading" | "success" | "error") => void;
+  setPageError: (error: unknown) => void;
   setUpdatedAt: (updatedAt: number) => void;
   setQuestionTitle: (questionTitle: string, questionId: number) => void;
   setQuestionVariantTitle: (
@@ -1717,6 +1719,12 @@ export const useAuthorStore = createWithEqualityFn<
         },
         pageState: "loading" as const,
         setPageState: (pageState) => set({ pageState }),
+        setPageError: (error) => {
+          // AuthorAccess handles 401s while keeping the draft mounted. Do not
+          // turn a recoverable session failure into a permanent workspace error.
+          if (error instanceof APIError && error.status === 401) return;
+          set({ pageState: "error" });
+        },
         updatedAt: undefined,
         setUpdatedAt: (updatedAt) => set({ updatedAt }),
         setAuthorStore: (state) => {

--- a/docs/cm-author-access.md
+++ b/docs/cm-author-access.md
@@ -1,0 +1,39 @@
+# CM quiz publishing and author access
+
+## Failure modes and fixes
+
+A copied `/author/<Mark ID>/questions` URL does not establish an LTI author session. The old layout treated missing, expired, wrong-role and failed session checks alike and described all of them as a learner trying to edit. A single authentication cookie could also be replaced by a learner preview or another quiz launch. CM reused old launch signatures in its generation-result actions.
+
+Mark now retains up to four verified author JWTs in HttpOnly cookies, selected for the requested author workspace. The ordinary current launch must still be present, valid and for the same user. Selected JWTs are signature/expiry checked, and the forwarded authentication cookie matches the selected session. Learner requests continue using the ordinary launch cookie. Author requests for another quiz are rejected independently of browser context headers; assignment and question guards enforce the author launch's assignment in the API as well. This preserves upstream collaborator authorization: AWB/CM must issue an authorized launch for the target quiz.
+
+The editor checks its session before mounting and offers AWB recovery for a missing session. Recovery resolves the Mark ID plus provider to a separately numbered AWB assignment and checks existing AWB access policy. An already mounted editor retains unsaved state while access is unavailable; it does not reopen under another account. API-client requests carry the mounted editor's account identity so pending work cannot silently save under a replacement account.
+
+AWB registration previously saved the assignment before linking the Mark group. A failure after that save, or a lost successful response, made a retry fail duplicate validation. The paired AWB change reuses the existing `(provider, Mark ID)` only for the same owner, retries group linking, preserves AWB edits, and rolls back a new registration if linking fails. The paired CM change derives the Mark ID from the authorized completed job and commits export result plus completion together. Fresh launch credentials are fetched on each click into a new tab; failure does not close or navigate an existing editor.
+
+## Existing records
+
+No schema migration is required in any of the three repositories. The existing unique index in AWB is reused.
+
+Retry publishing an existing completed CM quiz through the supported UI. Same-owner registration returns the existing AWB assignment and repairs the Mark group link; missing registrations are created. No duplicate Mark quiz is needed. Ownership/provider conflicts are rejected rather than transferred. Quizzes never explicitly published are not automatically published, and existing incorrect ownership or missing job output needs separate investigation. A valid fresh launch is required to repair a browser's missing/expired session; deployment does not turn an old URL into a credential.
+
+CM general assets support sharing through their holders, but the current generated-quiz job launch/export policies are job-owner scoped. AWB organization membership and existing assignment-holder permissions govern collaborative AWB launches. These changes do not add a new CM sharing policy. Already-issued JWTs retain their normal expiry; removing AWB membership prevents new launches but does not instantly revoke issued JWTs.
+
+## Staging deployment and test playbook
+
+Use only staging quizzes, accounts, providers, OAuth clients and signing configuration. Set Mark web `AWB_URL` to the staging AWB origin and `AWB_MARK_PROVIDER_ID` to the staging AWB provider for this Mark instance. Keep Mark quiz IDs and AWB primary keys distinct. Point CM's Mark and AWB connections and AWB's Mark provider at those same staging services. No LTI-gateway code change is required; the configured gateway must still validate/sign normal launches.
+
+Deploy AWB first (registration/recovery endpoint), then Mark's API, gateway and web together, then CM. Pairwise testing is useful and does not require simultaneous deployment:
+
+1. **Mark + AWB:** Register a staging quiz with different Mark/AWB IDs. Launch as its owner and as an authorized organization member. Verify an unrelated user and removed member cannot obtain a fresh author launch. Open the copied Mark editor link in incognito: expect sign-in guidance, then recovery to the correct AWB assignment after signing in. Verify a wrong provider/ID is unavailable.
+2. **Mark + CM:** Create a quiz and open Edit repeatedly; each click obtains fresh signatures in its own tab. Edit a title without saving, open a learner preview, then return and save as author. Keep two different author quizzes open and repeat. Block pop-ups or fail credential refresh and verify an actionable error without losing the earlier editor. Exercise expired sessions and recovery using the original account; switching accounts must not expose/reopen or save the previous editor's draft. Complete a learner submission and check its ordinary grade callback.
+3. **All three updated versions:** Generate in CM, publish to AWB, open it through AWB as a permitted colleague, and recover from the shared Mark URL. Retry publishing after a controlled link failure or lost response; verify one AWB record with the same Mark ID and owner, unchanged AWB edits, the required group link, and a completed CM export containing the correct AWB URL. Confirm direct author API calls for another quiz fail even when both quizzes have the same group and no author headers/referrer are supplied.
+
+Final acceptance needs all three updated versions connected at once. Mark + CM alone cannot prove AWB publishing/recovery, and Mark + AWB alone cannot prove CM's publishing and completion behavior. Do not promote until these end-to-end checks pass. For rollback, return Mark web/gateway/API together; the AWB retry endpoint is backward compatible and can stay deployed.
+
+## Local validation
+
+- AWB: 39 registration/recovery request examples; recovery RuboCop passes.
+- CM: 68 backend examples, 111 frontend tests, typecheck and changed-file lint pass.
+- Mark: 68 gateway tests pass (19 existing skipped), 25 assignment/question guard tests, 26 web tests including recovery and request context; full repository lint and gateway typecheck pass.
+- Mark web production build succeeds with `next build --webpack`. Default Turbopack rejects this worktree's external node_modules symlinks. Standalone web typecheck reports the same three VideoPresentationEditor BlobPart errors in the unchanged main checkout; the new author files have no remaining type errors.
+- Cross-app staging tests have not yet run. Dependency graph AST extraction was refreshed locally; the repository graph command reports disabled, and the visualizer skips HTML for graphs above its node limit.


### PR DESCRIPTION
Jira: SKILLS-131587
Copied Mark editor links cannot establish an author session, and learner previews can replace the single authentication cookie. The old UI reported missing or expired sessions as a learner-role error. Preserve verified per-quiz author sessions, select and forward the matching token, and require a valid same-account current launch. Bind author assignment/question access to the signed quiz even without browser headers, preserving collaborators authorized through CM/AWB launches.

Add sign-in recovery through AWB’s provider-scoped Mark-ID lookup. Keep an opened editor’s unsaved state through same-account recovery and prevent it reopening or saving under a replacement account. Sync and version-load HTTP 401 failures leave the workspace state intact so reauthentication restores the mounted draft; genuine workspace errors remain visible. No migration or LTI-gateway code change is required. Deploy Mark API, gateway and web together after AWB’s recovery route is available.

Validation: 68 gateway tests passed (19 existing skipped), 25 assignment/question guard tests passed, 26 web tests passed. Full repository lint and gateway typecheck passed. Web production build passed with `next build --webpack`; the default Turbopack build rejects the local worktree’s external node_modules symlinks. Standalone web typecheck has the same three VideoPresentationEditor BlobPart errors as the unchanged main checkout. Staging comparisons confirmed that author access survives a learner preview and editor refresh with the patched versions. Final shared-link/colleague acceptance on the user’s exported quiz remains pending.

Paired PRs: https://github.com/ibm-skills-network/author-workbench/pull/2952 and https://github.com/ibm-skills-network/context-manager/pull/983. See `docs/cm-author-access.md` for existing-record recovery, staged pairwise tests and the required all-three-app acceptance flow.


Recovery regression validation: 23 targeted web tests pass, including the real API client/store 401 recovery path, preservation of unsaved input, and genuine error handling. The recovery test fails without the fix. Changed-file ESLint has no errors (one pre-existing unused import warning). Latest commit CI is pending.
