### PR TITLE
Preserve learner sessions after author launches and fix preview grading

### DIFF
--- a/apps/api-gateway/src/auth/jwt/cookie-based/author.session.spec.ts
+++ b/apps/api-gateway/src/auth/jwt/cookie-based/author.session.spec.ts
@@ -198,3 +198,93 @@ describe("verified author sessions", () => {
     );
   });
 });
+
+describe("learner sessions across author launches", () => {
+  const learnerContext = { "x-mark-learner-assignment": "4892" };
+  it("preserves a verified learner session and forwards its grade callback token", async () => {
+    const learner = token({ role: "learner", gradingCallbackRequired: true });
+    const cookie = `authentication=${token()}; mark_learner_4892=${learner}`;
+    await expect(
+      authenticate(
+        cookie,
+        learnerContext,
+        "/api/v2/assignments/4892/attempts/17",
+      ).result,
+    ).resolves.toMatchObject({
+      role: "learner",
+      assignmentId: 4892,
+      gradingCallbackRequired: true,
+    });
+    expect(dedupeAuthenticationCookieHeader(cookie, learnerContext)).toBe(
+      `authentication=${learner}`,
+    );
+  });
+  it("saves a verified learner cookie before the author launch", async () => {
+    const learner = token({ role: "learner" });
+    const { result, response } = authenticate(
+      `authentication=${learner}`,
+      learnerContext,
+    );
+    await result;
+    expect(response.cookie).toHaveBeenCalledWith(
+      "mark_learner_4892",
+      learner,
+      expect.objectContaining({ httpOnly: true }),
+    );
+  });
+  it.each([
+    ["signed out", ""],
+    ["account changed", token({ userID: "other@example.test" })],
+    ["forged current session", token({}, "wrong-secret")],
+    [
+      "expired current session",
+      sign({ userID: "author@example.test", exp: 1 }, secret),
+    ],
+  ])("rejects learner recovery when %s", async (_name, current) => {
+    await expect(
+      authenticate(
+        `authentication=${current}; mark_learner_4892=${token({ role: "learner" })}`,
+        learnerContext,
+      ).result,
+    ).rejects.toThrow();
+  });
+  it("rejects an expired saved learner token", async () => {
+    const expired = sign(
+      {
+        userID: "author@example.test",
+        role: "learner",
+        assignmentID: 4892,
+        exp: 1,
+      },
+      secret,
+    );
+    await expect(
+      authenticate(
+        `authentication=${token()}; mark_learner_4892=${expired}`,
+        learnerContext,
+      ).result,
+    ).rejects.toThrow();
+  });
+  it("does not grant learner role from a context hint", async () => {
+    await expect(
+      authenticate(`authentication=${token()}`, learnerContext).result,
+    ).rejects.toThrow();
+  });
+  it("keeps deliberate author previews on their signed author session", async () => {
+    const cookie = `authentication=${token({ role: "learner" })}; mark_author_4892=${token()}`;
+    await expect(
+      authenticate(cookie, {
+        referer: "https://mark.example/learner/4892/questions?authorMode=true",
+      }).result,
+    ).resolves.toMatchObject({ role: "author" });
+  });
+  it("rejects a learner request for another assignment", async () => {
+    await expect(
+      authenticate(
+        `authentication=${token()}; mark_learner_4892=${token({ role: "learner" })}`,
+        learnerContext,
+        "/api/v2/assignments/4941/attempts/17",
+      ).result,
+    ).rejects.toThrow();
+  });
+});

--- a/apps/api-gateway/src/auth/jwt/cookie-based/jwt.cookie.extractor.ts
+++ b/apps/api-gateway/src/auth/jwt/cookie-based/jwt.cookie.extractor.ts
@@ -3,22 +3,31 @@ import { Request } from "express";
 const COOKIE_NAME = "authentication";
 export const AUTHOR_COOKIE_PREFIX = "mark_author_";
 
-/** A routing hint only: the selected token is still signature/expiry checked. */
-export function authorAssignmentContext(
+export const LEARNER_COOKIE_PREFIX = "mark_learner_";
+
+/** Context selects a token; it never grants a role or assignment access. */
+export function quizSessionContext(
   headers: Request["headers"],
-): number | undefined {
-  const explicit = headers["x-mark-author-assignment"];
-  if (typeof explicit === "string" && /^[1-9]\d*$/.test(explicit)) {
-    const id = Number(explicit);
-    return Number.isSafeInteger(id) ? id : undefined;
+): { role: "author" | "learner"; assignmentId: number } | undefined {
+  for (const role of ["author", "learner"] as const) {
+    const explicit = headers[`x-mark-${role}-assignment`];
+    if (typeof explicit === "string" && /^[1-9]\d*$/.test(explicit)) {
+      const assignmentId = Number(explicit);
+      return Number.isSafeInteger(assignmentId)
+        ? { role, assignmentId }
+        : undefined;
+    }
   }
   if (typeof headers.referer !== "string") return undefined;
   try {
-    const match = new URL(headers.referer).pathname.match(
-      /^\/author\/([1-9]\d*)(?:\/|$)/,
-    );
-    const id = match ? Number(match[1]) : undefined;
-    return Number.isSafeInteger(id) ? id : undefined;
+    const url = new URL(headers.referer);
+    const match = url.pathname.match(/^\/(author|learner)\/([1-9]\d*)(?:\/|$)/);
+    if (!match || !Number.isSafeInteger(Number(match[2]))) return undefined;
+    const role =
+      match[1] === "author" || url.searchParams.get("authorMode") === "true"
+        ? "author"
+        : "learner";
+    return { role, assignmentId: Number(match[2]) };
   } catch {
     return undefined;
   }
@@ -78,19 +87,23 @@ export function selectAuthenticationCookie(
   },
 ): AuthCookieSelection {
   const rawHeader = request.headers?.cookie;
-  const context = authorAssignmentContext(request.headers ?? {});
+  const context = quizSessionContext(request.headers ?? {});
   if (context !== undefined) {
     const legacy = selectAuthenticationCookie({
       headers: { cookie: rawHeader },
       cookies: request.cookies,
     });
     const scoped = parseCookiePairs(rawHeader)
-      .filter((pair) => pair.name === `${AUTHOR_COOKIE_PREFIX}${context}`)
+      .filter(
+        (pair) =>
+          pair.name ===
+          `${context.role === "author" ? AUTHOR_COOKIE_PREFIX : LEARNER_COOKIE_PREFIX}${context.assignmentId}`,
+      )
       .map((pair) => tryDecodeUriComponent(pair.rawValue));
     const legacyClaims = unverifiedSession(legacy.token);
     if (scoped.length > 0) {
       const newest = scoped[pickNewestIatIndex(scoped)];
-      // Switching accounts must not revive the previous user's author session.
+      // Switching accounts must not revive the previous user's saved session.
       if (
         !legacy.token ||
         legacyClaims.userID !== unverifiedSession(newest).userID
@@ -98,8 +111,8 @@ export function selectAuthenticationCookie(
         return legacy;
       if (
         legacy.token &&
-        legacyClaims.role === "author" &&
-        legacyClaims.assignmentID === context
+        legacyClaims.role === context.role &&
+        legacyClaims.assignmentID === context.assignmentId
       )
         scoped.push(legacy.token);
       return {
@@ -142,10 +155,12 @@ export function dedupeAuthenticationCookieHeader(
 ): string | undefined {
   const pairs = parseCookiePairs(rawHeader);
   const authPairs = pairs.filter((pair) => pair.name === COOKIE_NAME);
-  const hasAuthorCookies = pairs.some((pair) =>
-    pair.name.startsWith(AUTHOR_COOKIE_PREFIX),
+  const hasScopedCookies = pairs.some(
+    (pair) =>
+      pair.name.startsWith(AUTHOR_COOKIE_PREFIX) ||
+      pair.name.startsWith(LEARNER_COOKIE_PREFIX),
   );
-  if (authPairs.length <= 1 && !hasAuthorCookies) {
+  if (authPairs.length <= 1 && !hasScopedCookies) {
     return undefined;
   }
 
@@ -155,7 +170,9 @@ export function dedupeAuthenticationCookieHeader(
 
   const kept = pairs.filter(
     (pair) =>
-      pair.name !== COOKIE_NAME && !pair.name.startsWith(AUTHOR_COOKIE_PREFIX),
+      pair.name !== COOKIE_NAME &&
+      !pair.name.startsWith(AUTHOR_COOKIE_PREFIX) &&
+      !pair.name.startsWith(LEARNER_COOKIE_PREFIX),
   );
   if (token)
     kept.push({ name: COOKIE_NAME, rawValue: encodeURIComponent(token) });

--- a/apps/api-gateway/src/auth/jwt/cookie-based/jwt.cookie.strategy.ts
+++ b/apps/api-gateway/src/auth/jwt/cookie-based/jwt.cookie.strategy.ts
@@ -10,7 +10,8 @@ import {
 import { JwtConfigService } from "../jwt.config.service";
 import {
   AUTHOR_COOKIE_PREFIX,
-  authorAssignmentContext,
+  quizSessionContext,
+  LEARNER_COOKIE_PREFIX,
   selectAuthenticationCookie,
   unverifiedSession,
 } from "./jwt.cookie.extractor";
@@ -60,7 +61,7 @@ export class JwtCookieStrategy extends PassportStrategy(
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   validate(request: IRequestWithCookies, payload: IJwtPayload): UserSession {
-    const context = authorAssignmentContext(request.headers ?? {});
+    const context = quizSessionContext(request.headers ?? {});
     const routeId = request.originalUrl?.match(
       /\/assignments\/([1-9]\d*)(?:[/?]|$)/,
     )?.[1];
@@ -69,10 +70,14 @@ export class JwtCookieStrategy extends PassportStrategy(
         routeId &&
         Number(routeId) !== payload.assignmentID) ||
       (context !== undefined &&
-        (payload.role !== "author" || payload.assignmentID !== context))
+        (payload.role !== context.role ||
+          payload.assignmentID !== context.assignmentId ||
+          (routeId && Number(routeId) !== context.assignmentId)))
     ) {
-      logger.warn("Author session does not match requested workspace");
-      throw new UnauthorizedException("Relaunch this quiz as an author");
+      logger.warn("Quiz session does not match requested role or assignment");
+      throw new UnauthorizedException(
+        "Relaunch this quiz in the requested role",
+      );
     }
     const editorUser = request.headers?.["x-mark-author-user"];
     if (
@@ -86,7 +91,7 @@ export class JwtCookieStrategy extends PassportStrategy(
       );
     }
     // A scoped cookie must not revive an expired, tampered, or signed-out
-    // browser session. Passport verifies the selected author token; verify the
+    // browser session. Passport verifies the selected token; verify the
     // current launch separately before using it as the account-switch boundary.
     const selected = selectAuthenticationCookie(request).token;
     const current = selectAuthenticationCookie({
@@ -100,20 +105,26 @@ export class JwtCookieStrategy extends PassportStrategy(
         if (typeof claims === "string" || claims.userID !== payload.userID)
           throw new Error("Account changed");
       } catch {
-        logger.warn("Author recovery requires a valid current session");
-        throw new UnauthorizedException("Relaunch this quiz as an author");
+        logger.warn("Quiz session recovery requires a valid current session");
+        throw new UnauthorizedException(
+          "Relaunch this quiz in the requested role",
+        );
       }
     }
     // Only persist tokens after passport has verified their signature and expiry.
-    // A bounded set keeps previews and other quiz tabs from overwriting authors.
+    // A bounded set per role keeps author and learner launches independent.
     if (
-      payload.role === "author" &&
+      (payload.role === "author" || payload.role === "learner") &&
       Number.isSafeInteger(payload.assignmentID) &&
       payload.assignmentID > 0 &&
       request.res
     ) {
       const { token } = selectAuthenticationCookie(request);
-      const name = `${AUTHOR_COOKIE_PREFIX}${payload.assignmentID}`;
+      const prefix =
+        payload.role === "author"
+          ? AUTHOR_COOKIE_PREFIX
+          : LEARNER_COOKIE_PREFIX;
+      const name = `${prefix}${payload.assignmentID}`;
       if (token && request.cookies?.[name] !== token) {
         const secure = process.env.NODE_ENV === "production";
         const options = {
@@ -123,9 +134,7 @@ export class JwtCookieStrategy extends PassportStrategy(
           path: "/",
         };
         const others = Object.entries(request.cookies ?? {})
-          .filter(
-            ([key]) => key.startsWith(AUTHOR_COOKIE_PREFIX) && key !== name,
-          )
+          .filter(([key]) => key.startsWith(prefix) && key !== name)
           .sort(
             (a, b) =>
               (unverifiedSession(b[1]).iat ?? 0) -

--- a/apps/web/app/learner/[assignmentId]/page.tsx
+++ b/apps/web/app/learner/[assignmentId]/page.tsx
@@ -5,7 +5,7 @@ import AuthFetchToAbout from "./AuthFetchToAbout";
 
 interface Props {
   params: Promise<{ assignmentId: string }>;
-  searchParams: Promise<{ submissionTime?: string }>;
+  searchParams: Promise<{ submissionTime?: string; authorMode?: string }>;
 }
 
 async function Component(props: Props) {
@@ -15,7 +15,11 @@ async function Component(props: Props) {
   const headerList = await headers();
   const cookieHeader = headerList.get("cookie") || "";
   try {
-    const user = await getUser(cookieHeader);
+    const searchParams = await props.searchParams;
+    const user = await getUser(cookieHeader, {
+      assignmentId: Number(assignmentId),
+      role: searchParams.authorMode === "true" ? "author" : "learner",
+    });
     const role = user?.role;
 
     return (

--- a/apps/web/app/learner/[assignmentId]/questions/LearnerLayout.tsx
+++ b/apps/web/app/learner/[assignmentId]/questions/LearnerLayout.tsx
@@ -131,7 +131,10 @@ async function LearnerLayout(props: Props) {
 
   let user = null;
   try {
-    user = await getUser(cookieHeader);
+    user = await getUser(cookieHeader, {
+      assignmentId,
+      role: authorMode === "true" ? "author" : "learner",
+    });
     log("User fetched", `Role: ${user?.role ?? "unknown"}`);
   } catch (error) {
     const status = statusFromError(error);
@@ -168,6 +171,7 @@ async function LearnerLayout(props: Props) {
   try {
     listOfAttempts = await getAttempts(assignmentId, cookieHeader, {
       throwOnAuthError: true,
+      learnerContext: true,
     });
   } catch (error) {
     // An expired session or revoked access is the learner's situation, not a
@@ -203,7 +207,9 @@ async function LearnerLayout(props: Props) {
       // The server just vouched an attempt is active, so when the client-clock
       // in-progress filter disagrees (clock skew), fall back to the latest
       // unsubmitted attempt rather than dead-ending.
-      const refreshedAttempts = await getAttempts(assignmentId, cookieHeader);
+      const refreshedAttempts = await getAttempts(assignmentId, cookieHeader, {
+        learnerContext: true,
+      });
       const resumableAttempt = refreshedAttempts
         ? (getLatestAttempt(refreshedAttempts.filter(isAttemptInProgress)) ??
           getLatestAttempt(

--- a/apps/web/app/learner/[assignmentId]/questions/__tests__/LearnerLayout.test.tsx
+++ b/apps/web/app/learner/[assignmentId]/questions/__tests__/LearnerLayout.test.tsx
@@ -163,3 +163,28 @@ describe("LearnerLayout attempt resolution", () => {
     expect(createAttemptMock).not.toHaveBeenCalled();
   });
 });
+
+it("carries learner context through a server-rendered refresh and resumes the attempt", async () => {
+  getUserMock.mockResolvedValue({ role: "learner" });
+  getAttemptsMock.mockResolvedValue([inProgressAttempt(456)]);
+  const element = await LearnerLayout(props);
+  expect(getUserMock).toHaveBeenLastCalledWith("", {
+    assignmentId: 123,
+    role: "learner",
+  });
+  expect(getAttemptsMock).toHaveBeenLastCalledWith(123, "", {
+    throwOnAuthError: true,
+    learnerContext: true,
+  });
+  expect(element.props.children.props.attemptId).toBe(456);
+  expect(element.props.children.props.isNewAttempt).toBe(false);
+});
+
+it("explicit author previews request author context during server rendering", async () => {
+  getUserMock.mockResolvedValue({ role: "author" });
+  await LearnerLayout({ ...props, searchParams: { authorMode: "true" } });
+  expect(getUserMock).toHaveBeenLastCalledWith("", {
+    assignmentId: 123,
+    role: "author",
+  });
+});

--- a/apps/web/app/learner/utils/__tests__/authorPreview.test.ts
+++ b/apps/web/app/learner/utils/__tests__/authorPreview.test.ts
@@ -153,11 +153,28 @@ describe("buildAuthorPreviewPayload", () => {
   });
 });
 
-it("rejects incomplete cached preview details after a refresh", () => {
+it("fills missing preview settings without discarding unsaved overview content", () => {
   mockGetStoredData
-    .mockReturnValueOnce({ id: 1, name: "Assignment One" })
+    .mockReturnValueOnce({
+      id: 1,
+      name: "Assignment One",
+      introduction: "Unsaved introduction",
+      instructions: "Unsaved instructions",
+      gradingCriteriaOverview: "Unsaved rubric",
+    })
     .mockReturnValueOnce(VALID_QUESTIONS);
-  expect(readAuthorPreviewPayload(1)).toBeNull();
+  expect(readAuthorPreviewPayload(1)).toEqual({
+    assignmentDetails: {
+      id: 1,
+      name: "Assignment One",
+      introduction: "Unsaved introduction",
+      instructions: "Unsaved instructions",
+      gradingCriteriaOverview: "Unsaved rubric",
+      displayOrder: "DEFINED",
+      strictTimeLimit: false,
+    },
+    questions: VALID_QUESTIONS,
+  });
 });
 it("builds valid grading fields when optional assignment fields are missing", () => {
   const { assignmentDetails } = buildAuthorPreviewPayload({
@@ -181,4 +198,22 @@ it("preserves the time limit when rebuilding a timed preview", () => {
     questions: [],
   } as unknown as Assignment);
   expect(assignmentDetails.strictTimeLimit).toBe(true);
+});
+
+it("preserves explicit unsaved preview settings while filling missing text", () => {
+  mockGetStoredData
+    .mockReturnValueOnce({
+      id: 1,
+      name: "Quiz",
+      displayOrder: "RANDOM",
+      strictTimeLimit: false,
+      allotedTimeMinutes: 10,
+    })
+    .mockReturnValueOnce(VALID_QUESTIONS);
+  expect(readAuthorPreviewPayload(1)?.assignmentDetails).toMatchObject({
+    displayOrder: "RANDOM",
+    strictTimeLimit: false,
+    introduction: "",
+    instructions: "",
+  });
 });

--- a/apps/web/app/learner/utils/__tests__/authorPreview.test.ts
+++ b/apps/web/app/learner/utils/__tests__/authorPreview.test.ts
@@ -21,7 +21,14 @@ const mockProcessQuestions = processQuestions as jest.MockedFunction<
   typeof processQuestions
 >;
 
-const VALID_DETAILS = { id: 1, name: "Assignment One" };
+const VALID_DETAILS = {
+  id: 1,
+  name: "Assignment One",
+  displayOrder: "DEFINED",
+  strictTimeLimit: false,
+  introduction: "",
+  instructions: "",
+};
 const VALID_QUESTIONS = [{ id: 10, question: "Q1" }];
 
 describe("readAuthorPreviewPayload", () => {
@@ -144,4 +151,34 @@ describe("buildAuthorPreviewPayload", () => {
     });
     expect(mockProcessQuestions).toHaveBeenCalledWith([]);
   });
+});
+
+it("rejects incomplete cached preview details after a refresh", () => {
+  mockGetStoredData
+    .mockReturnValueOnce({ id: 1, name: "Assignment One" })
+    .mockReturnValueOnce(VALID_QUESTIONS);
+  expect(readAuthorPreviewPayload(1)).toBeNull();
+});
+it("builds valid grading fields when optional assignment fields are missing", () => {
+  const { assignmentDetails } = buildAuthorPreviewPayload({
+    id: 1,
+    name: "Quiz",
+    questions: [],
+  } as unknown as Assignment);
+  expect(assignmentDetails).toMatchObject({
+    displayOrder: "DEFINED",
+    strictTimeLimit: false,
+    introduction: "",
+    instructions: "",
+  });
+});
+
+it("preserves the time limit when rebuilding a timed preview", () => {
+  const { assignmentDetails } = buildAuthorPreviewPayload({
+    id: 1,
+    name: "Quiz",
+    allotedTimeMinutes: 10,
+    questions: [],
+  } as unknown as Assignment);
+  expect(assignmentDetails.strictTimeLimit).toBe(true);
 });

--- a/apps/web/app/learner/utils/authorPreview.ts
+++ b/apps/web/app/learner/utils/authorPreview.ts
@@ -18,7 +18,12 @@ const isMatchingAssignment = (
 ) =>
   assignmentDetails?.id === assignmentId &&
   typeof assignmentDetails.name === "string" &&
-  assignmentDetails.name.length > 0;
+  assignmentDetails.name.length > 0 &&
+  (assignmentDetails.displayOrder === "DEFINED" ||
+    assignmentDetails.displayOrder === "RANDOM") &&
+  typeof assignmentDetails.strictTimeLimit === "boolean" &&
+  typeof assignmentDetails.introduction === "string" &&
+  typeof assignmentDetails.instructions === "string";
 
 export function readAuthorPreviewPayload(
   assignmentId: number,
@@ -50,8 +55,8 @@ export function buildAuthorPreviewPayload(
     assignmentDetails: {
       id: assignment.id,
       name: assignment.name,
-      introduction: assignment.introduction,
-      instructions: assignment.instructions,
+      introduction: assignment.introduction ?? "",
+      instructions: assignment.instructions ?? "",
       gradingCriteriaOverview: assignment.gradingCriteriaOverview,
       graded: assignment.graded,
       numAttempts: assignment.numAttempts,
@@ -60,7 +65,9 @@ export function buildAuthorPreviewPayload(
       allotedTimeMinutes: assignment.allotedTimeMinutes,
       timeEstimateMinutes: assignment.timeEstimateMinutes,
       passingGrade: assignment.passingGrade,
-      displayOrder: assignment.displayOrder,
+      displayOrder: assignment.displayOrder ?? "DEFINED",
+      // Persisted assignments represent the time limit through allotted minutes.
+      strictTimeLimit: (assignment.allotedTimeMinutes ?? 0) > 0,
       questionDisplay: assignment.questionDisplay,
       numberOfQuestionsPerAttempt: assignment.numberOfQuestionsPerAttempt,
       requireAllQuestions: assignment.requireAllQuestions,

--- a/apps/web/app/learner/utils/authorPreview.ts
+++ b/apps/web/app/learner/utils/authorPreview.ts
@@ -18,12 +18,7 @@ const isMatchingAssignment = (
 ) =>
   assignmentDetails?.id === assignmentId &&
   typeof assignmentDetails.name === "string" &&
-  assignmentDetails.name.length > 0 &&
-  (assignmentDetails.displayOrder === "DEFINED" ||
-    assignmentDetails.displayOrder === "RANDOM") &&
-  typeof assignmentDetails.strictTimeLimit === "boolean" &&
-  typeof assignmentDetails.introduction === "string" &&
-  typeof assignmentDetails.instructions === "string";
+  assignmentDetails.name.length > 0;
 
 export function readAuthorPreviewPayload(
   assignmentId: number,
@@ -35,13 +30,27 @@ export function readAuthorPreviewPayload(
   const questions = getStoredData<QuestionStore[]>("questions", []);
 
   if (
+    !assignmentDetails ||
     !isMatchingAssignment(assignmentDetails, assignmentId) ||
     !Array.isArray(questions)
   ) {
     return null;
   }
 
-  return { assignmentDetails, questions };
+  // Older/incomplete settings must not discard unsaved overview text or questions.
+  return {
+    assignmentDetails: {
+      ...assignmentDetails,
+      displayOrder:
+        assignmentDetails.displayOrder === "RANDOM" ? "RANDOM" : "DEFINED",
+      strictTimeLimit:
+        assignmentDetails.strictTimeLimit ??
+        (assignmentDetails.allotedTimeMinutes ?? 0) > 0,
+      introduction: assignmentDetails.introduction ?? "",
+      instructions: assignmentDetails.instructions ?? "",
+    },
+    questions,
+  };
 }
 
 export function buildAuthorPreviewPayload(

--- a/apps/web/lib/__tests__/author-session.test.ts
+++ b/apps/web/lib/__tests__/author-session.test.ts
@@ -15,10 +15,12 @@ it("sends the editor identity and quiz context even without a referrer", () => {
   });
 });
 
-it("does not send author context to learner previews", () => {
+it("selects learner context without the author editor identity", () => {
   bindAuthorSession(4892, "author@example.test");
   window.history.replaceState({}, "", "/learner/4892");
-  expect(authorSessionHeaders()).toEqual({});
+  expect(authorSessionHeaders()).toEqual({
+    "x-mark-learner-assignment": "4892",
+  });
 });
 
 it("does not carry an editor identity into another quiz", () => {
@@ -26,5 +28,16 @@ it("does not carry an editor identity into another quiz", () => {
   window.history.replaceState({}, "", "/author/4941/questions");
   expect(authorSessionHeaders()).toEqual({
     "x-mark-author-assignment": "4941",
+  });
+});
+
+it("selects author context only for deliberate author previews", () => {
+  window.history.replaceState(
+    {},
+    "",
+    "/learner/4892/questions?authorMode=true",
+  );
+  expect(authorSessionHeaders(false)).toEqual({
+    "x-mark-author-assignment": "4892",
   });
 });

--- a/apps/web/lib/author-session.ts
+++ b/apps/web/lib/author-session.ts
@@ -9,11 +9,20 @@ export function authorSessionHeaders(
   includeIdentity = true,
 ): Record<string, string> {
   if (typeof window === "undefined") return {};
-  const match = window.location.pathname.match(/^\/author\/([1-9]\d*)(?:\/|$)/);
-  if (!match || !Number.isSafeInteger(Number(match[1]))) return {};
+  const match = window.location.pathname.match(
+    /^\/(author|learner)\/([1-9]\d*)(?:\/|$)/,
+  );
+  if (!match || !Number.isSafeInteger(Number(match[2]))) return {};
+  const role =
+    match[1] === "author" ||
+    new URLSearchParams(window.location.search).get("authorMode") === "true"
+      ? "author"
+      : "learner";
   return {
-    "x-mark-author-assignment": match[1],
-    ...(includeIdentity && editor?.assignmentId === Number(match[1])
+    [`x-mark-${role}-assignment`]: match[2],
+    ...(includeIdentity &&
+    role === "author" &&
+    editor?.assignmentId === Number(match[2])
       ? { "x-mark-author-user": editor.userId }
       : {}),
   };

--- a/apps/web/lib/author.ts
+++ b/apps/web/lib/author.ts
@@ -623,7 +623,7 @@ export async function deleteQuestion(
 export async function getAttempts(
   assignmentId: number,
   cookies?: string,
-  options?: { throwOnAuthError?: boolean },
+  options?: { throwOnAuthError?: boolean; learnerContext?: boolean },
 ): Promise<AssignmentAttempt[] | undefined> {
   const endpointURL = `${getApiRoutes().assignments}/${assignmentId}/attempts`;
 
@@ -635,6 +635,9 @@ export async function getAttempts(
         quiet: true,
         headers: {
           ...(cookies ? { Cookie: cookies } : {}),
+          ...(options?.learnerContext
+            ? { "x-mark-learner-assignment": String(assignmentId) }
+            : {}),
         },
       }),
     )) as AssignmentAttempt[];

--- a/apps/web/lib/learner.ts
+++ b/apps/web/lib/learner.ts
@@ -63,7 +63,12 @@ export async function createAttempt(
       {
         headers: {
           "Content-Type": "application/json",
-          ...(cookies ? { Cookie: cookies } : {}),
+          ...(cookies
+            ? {
+                Cookie: cookies,
+                "x-mark-learner-assignment": String(assignmentId),
+              }
+            : {}),
         },
       },
     );
@@ -235,7 +240,12 @@ export async function getAttempt(
       apiClient.get<AssignmentAttemptWithQuestions>(endpointURL, {
         quiet: true,
         headers: {
-          ...(cookies ? { Cookie: cookies } : {}),
+          ...(cookies
+            ? {
+                Cookie: cookies,
+                "x-mark-learner-assignment": String(assignmentId),
+              }
+            : {}),
         },
       }),
     );

--- a/apps/web/lib/shared.ts
+++ b/apps/web/lib/shared.ts
@@ -2002,11 +2002,19 @@ export async function removePriceUpscaling(
 
 const V1_USER_ROUTE = absoluteUrl("/api/v1/user-session");
 
-export async function getUser(cookies?: string): Promise<User | undefined> {
+export async function getUser(
+  cookies?: string,
+  context?: { assignmentId: number; role: "author" | "learner" },
+): Promise<User | undefined> {
   const res = await fetch(V1_USER_ROUTE, {
     cache: "no-store",
     headers: {
       ...authorSessionHeaders(false),
+      ...(context
+        ? {
+            [`x-mark-${context.role}-assignment`]: String(context.assignmentId),
+          }
+        : {}),
       ...(cookies ? { Cookie: cookies } : {}),
     },
   });

--- a/docs/cm-author-access.md
+++ b/docs/cm-author-access.md
@@ -37,3 +37,14 @@ Final acceptance needs all three updated versions connected at once. Mark + CM a
 - Mark: 68 gateway tests pass (19 existing skipped), 25 assignment/question guard tests, 26 web tests including recovery and request context; full repository lint and gateway typecheck pass.
 - Mark web production build succeeds with `next build --webpack`. Default Turbopack rejects this worktree's external node_modules symlinks. Standalone web typecheck reports the same three VideoPresentationEditor BlobPart errors in the unchanged main checkout; the new author files have no remaining type errors.
 - Cross-app staging tests have not yet run. Dependency graph AST extraction was refreshed locally; the repository graph command reports disabled, and the visualizer skips HTML for graphs above its node limit.
+
+
+## Learner refresh follow-up
+
+Author and learner sessions are now saved separately (up to four quizzes per role). Browser requests and learner server rendering explicitly select the role for the quiz; authorMode=true selects a deliberate author preview. Context never grants a role: the selected token and the current same-account launch must both be valid. Forward the selected learner token to the API for the original grade callback. Existing attempt-ownership checks remain in force.
+
+This follow-up also rebuilds incomplete cached previews and supplies display order, time-limit state, introduction and instructions for preview grading. Persisted allotted minutes determine the time-limit flag; valid unsaved preview settings are retained.
+
+Deploy the gateway and web together. No AWB/CM change or migration is required for this follow-up. An existing browser needs a fresh learner launch to populate its learner cookie; a lost learner token cannot be recovered from an author token. Start testing from CM Launch Quiz, not an old URL containing authorMode=true.
+
+Staging acceptance: launch learner, answer without submitting, open author, refresh the original learner tab, confirm the same attempt/answers and no authorMode=true switch, then submit and verify grading/callback. Repeat in the reverse launch order. Separately use Check learner side from the editor and verify explicit author preview grading after refresh, including a timed quiz. Check logout/account switching/expiry fail closed and do not use another user's saved session.

--- a/docs/cm-author-access.md
+++ b/docs/cm-author-access.md
@@ -43,7 +43,7 @@ Final acceptance needs all three updated versions connected at once. Mark + CM a
 
 Author and learner sessions are now saved separately (up to four quizzes per role). Browser requests and learner server rendering explicitly select the role for the quiz; authorMode=true selects a deliberate author preview. Context never grants a role: the selected token and the current same-account launch must both be valid. Forward the selected learner token to the API for the original grade callback. Existing attempt-ownership checks remain in force.
 
-This follow-up also rebuilds incomplete cached previews and supplies display order, time-limit state, introduction and instructions for preview grading. Persisted allotted minutes determine the time-limit flag; valid unsaved preview settings are retained.
+This follow-up also fills missing cached preview settings without discarding unsaved content, and supplies display order, time-limit state, introduction and instructions for preview grading. Persisted allotted minutes determine the time-limit flag; valid unsaved preview settings are retained.
 
 Deploy the gateway and web together. No AWB/CM change or migration is required for this follow-up. An existing browser needs a fresh learner launch to populate its learner cookie; a lost learner token cannot be recovered from an author token. Start testing from CM Launch Quiz, not an old URL containing authorMode=true.
 


### PR DESCRIPTION
Jira: SKILLS-131587

Opening an author launch replaces the ordinary authentication cookie. A previously opened learner tab can consequently become an author preview after refresh. Preserve separately verified learner sessions per quiz, select the intended role in browser requests and server-rendered learner pages, and forward the original learner token for grade callbacks. Explicit authorMode=true previews continue to use an author session. Selection requires a valid same-account current launch and a verified, unexpired saved token; role and quiz hints cannot grant access. Existing attempt ownership checks remain unchanged.

Staging quiz 3662 also returned HTTP 400 for missing/invalid author preview displayOrder, strictTimeLimit, introduction and instructions. Fill missing settings in cached previews without discarding unsaved overview text or questions, supply valid defaults for persisted previews, and derive persisted time-limit state from allotted minutes. Explicit unsaved preview settings are retained.

Validation: full gateway suite passed (273 tests, 19 existing skipped), full web suite passed (552 tests before adding one further passing timed-preview case); final focused web checks passed 27 tests and gateway auth checks passed 44 tests. Gateway typecheck and changed-file lint pass; web lint has one existing unused-variable warning. After Next route type generation, web typecheck reports only the three known VideoPresentationEditor BlobPart errors. Staging acceptance of this new branch remains pending.

Deploy gateway and web together; no AWB/CM change or migration is needed for this follow-up. Start with a fresh learner launch so the browser saves its learner session. Answer questions, open the author session, refresh the original learner tab, verify the same attempt/answers and learner mode, then submit and verify grading/callback. Repeat the reverse launch order. Separately test explicit Check learner side previews, refresh, and timed preview submission. Also verify account switching, logout and expiry cannot reuse another account's saved session.

Follow-up to merged #661.


CI follow-up: Playwright exposed unsaved overview content being replaced when cached displayOrder was absent. Corrected the cache normalization, left the browser test unchanged, and reproduced the failure with a regression test before fixing it. All 554 frontend unit tests pass; changed-file lint has no errors. Playwright rerun passed on commit 5eba5e53, including the unchanged author overview test (run 34600658202, job 103266844267).
